### PR TITLE
[Design] #27 - ModalView UI 및 기능 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */; };
 		2CA2F6482B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */; };
 		2CA2F64A2B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */; };
+		2CA2F64C2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */; };
 		2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */; };
 		2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */; };
 		2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */; };
@@ -110,6 +111,7 @@
 		2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = " MyPageCustomModalViewController.swift"; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/ MyPageCustomModalViewController.swift"; sourceTree = "<group>"; };
 		2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyPageCustomAvatarModalView.swift; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomAvatarModalView.swift"; sourceTree = "<group>"; };
+		2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyPageModalAvatarFeatureLabelView.swift; path = "../../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift"; sourceTree = "<group>"; };
 		2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSMainButton.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				2CCBFA052B4DD85600D787C2 /* MyPageTallyReuseView.swift */,
 				2CCBFA072B4DE38800D787C2 /* MyPageInventoryView.swift */,
 				2C5D0F5A2B500EF100C76D3C /* MyPageSettingView.swift */,
+				2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */,
 			);
 			path = MyPageAssistantView;
 			sourceTree = "<group>";
@@ -771,6 +774,7 @@
 				A107A4A02B4DD7E200668C3E /* HomeSosoPickTitleView.swift in Sources */,
 				A1708F142B4D8DF400E35E50 /* HomeViewController.swift in Sources */,
 				A1DBB2FA2B4AA981000EE869 /* SearchCollectionViewCell.swift in Sources */,
+				2CA2F64C2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */,
 				A14EDBC12B4F06E600906957 /* HomeSosoPickView.swift in Sources */,
 				A147CBC42B4D662E0040AE39 /* SearchView.swift in Sources */,
 				A1DBB2FE2B4AEB22000EE869 /* UIView+.swift in Sources */,

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -21,9 +21,9 @@
 		2C79CB992B45A0B200734E1F /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */; };
 		2C79CB9B2B45A0B700734E1F /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */; };
 		2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */; };
-		2CA2F6482B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */; };
-		2CA2F64A2B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */; };
-		2CA2F64C2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */; };
+		2CA2F64E2B527B060045B4C2 /* MyPageCustomModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F64D2B527B060045B4C2 /* MyPageCustomModalView.swift */; };
+		2CA2F6502B527B3A0045B4C2 /* MyPageCustomModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F64F2B527B3A0045B4C2 /* MyPageCustomModalViewController.swift */; };
+		2CA2F6522B527B590045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6512B527B590045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */; };
 		2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */; };
 		2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */; };
 		2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */; };
@@ -109,9 +109,9 @@
 		2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
-		2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = " MyPageCustomModalViewController.swift"; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/ MyPageCustomModalViewController.swift"; sourceTree = "<group>"; };
-		2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyPageCustomAvatarModalView.swift; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomAvatarModalView.swift"; sourceTree = "<group>"; };
-		2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyPageModalAvatarFeatureLabelView.swift; path = "../../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift"; sourceTree = "<group>"; };
+		2CA2F64D2B527B060045B4C2 /* MyPageCustomModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCustomModalView.swift; sourceTree = "<group>"; };
+		2CA2F64F2B527B3A0045B4C2 /* MyPageCustomModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCustomModalViewController.swift; sourceTree = "<group>"; };
+		2CA2F6512B527B590045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageModalAvatarFeatureLabelView.swift; sourceTree = "<group>"; };
 		2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSMainButton.swift; sourceTree = "<group>"; };
@@ -245,7 +245,7 @@
 			children = (
 				2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */,
 				2C5D0F5E2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift */,
-				2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */,
+				2CA2F64F2B527B3A0045B4C2 /* MyPageCustomModalViewController.swift */,
 			);
 			path = MyPageViewController;
 			sourceTree = "<group>";
@@ -255,7 +255,7 @@
 			children = (
 				2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */,
 				2C5D0F602B50525700C76D3C /* MyPageChangeNicknameView.swift */,
-				2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */,
+				2CA2F64D2B527B060045B4C2 /* MyPageCustomModalView.swift */,
 				2C5D0F572B4FDE7500C76D3C /* MyPageCell */,
 				2CCBF9FE2B4DBF6A00D787C2 /* MyPageAssistantView */,
 			);
