### PR TITLE
[Feat] #27 - MyPageChangeNicknameView UI 및 기능 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		2C5D0F592B4FDEC000C76D3C /* MyPageInventoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0F582B4FDEC000C76D3C /* MyPageInventoryCollectionViewCell.swift */; };
 		2C5D0F5B2B500EF100C76D3C /* MyPageSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0F5A2B500EF100C76D3C /* MyPageSettingView.swift */; };
 		2C5D0F5D2B50100000C76D3C /* MyPageSettingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0F5C2B50100000C76D3C /* MyPageSettingCollectionViewCell.swift */; };
+		2C5D0F5F2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0F5E2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift */; };
+		2C5D0F612B50525700C76D3C /* MyPageChangeNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0F602B50525700C76D3C /* MyPageChangeNicknameView.swift */; };
 		2C79CB952B45A0A400734E1F /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB942B45A0A400734E1F /* Pretendard-SemiBold.otf */; };
 		2C79CB972B45A0AB00734E1F /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB962B45A0AB00734E1F /* Pretendard-Medium.otf */; };
 		2C79CB992B45A0B200734E1F /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */; };
@@ -63,6 +65,8 @@
 		2C5D0F582B4FDEC000C76D3C /* MyPageInventoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageInventoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		2C5D0F5A2B500EF100C76D3C /* MyPageSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageSettingView.swift; sourceTree = "<group>"; };
 		2C5D0F5C2B50100000C76D3C /* MyPageSettingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageSettingCollectionViewCell.swift; sourceTree = "<group>"; };
+		2C5D0F5E2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageChangeNicknameViewController.swift; sourceTree = "<group>"; };
+		2C5D0F602B50525700C76D3C /* MyPageChangeNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageChangeNicknameView.swift; sourceTree = "<group>"; };
 		2C79CB942B45A0A400734E1F /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		2C79CB962B45A0AB00734E1F /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */,
+				2C5D0F5E2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift */,
 			);
 			path = MyPageViewController;
 			sourceTree = "<group>";
@@ -174,6 +179,7 @@
 			isa = PBXGroup;
 			children = (
 				2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */,
+				2C5D0F602B50525700C76D3C /* MyPageChangeNicknameView.swift */,
 				2C5D0F572B4FDE7500C76D3C /* MyPageCell */,
 				2CCBF9FE2B4DBF6A00D787C2 /* MyPageAssistantView */,
 			);
@@ -487,6 +493,7 @@
 				A1A1F9CD2B48733200705F44 /* SearchViewController.swift in Sources */,
 				2C5D0F5D2B50100000C76D3C /* MyPageSettingCollectionViewCell.swift in Sources */,
 				2C5D0F5B2B500EF100C76D3C /* MyPageSettingView.swift in Sources */,
+				2C5D0F612B50525700C76D3C /* MyPageChangeNicknameView.swift in Sources */,
 				2CCBFA082B4DE38800D787C2 /* MyPageInventoryView.swift in Sources */,
 				2C5D0F592B4FDEC000C76D3C /* MyPageInventoryCollectionViewCell.swift in Sources */,
 				2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */,
@@ -494,6 +501,7 @@
 				2C2491842B4ADC230096F255 /* WSSTabBarItem.swift in Sources */,
 				A1EC91B42B46DA3100CFB33D /* ImageLiterals.swift in Sources */,
 				2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */,
+				2C5D0F5F2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift in Sources */,
 				2C01F9852B482EB700D90FFE /* UserRepository.swift in Sources */,
 				2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */,
 				2CCBFA042B4DD73D00D787C2 /* MyPageTallyView.swift in Sources */,

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -13,7 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
+        let navigationController = UINavigationController(rootViewController: MyPageChangeNicknameViewController())
         
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = navigationController

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -13,7 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let navigationController = UINavigationController(rootViewController: MyPageChangeNicknameViewController())
+        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
         
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = navigationController

