### PR TITLE
[Feat] #21 - 공통 메인버튼 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */; };
 		2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */; };
 		2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */; };
+		2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */; };
 		2CD2291C2B42E685005400BE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291B2B42E685005400BE /* AppDelegate.swift */; };
 		2CD2291E2B42E685005400BE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291D2B42E685005400BE /* SceneDelegate.swift */; };
 		2CD229202B42E685005400BE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291F2B42E685005400BE /* ViewController.swift */; };
@@ -49,6 +50,7 @@
 		2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
+		2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSMainButton.swift; sourceTree = "<group>"; };
 		2CD229182B42E685005400BE /* WSSiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WSSiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CD2291B2B42E685005400BE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2CD2291D2B42E685005400BE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 			children = (
 				2C2491852B4ADC420096F255 /* WSSTabBarController.swift */,
 				2C2491832B4ADC230096F255 /* WSSTabBarItem.swift */,
+				2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				A1EC91B42B46DA3100CFB33D /* ImageLiterals.swift in Sources */,
 				2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */,
 				2C01F9852B482EB700D90FFE /* UserRepository.swift in Sources */,
+				2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */,
 				2C2491812B4ADC000096F255 /* StringLiterals.swift in Sources */,
 				2C2491862B4ADC420096F255 /* WSSTabBarController.swift in Sources */,
 				2CD229572B42EA75005400BE /* UIColor+.swift in Sources */,

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		2C79CB992B45A0B200734E1F /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */; };
 		2C79CB9B2B45A0B700734E1F /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */; };
 		2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */; };
+		2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */; };
+		2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */; };
 		2CD2291C2B42E685005400BE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291B2B42E685005400BE /* AppDelegate.swift */; };
 		2CD2291E2B42E685005400BE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291D2B42E685005400BE /* SceneDelegate.swift */; };
 		2CD229202B42E685005400BE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2291F2B42E685005400BE /* ViewController.swift */; };
@@ -45,6 +47,8 @@
 		2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
+		2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		2CD229182B42E685005400BE /* WSSiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WSSiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CD2291B2B42E685005400BE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2CD2291D2B42E685005400BE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +104,31 @@
 				2C2491832B4ADC230096F255 /* WSSTabBarItem.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		2CCBF9E92B4C1E2200D787C2 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				2CCBF9EA2B4C1E3700D787C2 /* MyPageViewController */,
+				2CCBF9EB2B4C1E4600D787C2 /* MyPageView */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		2CCBF9EA2B4C1E3700D787C2 /* MyPageViewController */ = {
+			isa = PBXGroup;
+			children = (
+				2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */,
+			);
+			path = MyPageViewController;
+			sourceTree = "<group>";
+		};
+		2CCBF9EB2B4C1E4600D787C2 /* MyPageView */ = {
+			isa = PBXGroup;
+			children = (
+				2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */,
+			);
+			path = MyPageView;
 			sourceTree = "<group>";
 		};
 		2CD2290F2B42E685005400BE = {
@@ -200,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				2CD2291F2B42E685005400BE /* ViewController.swift */,
+				2CCBF9E92B4C1E2200D787C2 /* MyPage */,
 				2C2491822B4ADC1D0096F255 /* Base */,
 			);
 			path = Presentation;