@@ -278,7 +278,7 @@
 				2CCBFA052B4DD85600D787C2 /* MyPageTallyReuseView.swift */,
 				2CCBFA072B4DE38800D787C2 /* MyPageInventoryView.swift */,
 				2C5D0F5A2B500EF100C76D3C /* MyPageSettingView.swift */,
-				2CA2F64B2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */,
+				2CA2F6512B527B590045B4C2 /* MyPageModalAvatarFeatureLabelView.swift */,
 			);
 			path = MyPageAssistantView;
 			sourceTree = "<group>";
@@ -718,10 +718,10 @@
 				A107A49C2B4DC8C600668C3E /* HomeCharacterTagView.swift in Sources */,
 				2CCBFA062B4DD85600D787C2 /* MyPageTallyReuseView.swift in Sources */,
 				2CD229202B42E685005400BE /* ViewController.swift in Sources */,
+				2CA2F64E2B527B060045B4C2 /* MyPageCustomModalView.swift in Sources */,
 				A14EB86A2B4F15D400A0A799 /* HomeSosoPickUserNumberChipView.swift in Sources */,
 				A1708F182B4D8E2F00E35E50 /* HomeView.swift in Sources */,
 				2CD2291C2B42E685005400BE /* AppDelegate.swift in Sources */,
-				2CA2F6482B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift in Sources */,
 				A1708F162B4D8E2700E35E50 /* HomeHeaderView.swift in Sources */,
 				2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */,
 				39AF30D12B50182F00FDC1F3 /* RegisterNormalReadStatusButton.swift in Sources */,
@@ -754,6 +754,8 @@
 				A147CBC62B4D6E190040AE39 /* UIStackView+.swift in Sources */,
 				392A29272B4E96F30065EB97 /* UILabel+.swift in Sources */,
 				39CC16882B51D94F003F56AE /* RegisterSuccessViewModel.swift in Sources */,
+				2CA2F6522B527B590045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */,
+				2CA2F6502B527B3A0045B4C2 /* MyPageCustomModalViewController.swift in Sources */,
 				2C2491842B4ADC230096F255 /* WSSTabBarItem.swift in Sources */,
 				A107A49A2B4DB66D00668C3E /* HomeSearchButtonView.swift in Sources */,
 				A1EC91B42B46DA3100CFB33D /* ImageLiterals.swift in Sources */,
@@ -774,7 +776,6 @@
 				A107A4A02B4DD7E200668C3E /* HomeSosoPickTitleView.swift in Sources */,
 				A1708F142B4D8DF400E35E50 /* HomeViewController.swift in Sources */,
 				A1DBB2FA2B4AA981000EE869 /* SearchCollectionViewCell.swift in Sources */,
-				2CA2F64C2B52798D0045B4C2 /* MyPageModalAvatarFeatureLabelView.swift in Sources */,
 				A14EDBC12B4F06E600906957 /* HomeSosoPickView.swift in Sources */,
 				A147CBC42B4D662E0040AE39 /* SearchView.swift in Sources */,
 				A1DBB2FE2B4AEB22000EE869 /* UIView+.swift in Sources */,
@@ -782,7 +783,6 @@
 				A1DBB3002B4AFCC0000EE869 /* SearchDummy.swift in Sources */,
 				2CCBFA022B4DC10500D787C2 /* MyPageProfileView.swift in Sources */,
 				392A292D2B4ECF320065EB97 /* RegisterNormalReadStatusView.swift in Sources */,
-				2CA2F64A2B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift in Sources */,
 				A1A1F9D22B4873A100705F44 /* SearchResultView.swift in Sources */,
 				2CCBFA002B4DBFD200D787C2 /* MyPageViewModel.swift in Sources */,
 			);

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		2C79CB992B45A0B200734E1F /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */; };
 		2C79CB9B2B45A0B700734E1F /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */; };
 		2C79CB9D2B45A1DD00734E1F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */; };
+		2CA2F6482B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */; };
+		2CA2F64A2B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */; };
 		2CCBF9EE2B4C1FC500D787C2 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */; };
 		2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */; };
 		2CCBF9F22B4D347B00D787C2 /* WSSMainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */; };
@@ -106,6 +108,8 @@
 		2C79CB982B45A0B200734E1F /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		2C79CB9A2B45A0B700734E1F /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		2C79CB9C2B45A1DD00734E1F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = " MyPageCustomModalViewController.swift"; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/ MyPageCustomModalViewController.swift"; sourceTree = "<group>"; };