--- a/WSSiOS/WSSiOS/Resource/Assets.xcassets/exampleAvater.imageset/Contents.json
+++ b/WSSiOS/WSSiOS/Resource/Assets.xcassets/exampleAvater.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "임시 아바타-2.png",
+      "filename" : "임시 아바타-2.png",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class MyPageChangeNicknameView: UIView {
+final class MyPageChangeNicknameView: UIView {
     
     //MARK: - UI Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -63,7 +63,7 @@ class MyPageChangeNicknameView: UIView {
         }
         
         countNicknameLabel.do {
-            $0.text = "3/10"
+            $0.text = "\(changeNicknameTextField.text?.count)/10"
             $0.font = .Label1
             $0.textColor = .Gray200
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -16,6 +16,7 @@ class MyPageChangeNicknameView: UIView {
     
     private let nicknameLabel = UILabel()
     var changeNicknameTextField = UITextField()
+    var setClearButton = UIButton(type: .custom)
     var textFieldUnderBarView = UIView()
     var countNicknameLabel = UILabel()
     
@@ -47,6 +48,14 @@ class MyPageChangeNicknameView: UIView {
             $0.font = .Body1
             $0.textColor = .Black
             $0.borderStyle = .none
+            $0.rightView = setClearButton
+            $0.rightViewMode = .always
+        }
+        
+        setClearButton.do {
+            $0.setImage(ImageLiterals.icon.searchCancel, for: .normal)
+            $0.frame = CGRect(x: 0, y: 0, width: 25, height: 25)
+            $0.imageView?.contentMode = .scaleAspectFill
         }
         
         textFieldUnderBarView.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -1,0 +1,41 @@
+//
+//  MyPageChangeNicknameView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/12/24.
+//
+
+import UIKit
+
+class MyPageChangeNicknameView: UIView {
+
+    //MARK: - UI Components
+    
+   
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierachy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+       
+    }
+    
+    private func setHierachy() {
+    
+    }
+    
+    private func setLayout() {
+        
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -7,11 +7,17 @@
 
 import UIKit
 
-class MyPageChangeNicknameView: UIView {
+import SnapKit
+import Then
 
+class MyPageChangeNicknameView: UIView {
+    
     //MARK: - UI Components
     
-   
+    private let nicknameLabel = UILabel()
+    var changeNicknameTextField = UITextField()
+    var textFieldUnderBarView = UIView()
+    var countNicknameLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -28,14 +34,60 @@ class MyPageChangeNicknameView: UIView {
     }
     
     private func setUI() {
-       
+        self.backgroundColor = .White
+        
+        nicknameLabel.do {
+            $0.text = "닉네임"
+            $0.font = .Body2
+            $0.textColor = .Gray200
+        }
+        
+        changeNicknameTextField.do {
+            $0.text = "김명진"
+            $0.font = .Body1
+            $0.textColor = .Black
+            $0.borderStyle = .none
+        }
+        
+        textFieldUnderBarView.do {
+            $0.backgroundColor = .Gray200
+        }
+        
+        countNicknameLabel.do {
+            $0.text = "3/10"
+            $0.font = .Label1
+            $0.textColor = .Gray200
+        }
     }
     
     private func setHierachy() {
-    
+        self.addSubviews(nicknameLabel,
+                         changeNicknameTextField,
+                         textFieldUnderBarView,
+                         countNicknameLabel)
     }
     
     private func setLayout() {
+        nicknameLabel.snp.makeConstraints() {
+            $0.top.leading.equalTo(safeAreaLayoutGuide).offset(20)
+        }
         
+        changeNicknameTextField.snp.makeConstraints() {
+            $0.top.equalTo(nicknameLabel.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(41)
+        }
+        
+        textFieldUnderBarView.snp.makeConstraints() {
+            $0.bottom.equalTo(changeNicknameTextField.snp.bottom)
+            $0.leading.equalTo(changeNicknameTextField.snp.leading)
+            $0.width.equalTo(changeNicknameTextField.snp.width)
+            $0.height.equalTo(1.3)
+        }
+        
+        countNicknameLabel.snp.makeConstraints() {
+            $0.top.equalTo(changeNicknameTextField.snp.bottom).offset(10)
+            $0.trailing.equalTo(changeNicknameTextField.snp.trailing)
+        }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageChangeNicknameView.swift
@@ -15,10 +15,10 @@ class MyPageChangeNicknameView: UIView {
     //MARK: - UI Components
     
     private let nicknameLabel = UILabel()
-    var changeNicknameTextField = UITextField()
-    var setClearButton = UIButton(type: .custom)
-    var textFieldUnderBarView = UIView()
-    var countNicknameLabel = UILabel()
+    public var changeNicknameTextField = UITextField()
+    public var setClearButton = UIButton(type: .custom)
+    public var textFieldUnderBarView = UIView()
+    public var countNicknameLabel = UILabel()
     
     // MARK: - Life Cycle
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
@@ -37,37 +37,37 @@ class MyPageChangeNicknameViewController: UIViewController {
     private func textFieldEvent() {
         rootView.changeNicknameTextField.rx.controlEvent([.editingDidBegin, .editingChanged])
             .asObservable()
-            .subscribe(onNext: { _ in
-                self.rootView.textFieldUnderBarView.backgroundColor = .Primary100
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.rootView.textFieldUnderBarView.backgroundColor = .Primary100
             })
             .disposed(by: disposeBag)
         
         rootView.changeNicknameTextField.rx.controlEvent([.editingDidEnd])
             .asObservable()
-            .subscribe(onNext: { _ in
-                self.rootView.textFieldUnderBarView.backgroundColor = .Gray200
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.rootView.textFieldUnderBarView.backgroundColor = .Gray200
             })
             .disposed(by: disposeBag)
         
         rootView.changeNicknameTextField.rx.text
-            .subscribe(onNext: { text in
+            .subscribe(with: self, onNext: { owner, text in
                 if let countText = text?.count {
-                    self.rootView.countNicknameLabel.text = "\(countText)/10"
+                    owner.rootView.countNicknameLabel.text = "\(countText)/10"
                 }
             })
             .disposed(by: disposeBag)
         
         rootView.changeNicknameTextField.rx.text.orEmpty
-            .subscribe(onNext: { text in 
+            .subscribe(with: self, onNext: { owner, text in
                 self.limitNum(text)
             })
             .disposed(by: disposeBag)
         
         rootView.setClearButton.rx.tap
-            .bind {
-                self.rootView.changeNicknameTextField.text = ""
-                self.rootView.countNicknameLabel.text = "0/10"
-            }
+            .bind(with: self, onNext: { owner, _ in
+                owner.rootView.changeNicknameTextField.text = ""
+                owner.rootView.countNicknameLabel.text = "0/10"
+            })
             .disposed(by: disposeBag)
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
@@ -7,10 +7,14 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
+
 class MyPageChangeNicknameViewController: UIViewController {
-
+    
     //MARK: - Set Properties
-
+    
+    private let disposeBag = DisposeBag()
     
     //MARK: - UI Components
     
@@ -24,13 +28,46 @@ class MyPageChangeNicknameViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        textFieldEvent()
+    }
 
+    //MARK: - Custom Method
+    
+    private func textFieldEvent() {
+        rootView.changeNicknameTextField.rx.controlEvent([.editingDidBegin, .editingChanged])
+            .asObservable()
+            .subscribe(onNext: { _ in
+                self.rootView.textFieldUnderBarView.backgroundColor = .Primary100
+            })
+            .disposed(by: disposeBag)
+        
+        rootView.changeNicknameTextField.rx.controlEvent([.editingDidEnd])
+            .asObservable()
+            .subscribe(onNext: { _ in
+                self.rootView.textFieldUnderBarView.backgroundColor = .Gray200
+            })
+            .disposed(by: disposeBag)
+        
+        rootView.changeNicknameTextField.rx.text
+            .subscribe(onNext: { text in
+                if let countText = text?.count {
+                    self.rootView.countNicknameLabel.text = "\(countText)/10"
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        rootView.changeNicknameTextField.rx.text.orEmpty
+            .subscribe(onNext: { text in 
+                self.limitNum(text)
+            })
+            .disposed(by: disposeBag)
     }
     
-    //MARK: - UI Components
-    
-
-    
-    //MARK: - Custom Method
-
+    private func limitNum(_ text: String) {
+        if text.count > 9 {
+            let index = text.index(text.startIndex, offsetBy: 9)
+            self.rootView.changeNicknameTextField.text = String(text[..<index])
+        }
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-class MyPageChangeNicknameViewController: UIViewController {
+final class MyPageChangeNicknameViewController: UIViewController {
     
     //MARK: - Set Properties
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
@@ -31,7 +31,7 @@ class MyPageChangeNicknameViewController: UIViewController {
         
         textFieldEvent()
     }
-
+    
     //MARK: - Custom Method
     
     private func textFieldEvent() {
@@ -61,6 +61,13 @@ class MyPageChangeNicknameViewController: UIViewController {
             .subscribe(onNext: { text in 
                 self.limitNum(text)
             })
+            .disposed(by: disposeBag)
+        
+        rootView.setClearButton.rx.tap
+            .bind {
+                self.rootView.changeNicknameTextField.text = ""
+                self.rootView.countNicknameLabel.text = "0/10"
+            }
             .disposed(by: disposeBag)
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageChangeNicknameViewController.swift
@@ -1,0 +1,36 @@
+//
+//  MyPageChangeNicknameViewController.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/12/24.
+//
+
+import UIKit
+
+class MyPageChangeNicknameViewController: UIViewController {
+
+    //MARK: - Set Properties
+
+    
+    //MARK: - UI Components
+    
+    private var rootView = MyPageChangeNicknameView()
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+    
+    //MARK: - UI Components
+    
+
+    
+    //MARK: - Custom Method
+
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
@@ -40,6 +40,7 @@ final class MyPageViewController: UIViewController {
         
         register()
         bindDataToMyPageCollectionView()
+        pushChangeNicknameViewController()
     }
     
     //MARK: - UI Components
@@ -64,6 +65,20 @@ final class MyPageViewController: UIViewController {
             cellIdentifier: "MyPageSettingCollectionViewCell",
             cellType: MyPageSettingCollectionViewCell.self)) { (row, element, cell) in
                 cell.myPageSettingCellLabel.text = element
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func pushChangeNicknameViewController() {
+        rootView.myPageTallyView.myPageUserNameButton.rx.tap
+            .bind {[weak self] in
+                if let tabBarController = self?.tabBarController as? WSSTabBarController {
+                    tabBarController.tabBar.isHidden = true
+                    tabBarController.shadowView.isHidden = true
+                }
+                
+                let changeNicknameViewController = MyPageChangeNicknameViewController()
+                self?.navigationController?.pushViewController(changeNicknameViewController, animated: true)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#27 

<br/>

### 🌟Motivation
닉네임을 수정하는 뷰를 구현하였습니다.

<br/>

### 🌟Key Changes

<br/>

Rx가 어색해서 레퍼런스 많이 참고해서 구현하였는데, 분기처리나 로직 등등 더 간단하게 코드 구현할 수 있는 부분이 있다면 말씀 주시면 감사하겠습니다!

```swift
private func textFieldEvent() {
        rootView.changeNicknameTextField.rx.controlEvent([.editingDidBegin, .editingChanged])
            .asObservable()
            .subscribe(onNext: { _ in
                self.rootView.textFieldUnderBarView.backgroundColor = .Primary100
            })
            .disposed(by: disposeBag)
        
        rootView.changeNicknameTextField.rx.controlEvent([.editingDidEnd])
            .asObservable()
            .subscribe(onNext: { _ in
                self.rootView.textFieldUnderBarView.backgroundColor = .Gray200
            })
            .disposed(by: disposeBag)
        
        rootView.changeNicknameTextField.rx.text
            .subscribe(onNext: { text in
                if let countText = text?.count {
                    self.rootView.countNicknameLabel.text = "\(countText)/10"
                }
            })
            .disposed(by: disposeBag)
        
        rootView.changeNicknameTextField.rx.text.orEmpty
            .subscribe(onNext: { text in 
                self.limitNum(text)
            })
            .disposed(by: disposeBag)
    }
```
<br/>

hidesBottomBarWhenPushed 이 함수를 true 로 선언해주면 아래코드처럼 isHidden 처리 해주지 않아도 탭바가 없어진 뷰로 push 된답니다!
하지만 WSS 탭바는 radius 값을 주어야 하기 때문에 탭바 뒤에 독립적으로 shadowView 를 만들어주었기 때문에 위 함수를 사용하지 않고 아래처럼 작업해주어야 하였습니다.

```swift
private func pushChangeNicknameViewController() {
        rootView.myPageTallyView.myPageUserNameButton.rx.tap
            .bind {[weak self] in
                if let tabBarController = self?.tabBarController as? WSSTabBarController {
                    tabBarController.tabBar.isHidden = true
                    tabBarController.shadowView.isHidden = true
                }
                
                let changeNicknameViewController = MyPageChangeNicknameViewController()
                self?.navigationController?.pushViewController(changeNicknameViewController, animated: true)
            }
            .disposed(by: disposeBag)
    }
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2024-01-12 at 03 51 50](https://github.com/Team-WSS/WSS-iOS/assets/103318297/b3255d66-a41c-453c-8af5-0214c6e0b849)


<br/>

### 🌟To Reviewer
네비게이션바를 한 번에 처리하려고 해서 구현 안했습니당, 후딱 할게요 !
커스텀한 수정 버튼의 이미지가 늘어나지 않는 이슈가 ,,, 있는데 서연이랑 열심히 알아보도록 하겠습니당
<br/>

### 🌟Reference
- RxSwift 사용하여 TextField 컨트롤하기
https://myseong.tistory.com/12
- TabBar Shadow 가 안지워지는 현상 및 push 하면서 탭바지울 수 있는 함수 
chatGPT 4.0

<br/>