@@ -331,11 +361,13 @@
 			files = (
 				2CD229202B42E685005400BE /* ViewController.swift in Sources */,
 				2CD2291C2B42E685005400BE /* AppDelegate.swift in Sources */,
+				2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */,
 				A1C3EC532B46962F00D997C2 /* UIImage+.swift in Sources */,
 				2CD2291E2B42E685005400BE /* SceneDelegate.swift in Sources */,
 				2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */,
 				2C2491842B4ADC230096F255 /* WSSTabBarItem.swift in Sources */,
 				A1EC91B42B46DA3100CFB33D /* ImageLiterals.swift in Sources */,
+				2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */,
 				2C01F9852B482EB700D90FFE /* UserRepository.swift in Sources */,
 				2C2491812B4ADC000096F255 /* StringLiterals.swift in Sources */,
 				2C2491862B4ADC420096F255 /* WSSTabBarController.swift in Sources */,

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -13,7 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
+        let navigationController = UINavigationController(rootViewController: ViewController())
         
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = navigationController

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 class WSSMainButton: UIButton {
     
+    //MARK: - Life Cycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
@@ -25,6 +27,8 @@ class WSSMainButton: UIButton {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    //MARK: - UI
     
     private func setUI(title: String) {
         setTitle(title, for: .normal)

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -7,13 +7,15 @@
 
 import UIKit
 
+import SnapKit
+
 class WSSMainButton: UIButton {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
     
-    init(title: String) {
+    init(title: String, selfY: Bool) {
         super.init(frame: .zero)
         
         setTitle(title, for: .normal)
@@ -21,11 +23,20 @@ class WSSMainButton: UIButton {
         setTitleColor(.White, for: .normal)
         backgroundColor = .Primary100
         layer.cornerRadius = 12
+        
+        self.snp.makeConstraints() {
+            $0.centerX.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(53)
+            
+            if !selfY {
+                $0.bottom.equalTo(super.safeAreaInsets.bottom)
+            }
+        }
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
     
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -8,14 +8,20 @@
 import UIKit
 
 class WSSMainButton: UIButton {
-
+    
     override init(frame: CGRect) {
-            super.init(frame: frame)
-        }
+        super.init(frame: frame)
+    }
     
     init(title: String) {
-            super.init(frame: .zero)
-        }
+        super.init(frame: .zero)
+        
+        setTitle(title, for: .normal)
+        titleLabel?.font = .Title1
+        setTitleColor(.White, for: .normal)
+        backgroundColor = .Primary100
+        layer.cornerRadius = 12
+    }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -18,12 +18,23 @@ class WSSMainButton: UIButton {
     init(title: String, selfY: Bool) {
         super.init(frame: .zero)
         
+        setUI(title: title)
+        setLayout(selfY: selfY)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI(title: String) {
         setTitle(title, for: .normal)
         titleLabel?.font = .Title1
         setTitleColor(.White, for: .normal)
         backgroundColor = .Primary100
         layer.cornerRadius = 12
-        
+    }
+    
+    private func setLayout(selfY: Bool) {
         self.snp.makeConstraints() {
             $0.centerX.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
@@ -34,9 +45,4 @@ class WSSMainButton: UIButton {
             }
         }
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -17,15 +17,21 @@ class WSSMainButton: UIButton {
         super.init(frame: frame)
     }
     
-    init(title: String, selfY: Bool) {
+    init(title: String) {
         super.init(frame: .zero)
         
         setUI(title: title)
-        setLayout(selfY: selfY)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        if superview != nil {
+            setLayout()
+        }
     }
     
     //MARK: - UI
@@ -38,15 +44,12 @@ class WSSMainButton: UIButton {
         layer.cornerRadius = 12
     }
     
-    private func setLayout(selfY: Bool) {
+    private func setLayout() {
         self.snp.makeConstraints() {
             $0.centerX.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(34)
             $0.height.equalTo(53)
-            
-            if !selfY {
-                $0.bottom.equalTo(super.safeAreaInsets.bottom)
-            }
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class WSSMainButton: UIButton {
+final class WSSMainButton: UIButton {
     
     //MARK: - Life Cycle
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -1,0 +1,25 @@
+//
+//  WSSMainButton.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/9/24.
+//
+
+import UIKit
+
+class WSSMainButton: UIButton {
+
+    override init(frame: CGRect) {
+            super.init(frame: frame)
+        }
+    
+    init(title: String) {
+            super.init(frame: .zero)
+        }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -31,7 +31,12 @@ class WSSMainButton: UIButton {
         super.didMoveToSuperview()
         
         if superview != nil {
-            setLayout()
+            self.snp.makeConstraints() {
+                $0.centerX.equalToSuperview()
+                $0.leading.equalToSuperview().inset(20)
+                $0.bottom.equalTo(superview!.safeAreaLayoutGuide).offset(-10)
+                $0.height.equalTo(53)
+            }
         }
     }
     
@@ -43,14 +48,5 @@ class WSSMainButton: UIButton {
         setTitleColor(.White, for: .normal)
         backgroundColor = .Primary100
         layer.cornerRadius = 12
-    }
-    
-    private func setLayout() {
-        self.snp.makeConstraints() {
-            $0.centerX.equalToSuperview()
-            $0.leading.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(34)
-            $0.height.equalTo(53)
-        }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -29,6 +29,7 @@ class WSSMainButton: UIButton {
     
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
+        
         if superview != nil {
             setLayout()
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageView.swift
@@ -1,0 +1,20 @@
+//
+//  MyPageView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/8/24.
+//
+
+import UIKit
+
+class MyPageView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
@@ -1,0 +1,29 @@
+//
+//  MyPageViewController.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/8/24.
+//
+
+import UIKit
+
+class MyPageViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
@@ -10,13 +10,9 @@ import UIKit
 import SnapKit
 
 class ViewController: UIViewController {
-     
-    private var mainButton = WSSMainButton(title: "안녕 얘두라?")
         
         override func viewDidLoad() {
             super.viewDidLoad()
-            self.view.backgroundColor = .white
-            self.view.addSubview(mainButton)
         }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
@@ -11,8 +11,12 @@ import SnapKit
 
 class ViewController: UIViewController {
      
-     override func viewDidLoad() {
-         super.viewDidLoad()
-     }
+    private var mainButton = WSSMainButton(title: "안녕 얘두라?")
+        
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            self.view.backgroundColor = .white
+            self.view.addSubview(mainButton)
+        }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
@@ -10,13 +10,9 @@ import UIKit
 import SnapKit
 
 class ViewController: UIViewController {
-    
-    private var mainButton = WSSMainButton(title: "안녕 얘두라?")
      
      override func viewDidLoad() {
          super.viewDidLoad()
-         self.view.backgroundColor = .white
-         self.view.addSubview(mainButton)
      }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/ViewController.swift
@@ -10,11 +10,13 @@ import UIKit
 import SnapKit
 
 class ViewController: UIViewController {
-
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
+    private var mainButton = WSSMainButton(title: "안녕 얘두라?")
+     
+     override func viewDidLoad() {
+         super.viewDidLoad()
+         self.view.backgroundColor = .white
+         self.view.addSubview(mainButton)
+     }
 }
 


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#21 
<br/>

### 🌟Motivation
공통으로 사용하는 메인버튼을 구현하였습니다
<br/>

### 🌟Key Changes

<br/>

didMoveToSuperview() 라는 함수를 처음 알게되었습니다.
superView 가 로드되면 실행되는 함수랍니당!
```swift
override func didMoveToSuperview() {
        super.didMoveToSuperview()
        
        if superview != nil {
            setLayout()
        }
    }
```

<br/>

bottom 을 $0.bottom.equalTo(super.safeAreaLayout) 으로 주었더니 실행되지 않았습니다 ㅠㅠ (위에 올라가 있더라구요)
그 이유는 아직 super 가 결정되지 않아 super 를 UIButton 으로 판단해버려 UIButton의 safeAreaLayout 을 잡아버리는데! 버튼은 safeAreaLayout 이 없기 때문에 버튼이 포함된 뷰를 생성하여~~ 이런식으로 된다고 합니다 ㅠㅠ 그래서 아래처럼 구현해 주었습니다!
```swift
private func setLayout() {
        self.snp.makeConstraints() {
            $0.centerX.equalToSuperview()
            $0.leading.equalToSuperview().inset(20)
            $0.bottom.equalToSuperview().inset(34)
            $0.height.equalTo(53)
        }
    }
```

<br/>

### 🌟Simulation
![Simulator Screenshot - iPhone 13 mini - 2024-01-09 at 18 16 55](https://github.com/Team-WSS/WSS-iOS/assets/103318297/d8b50dcf-ab67-42d6-95c8-d707f5476bf1)

<br/>

### 🌟To Reviewer
아래처럼 사용하시면 됩니다! 레이아웃도 자동으로 잡아주니까요, 편하게 사용하세용!
```swift
    private var mainButton = WSSMainButton(title: "안녕 얘두라?")
    
    override func viewDidLoad() {
        super.viewDidLoad()
        self.view.backgroundColor = .white
        self.view.addSubview(mainButton)
    }
```
<br/>

### 🌟Reference
didMoveToSuperview() - ChatGPT
<br/>