+		2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyPageCustomAvatarModalView.swift; path = "../../../../../../../../../.Trash/WSS-iOS 오후 11.50.02/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomAvatarModalView.swift"; sourceTree = "<group>"; };
 		2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSMainButton.swift; sourceTree = "<group>"; };
@@ -239,6 +243,7 @@
 			children = (
 				2CCBF9ED2B4C1FC500D787C2 /* MyPageViewController.swift */,
 				2C5D0F5E2B50523B00C76D3C /* MyPageChangeNicknameViewController.swift */,
+				2CA2F6472B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift */,
 			);
 			path = MyPageViewController;
 			sourceTree = "<group>";
@@ -248,6 +253,7 @@
 			children = (
 				2CCBF9EF2B4C1FD800D787C2 /* MyPageView.swift */,
 				2C5D0F602B50525700C76D3C /* MyPageChangeNicknameView.swift */,
+				2CA2F6492B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift */,
 				2C5D0F572B4FDE7500C76D3C /* MyPageCell */,
 				2CCBF9FE2B4DBF6A00D787C2 /* MyPageAssistantView */,
 			);
@@ -712,6 +718,7 @@
 				A14EB86A2B4F15D400A0A799 /* HomeSosoPickUserNumberChipView.swift in Sources */,
 				A1708F182B4D8E2F00E35E50 /* HomeView.swift in Sources */,
 				2CD2291C2B42E685005400BE /* AppDelegate.swift in Sources */,
+				2CA2F6482B5278AF0045B4C2 /*  MyPageCustomModalViewController.swift in Sources */,
 				A1708F162B4D8E2700E35E50 /* HomeHeaderView.swift in Sources */,
 				2CCBF9F02B4C1FD800D787C2 /* MyPageView.swift in Sources */,
 				39AF30D12B50182F00FDC1F3 /* RegisterNormalReadStatusButton.swift in Sources */,
@@ -771,6 +778,7 @@
 				A1DBB3002B4AFCC0000EE869 /* SearchDummy.swift in Sources */,
 				2CCBFA022B4DC10500D787C2 /* MyPageProfileView.swift in Sources */,
 				392A292D2B4ECF320065EB97 /* RegisterNormalReadStatusView.swift in Sources */,
+				2CA2F64A2B5278C50045B4C2 /* MyPageCustomAvatarModalView.swift in Sources */,
 				A1A1F9D22B4873A100705F44 /* SearchResultView.swift in Sources */,
 				2CCBFA002B4DBFD200D787C2 /* MyPageViewModel.swift in Sources */,
 			);

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         navigationController.isNavigationBarHidden = true
         
         self.window = UIWindow(windowScene: windowScene)
-        self.window?.rootViewController = RegisterNormalViewController()
+        self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }
 

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
+        let navigationController = UINavigationController(rootViewController: MyPageCustomModalViewController())
         navigationController.isNavigationBarHidden = true
         
         self.window = UIWindow(windowScene: windowScene)

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -8,48 +8,48 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-
-        let navigationController = UINavigationController(rootViewController: MyPageViewController())
+        
+        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
         navigationController.isNavigationBarHidden = true
         
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
+    
+    
 }
 

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        let navigationController = UINavigationController(rootViewController: MyPageCustomModalViewController())
+        let navigationController = UINavigationController(rootViewController: MyPageViewController())
         navigationController.isNavigationBarHidden = true
         
         self.window = UIWindow(windowScene: windowScene)

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSMainButton.swift
@@ -34,7 +34,6 @@ final class WSSMainButton: UIButton {
             self.snp.makeConstraints() {
                 $0.centerX.equalToSuperview()
                 $0.leading.equalToSuperview().inset(20)
-                $0.bottom.equalTo(superview!.safeAreaLayoutGuide).offset(-10)
                 $0.height.equalTo(53)
             }
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift
@@ -1,0 +1,85 @@
+//
+//  MyPageCustomModalLabelView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/13/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class MyPageModalAvatarFeatureLabelView: UIView {
+    
+    //MARK: - UI Components
+    
+    private var stackView = UIStackView()
+    public var modalAvaterBadgeImageView = UIImageView()
+    public var modalAvaterTitleLabel = UILabel()
+    private let emptylabel1 = UILabel()
+    private let emptylabel2 = UILabel()
+    
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierachy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - set UI
+    
+    private func setUI() {
+        stackView.do {
+            $0.axis = .horizontal
+            $0.alignment = .center
+            $0.distribution = .fill
+            $0.spacing = 6
+            $0.backgroundColor = .clear
+            $0.layer.borderColor = UIColor.Gray100.cgColor
+            $0.layer.borderWidth = 1
+            $0.layer.cornerRadius = 26
+            
+            modalAvaterBadgeImageView.image = ImageLiterals.icon.Badge.HF
+            
+            modalAvaterTitleLabel.do {
+                $0.text = "회귀자"
+                $0.font = .HeadLine1
+                $0.textColor = .Black
+            }
+        }
+    }
+    
+    //MARK: - set Hierachy
+    
+    private func setHierachy() {
+        self.addSubview(stackView)
+        stackView.addArrangedSubviews(emptylabel1,
+                                      modalAvaterBadgeImageView,
+                                      modalAvaterTitleLabel,
+                                      emptylabel2)
+    }
+    
+    //MARK: - set Layout
+    
+    private func setLayout() {
+        stackView.snp.makeConstraints() {
+            $0.edges.equalToSuperview()
+        }
+        
+        [emptylabel1, emptylabel2].forEach {
+            $0.snp.makeConstraints() {
+                $0.height.equalTo(52)
+                $0.width.equalTo(10)
+            }     
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageAssistantView/MyPageModalAvatarFeatureLabelView.swift
@@ -10,15 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
-class MyPageModalAvatarFeatureLabelView: UIView {
+final class MyPageModalAvatarFeatureLabelView: UIView {
     
     //MARK: - UI Components
     
     private var stackView = UIStackView()
     public var modalAvaterBadgeImageView = UIImageView()
     public var modalAvaterTitleLabel = UILabel()
-    private let emptylabel1 = UILabel()
-    private let emptylabel2 = UILabel()
     
     
     // MARK: - Life Cycle
@@ -38,15 +36,18 @@ class MyPageModalAvatarFeatureLabelView: UIView {
     //MARK: - set UI
     
     private func setUI() {
+        self.do {
+            $0.backgroundColor = .clear
+            $0.layer.borderColor = UIColor.Gray100.cgColor
+            $0.layer.borderWidth = 1
+            $0.layer.cornerRadius = 26
+        }
+        
         stackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
             $0.distribution = .fill
             $0.spacing = 6
-            $0.backgroundColor = .clear
-            $0.layer.borderColor = UIColor.Gray100.cgColor
-            $0.layer.borderWidth = 1
-            $0.layer.cornerRadius = 26
             
             modalAvaterBadgeImageView.image = ImageLiterals.icon.Badge.HF
             
@@ -62,24 +63,20 @@ class MyPageModalAvatarFeatureLabelView: UIView {
     
     private func setHierachy() {
         self.addSubview(stackView)
-        stackView.addArrangedSubviews(emptylabel1,
-                                      modalAvaterBadgeImageView,
-                                      modalAvaterTitleLabel,
-                                      emptylabel2)
+        stackView.addArrangedSubviews(modalAvaterBadgeImageView,
+                                      modalAvaterTitleLabel)
     }
     
     //MARK: - set Layout
     
     private func setLayout() {
         stackView.snp.makeConstraints() {
-            $0.edges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.verticalEdges.equalToSuperview().inset(11)
         }
         
-        [emptylabel1, emptylabel2].forEach {
-            $0.snp.makeConstraints() {
-                $0.height.equalTo(52)
-                $0.width.equalTo(10)
-            }     
+        modalAvaterBadgeImageView.snp.makeConstraints() {
+            $0.size.equalTo(30)
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCell/MyPageInventoryCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCell/MyPageInventoryCollectionViewCell.swift
@@ -18,7 +18,7 @@ final class MyPageInventoryCollectionViewCell: UICollectionViewCell {
     
     //MARK: - UI Components
     
-    var myPageAvaterImageView = UIImageView()
+    var myPageAvaterButton = UIButton()
     
     //MARK: - Life Cycle
     
@@ -38,7 +38,7 @@ final class MyPageInventoryCollectionViewCell: UICollectionViewCell {
     //MARK: - Set UI
     
     private func setUI() {
-        myPageAvaterImageView.do {
+        myPageAvaterButton.do {
             $0.layer.cornerRadius = 12
             $0.layer.masksToBounds = true
         }
@@ -47,13 +47,13 @@ final class MyPageInventoryCollectionViewCell: UICollectionViewCell {
     //MARK: - Set Hierachy
     
     private func setHierachy() {
-        self.addSubview(myPageAvaterImageView)
+        self.addSubview(myPageAvaterButton)
     }
     
     //MARK: - Set Layout
     
     private func setLayout() {
-        myPageAvaterImageView.snp.makeConstraints() {
+        myPageAvaterButton.snp.makeConstraints() {
             $0.height.width.equalToSuperview()
         }
     }
@@ -61,14 +61,14 @@ final class MyPageInventoryCollectionViewCell: UICollectionViewCell {
     // 네트워크 연결 후 수정 예정
     
     func bindData(_ selected: Bool) {
-        myPageAvaterImageView.image = UIImage(named: "exampleAvater")
+        myPageAvaterButton.setImage(UIImage(named: "exampleAvater"), for: .normal)
 
         if selected {
-            myPageAvaterImageView.layer.borderColor = UIColor.Primary100.cgColor
-            myPageAvaterImageView.layer.borderWidth = 1
+            myPageAvaterButton.layer.borderColor = UIColor.Primary100.cgColor
+            myPageAvaterButton.layer.borderWidth = 1
         }else {
-            myPageAvaterImageView.layer.borderColor = UIColor.Primary100.cgColor
-            myPageAvaterImageView.layer.borderWidth = 1
+            myPageAvaterButton.layer.borderColor = UIColor.Primary100.cgColor
+            myPageAvaterButton.layer.borderWidth = 1
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
@@ -1,0 +1,113 @@
+//
+//  MyPageCustomModalView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/13/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class MyPageCustomModalView: UIView {
+
+    //MARK: - UI Components
+    
+    public var modalAvatarFeatureView = MyPageModalAvatarFeatureLabelView()
+    public var modalAvaterImageView = UIImageView()
+    public var modalTitleLabel = UILabel()
+    public var modalExplanationLabel = UILabel()
+    public var modalChangeButton = WSSMainButton(title: "대표 캐릭터 설정하기")
+    public var modalContinueButton = UIButton()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierachy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.do {
+            $0.backgroundColor = .White
+            $0.layer.cornerRadius = 10
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            $0.layer.masksToBounds = true
+        }
+
+        //뷰컨으로 뺄 예정
+        modalAvaterImageView.backgroundColor = .Gray300
+        
+        modalTitleLabel.do {
+            //text 뷰컨으로 뺄 예정
+            $0.text = "오늘 당신을 만날 걸 알고 있었어"
+            $0.font = .HeadLine1
+            $0.textColor = .Black
+        }
+        
+        modalExplanationLabel.do {
+            //text 뷰컨으로 뺄 예정
+            $0.text = "메모를 작성해서 잠금해제 됐어요!"
+            $0.font = .Title1
+            $0.textColor = .Gray200
+        }
+        
+        modalContinueButton.do {
+            $0.setTitle("원래대로 유지하기", for: .normal)
+            $0.setTitleColor(.Gray300, for: .normal)
+            $0.titleLabel?.font = .Body2
+            $0.layer.backgroundColor = UIColor.clear.cgColor
+        }
+    }
+    
+    private func setHierachy() {
+        self.addSubviews(modalAvatarFeatureView,
+                         modalAvaterImageView,
+                         modalTitleLabel,
+                         modalExplanationLabel,
+                         modalChangeButton,
+                         modalContinueButton)
+    }
+    
+    private func setLayout() {
+        modalAvatarFeatureView.snp.makeConstraints() {
+            $0.top.equalToSuperview().inset(30)
+            $0.centerX.equalToSuperview()
+        }
+        
+        modalAvaterImageView.snp.makeConstraints() {
+            $0.top.equalTo(modalAvatarFeatureView.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+            $0.size.equalTo(220)
+        }
+        
+        modalTitleLabel.snp.makeConstraints() {
+            $0.top.equalTo(modalAvaterImageView.snp.bottom).offset(18)
+            $0.centerX.equalToSuperview()
+        }
+        
+        modalExplanationLabel.snp.makeConstraints() {
+            $0.top.equalTo(modalTitleLabel.snp.bottom).offset(4)
+            $0.centerX.equalToSuperview()
+        }
+        
+        modalChangeButton.snp.makeConstraints() {
+            $0.top.equalTo(modalExplanationLabel.snp.bottom).offset(30)
+            $0.height.equalTo(53)
+        }
+        
+        modalContinueButton.snp.makeConstraints() {
+            $0.top.equalTo(modalChangeButton.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(53)
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
@@ -14,7 +14,7 @@ class MyPageCustomModalView: UIView {
 
     //MARK: - UI Components
     
-    public var modalAvatarFeatureView = MyPageModalAvatarFeatureLabelView()
+    public var modalAvatarFeatureLabelView = MyPageModalAvatarFeatureLabelView()
     public var modalAvaterImageView = UIImageView()
     public var modalTitleLabel = UILabel()
     public var modalExplanationLabel = UILabel()
@@ -69,7 +69,7 @@ class MyPageCustomModalView: UIView {
     }
     
     private func setHierachy() {
-        self.addSubviews(modalAvatarFeatureView,
+        self.addSubviews(modalAvatarFeatureLabelView,
                          modalAvaterImageView,
                          modalTitleLabel,
                          modalExplanationLabel,
@@ -78,13 +78,14 @@ class MyPageCustomModalView: UIView {
     }
     
     private func setLayout() {
-        modalAvatarFeatureView.snp.makeConstraints() {
+        modalAvatarFeatureLabelView.snp.makeConstraints() {
             $0.top.equalToSuperview().inset(30)
             $0.centerX.equalToSuperview()
+            $0.height.equalTo(52)
         }
         
         modalAvaterImageView.snp.makeConstraints() {
-            $0.top.equalTo(modalAvatarFeatureView.snp.bottom).offset(30)
+            $0.top.equalTo(modalAvatarFeatureLabelView.snp.bottom).offset(30)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(220)
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageView/MyPageCustomModalView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class MyPageCustomModalView: UIView {
+final class MyPageCustomModalView: UIView {
 
     //MARK: - UI Components
     
@@ -81,7 +81,7 @@ class MyPageCustomModalView: UIView {
         modalAvatarFeatureLabelView.snp.makeConstraints() {
             $0.top.equalToSuperview().inset(30)
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(52)
+//            $0.height.equalTo(52)
         }
         
         modalAvaterImageView.snp.makeConstraints() {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageCustomModalViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageCustomModalViewController.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-import RxSwift
 import RxCocoa
+import RxSwift
 
 class MyPageCustomModalViewController: UIViewController {
-
+    
     //MARK: - Set Properties
     
     private let disposeBag = DisposeBag()
@@ -19,19 +19,37 @@ class MyPageCustomModalViewController: UIViewController {
     //MARK: - UI Components
     
     private var rootView = MyPageCustomModalView()
+    private let myPageViewController = MyPageViewController()
     
     // MARK: - Life Cycle
-    
-    override func loadView() {
-        self.view = rootView
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setHierachy()
+        setLayout()
+        tapContinueButton()
     }
     
     //MARK: - Custom Method
     
+    private func setHierachy() {
+        self.view.addSubview(rootView)
+    }
     
+    private func setLayout() {
+        rootView.snp.makeConstraints() {
+            $0.bottom.width.equalToSuperview()
+            $0.height.equalTo(572)
+        }
+    }
+    
+    private func tapContinueButton() {
+        rootView.modalContinueButton.rx.tap
+            .bind(with: self, onNext: { owner, _ in
+//                owner.myPageViewController.myPageViewModel.removeDimmedView.onNext(())
+                owner.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageCustomModalViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageCustomModalViewController.swift
@@ -1,0 +1,37 @@
+//
+//  MyPageCustomModalViewController.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/13/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+class MyPageCustomModalViewController: UIViewController {
+
+    //MARK: - Set Properties
+    
+    private let disposeBag = DisposeBag()
+    
+    //MARK: - UI Components
+    
+    private var rootView = MyPageCustomModalView()
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    //MARK: - Custom Method
+    
+    
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/MyPageViewController/MyPageViewController.swift
@@ -7,8 +7,10 @@
 
 import UIKit
 
-import RxSwift
 import RxCocoa
+import RxSwift
+import SnapKit
+import Then
 
 final class MyPageViewController: UIViewController {
     
@@ -28,6 +30,7 @@ final class MyPageViewController: UIViewController {
     //MARK: - UI Components
     
     private var rootView = MyPageView()
+//    private let dimmedView = UIView()
     
     // MARK: - Life Cycle
     
@@ -41,6 +44,7 @@ final class MyPageViewController: UIViewController {
         register()
         bindDataToMyPageCollectionView()
         pushChangeNicknameViewController()
+//        removeDimmedView()
     }
     
     //MARK: - UI Components
@@ -57,7 +61,11 @@ final class MyPageViewController: UIViewController {
         items.bind(to: rootView.myPageInventoryView.myPageAvaterCollectionView.rx.items(
             cellIdentifier: "MyPageInventoryCollectionViewCell",
             cellType: MyPageInventoryCollectionViewCell.self)) { (row, element, cell) in
-                cell.myPageAvaterImageView.image = element
+                cell.myPageAvaterButton.setImage(element, for: .normal)
+                cell.myPageAvaterButton.rx.tap
+                    .bind(with: self, onNext: { owner, _ in 
+                        owner.tapAvatarButton()
+                    })
             }
             .disposed(by: disposeBag)
         
@@ -71,15 +79,36 @@ final class MyPageViewController: UIViewController {
     
     private func pushChangeNicknameViewController() {
         rootView.myPageTallyView.myPageUserNameButton.rx.tap
-            .bind {[weak self] in
-                if let tabBarController = self?.tabBarController as? WSSTabBarController {
+            .bind(with: self, onNext: { owner, _ in 
+                if let tabBarController = owner.tabBarController as? WSSTabBarController {
                     tabBarController.tabBar.isHidden = true
                     tabBarController.shadowView.isHidden = true
                 }
                 
                 let changeNicknameViewController = MyPageChangeNicknameViewController()
-                self?.navigationController?.pushViewController(changeNicknameViewController, animated: true)
-            }
+                owner.navigationController?.pushViewController(changeNicknameViewController, animated: true)
+            })
             .disposed(by: disposeBag)
     }
+}
+
+extension MyPageViewController {
+    @objc func tapAvatarButton() {
+        let modalVC = MyPageCustomModalViewController()
+//        addDimmedView()
+        modalVC.modalPresentationStyle = .overFullScreen
+        present(modalVC, animated: true)
+    }
+    
+//    private func addDimmedView() {
+//        view.addSubview(dimmedView)
+//        dimmedView.do {
+//            $0.backgroundColor = .Black
+//            $0.alpha = 0.6
+//            $0.addGestureRecognizer(tapGesture)
+//        }
+//        dimmedView.snp.makeConstraints() {
+//            $0.edges.equalToSuperview()
+//        }
+//    }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#27 
<br/>

### 🌟Motivation
모달을 구현하였습니당
<br/>

### 🌟Key Changes

<br/>

캐릭터 특성 라벨은 PPP 때 쓰던걸로 만들었습니당

```swift
stackView.addArrangedSubviews(emptylabel1,
                                      modalAvaterBadgeImageView,
                                      modalAvaterTitleLabel,
                                      emptylabel2)
```
<br/>

++위처럼 잡아주던걸 StackView 자체적으로 만들어주어 편하게 emptyView 사용 안해도 되도록 하였습니다 :)

```swift
stackView.snp.makeConstraints() {
            $0.horizontalEdges.equalToSuperview().inset(20)
            $0.verticalEdges.equalToSuperview().inset(11)
        }
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2024-01-13 at 23 24 29](https://github.com/Team-WSS/WSS-iOS/assets/103318297/34cff1c2-3d4a-46ca-9429-f87f2f1da1a0)

<br/>

### 🌟To Reviewer
시뮬레이션에서 버벅이는데 제 시뮬에서는 잘 돌아갑니다!

PageVC 에서 modalVC 가 뜰 때는 뒤에 반투명한 배경이 뜨고 모달이 뜨는데,
반대로 modalVC 를 dismiss 할 때 PageVC의 반투명한 배경이 사라지지 않았습니다.
이 에러는 네트워크 붙이면서 한 번 더 구현해보겠습니당

공통 컴포넌트로 사용하는 WSSMainButton 의 bottom 값을 해제했습니다.
아무래도 항상 그 래이아웃으로 잡히는 게 아니라서 불편하더라구요용
참고해두세요!

```swift
if superview != nil {
            self.snp.makeConstraints() {
                $0.centerX.equalToSuperview()
                $0.leading.equalToSuperview().inset(20)
                $0.height.equalTo(53)
            }
        }
```

<br/>

### 🌟Reference
- 모달 커스텀
https://mcflynn.tistory.com/20
https://velog.io/@minsang/iOS-Bottom-Sheet
<br/>
