### PR TITLE
[Feat] #21 - 공통 토스트 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		CD3E5AA22B55190400C0A659 /* UserNovelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AA12B55190400C0A659 /* UserNovelResult.swift */; };
 		CD3E5AAB2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AAA2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift */; };
 		CD3E5AB32B565DFF00C0A659 /* NovelMemoResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AB22B565DFF00C0A659 /* NovelMemoResult.swift */; };
+		CDE596D62B57708D00D99DA1 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE596D52B57708D00D99DA1 /* UIViewController+.swift */; };
+		CDE596D82B5770CE00D99DA1 /* WSSToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE596D72B5770CE00D99DA1 /* WSSToastView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -330,6 +332,8 @@
 		CD3E5AA12B55190400C0A659 /* UserNovelResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNovelResult.swift; sourceTree = "<group>"; };
 		CD3E5AAA2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailMemoSettingButtonView.swift; sourceTree = "<group>"; };
 		CD3E5AB22B565DFF00C0A659 /* NovelMemoResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelMemoResult.swift; sourceTree = "<group>"; };
+		CDE596D52B57708D00D99DA1 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		CDE596D72B5770CE00D99DA1 /* WSSToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSToastView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -385,6 +389,7 @@
 				2C2491832B4ADC230096F255 /* WSSTabBarItem.swift */,
 				2CCBF9F12B4D347B00D787C2 /* WSSMainButton.swift */,
 				39CC168B2B526991003F56AE /* WSSSectionTitleView.swift */,
+				CDE596D72B5770CE00D99DA1 /* WSSToastView.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -562,6 +567,7 @@
 				A1DBB2FD2B4AEB22000EE869 /* UIView+.swift */,
 				A147CBC52B4D6E190040AE39 /* UIStackView+.swift */,
 				CD39F2C02B4FF81E00B73A5C /* UIButton+.swift */,
+				CDE596D52B57708D00D99DA1 /* UIViewController+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1250,6 +1256,7 @@
 				A1C3EC532B46962F00D997C2 /* UIImage+.swift in Sources */,
 				39CD5E0C2B4F3D0700668B9A /* RegisterNormalNovelSummaryView.swift in Sources */,
 				A122C9F22B53146800DFCFE4 /* (null) in Sources */,
+				CDE596D62B57708D00D99DA1 /* UIViewController+.swift in Sources */,
 				A1147A792B50552500141692 /* HomeSosoPickDummy.swift in Sources */,
 				A1654F162B540513004F78E8 /* NetworkLogger.swift in Sources */,
 				A14EDBBF2B4F05F300906957 /* HomeSosoPickCollectionViewCell.swift in Sources */,
@@ -1260,6 +1267,7 @@
 				CD39F2E42B50F23B00B73A5C /* NovelDetailInfoPlatformView.swift in Sources */,
 				CD39F2BD2B4FE98500B73A5C /* NovelDetailHeaderView.swift in Sources */,
 				CD39F2E62B50F2E900B73A5C /* NovelDetailInfoPlatformCollectionViewCell.swift in Sources */,
+				CDE596D82B5770CE00D99DA1 /* WSSToastView.swift in Sources */,
 				A1A1F9D42B4873B500705F44 /* SearchEmptyView.swift in Sources */,
 				3999BFE92B4E6C3500984832 /* RegisterNormalViewController.swift in Sources */,
 				39CC16902B529AB6003F56AE /* RegisterNormalReadStatusView.swift in Sources */,

--- a/WSSiOS/WSSiOS/Resource/Assets.xcassets/icAlert/icAlertCheck.imageset/Contents.json
+++ b/WSSiOS/WSSiOS/Resource/Assets.xcassets/icAlert/icAlertCheck.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "Group 1171275377.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WSSiOS/WSSiOS/Resource/Assets.xcassets/icAlert/icAlertCheck.imageset/Group 1171275377.svg
+++ b/WSSiOS/WSSiOS/Resource/Assets.xcassets/icAlert/icAlertCheck.imageset/Group 1171275377.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22.5 12.9648C22.5 18.7637 17.7989 23.4648 12 23.4648C6.20114 23.4648 1.5 18.7637 1.5 12.9648C1.5 7.16598 6.20114 2.46484 12 2.46484C17.7989 2.46484 22.5 7.16598 22.5 12.9648Z" fill="#6341F0"/>
+<path d="M7 12.7247L10.2401 15.9648L16.2401 9.96484" stroke="#F1EFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/WSSiOS/WSSiOS/Resource/Constants/Images/ImageLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Images/ImageLiterals.swift
@@ -13,6 +13,7 @@ enum ImageLiterals {
         enum Alert {
             static var success: UIImage{ .load(named: "icAlertSuccess")}
             static var warning: UIImage{ .load(named: "icAlertWarning")}
+            static var check: UIImage{ .load(named: "icAlertCheck")}
         }
         
         enum BookRegistration {

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -1,0 +1,32 @@
+//
+//  UIViewController+.swift
+//  WSSiOS
+//
+//  Created by Hyowon Jeon on 1/17/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+extension UIViewController {
+    func showToast(_ toastStatus: ToastStatus) {
+        let toastView = WSSToastView(toastStatus)
+        
+        self.view.addSubview(toastView)
+        
+        toastView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.snp.bottom).offset(-212)
+        }
+        
+        UIView.animate(withDuration: 0, animations: {
+            toastView.alpha = 1
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.3, delay: 3.0) {
+                toastView.alpha = 0
+            }
+        })
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Data/DTO/NovelMemoResult.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/NovelMemoResult.swift
@@ -26,23 +26,3 @@ struct MemoDetail: Codable {
     let memoDate: String
     let memoContent: String
 }
-
-// 삭제 예정
-struct RecordMemos: Decodable {
-    let memoCount: Int
-    let memos: [RecordMemo]
-}
-
-struct RecordMemo: Codable {
-    let id: Int
-    let novelTitle: String
-    let content: String
-    let date: String
-    
-    enum CodingKeys: String, CodingKey {
-        case id = "memoId"
-        case novelTitle
-        case content = "memoContent"
-        case date = "memoDate"
-    }
-}

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSToastView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSToastView.swift
@@ -1,0 +1,128 @@
+//
+//  WSSToastView.swift
+//  WSSiOS
+//
+//  Created by Hyowon Jeon on 1/17/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+enum ToastStatus {
+    case memoSaveSuccess
+    case memoSaveFail
+    case memoDelete
+    case avatarUnlock
+    case nicknameSave
+    
+    var toastImage: UIImage {
+        switch self {
+        case .memoSaveSuccess, .nicknameSave:
+            ImageLiterals.icon.Alert.success
+        case .memoSaveFail, .memoDelete:
+            ImageLiterals.icon.Alert.warning
+        case .avatarUnlock:
+            ImageLiterals.icon.Alert.check
+        }
+    }
+    
+    var toastText: String {
+        switch self {
+        case .memoSaveSuccess:
+            "메모를 저장했어요"
+        case .memoSaveFail:
+            "메모 저장에 실패했어요"
+        case .memoDelete:
+            "메모를 삭제했어요"
+        case .avatarUnlock:
+            "새 캐릭터가 열렸어요!\n마이페이지에서 확인하세요"
+        case .nicknameSave:
+            "닉네임을 저장했어요"
+        }
+    }
+}
+
+final class WSSToastView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let toastImageView = UIImageView()
+    private let descriptionLabel = UILabel()
+    
+    // MARK: - Life Cycle
+    
+    
+    init(_ toastStatus: ToastStatus) {
+        super.init(frame: .zero)
+        
+        setUI()
+        setHierachy()
+        
+        bindData(toastStatus)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setUI() {
+        self.do {
+            $0.backgroundColor = .GrayToast.withAlphaComponent(0.8)
+            $0.layer.cornerRadius = 20
+        }
+        
+        toastImageView.do {
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        descriptionLabel.do {
+            $0.textColor = .Gray50
+            $0.font = .Body1
+            $0.numberOfLines = 2
+        }
+    }
+    
+    private func setHierachy() {
+        self.addSubviews(toastImageView,
+                         descriptionLabel)
+    }
+    
+    func bindData(_ status: ToastStatus) {
+        self.toastImageView.image = status.toastImage
+        self.descriptionLabel.text = status.toastText
+        self.setLayout(status)
+    }
+    
+    func setLayout(_ status: ToastStatus) {
+        switch status {
+        case .memoSaveSuccess, .memoSaveFail, .memoDelete, .nicknameSave:
+            toastImageView.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(14)
+                $0.leading.equalToSuperview().inset(20)
+                $0.size.equalTo(24)
+            }
+            
+            descriptionLabel.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(14)
+                $0.leading.equalTo(toastImageView.snp.trailing).offset(8)
+                $0.trailing.equalToSuperview().inset(20)
+            }
+        case .avatarUnlock:
+            toastImageView.snp.makeConstraints {
+                $0.top.equalToSuperview().inset(14)
+                $0.leading.equalToSuperview().inset(20)
+                $0.size.equalTo(24)
+            }
+            
+            descriptionLabel.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(14)
+                $0.leading.equalTo(toastImageView.snp.trailing).offset(8)
+                $0.trailing.equalToSuperview().inset(60)
+            }
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Memo/MemoViewController/MemoEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Memo/MemoViewController/MemoEditViewController.swift
@@ -98,7 +98,7 @@ final class MemoEditViewController: UIViewController {
     
     private func setBinding() {
         backButton.rx.tap.bind {
-            if let memoContent = self.memoContent {
+            if self.memoContent != nil {
                 if self.updatedMemoContent != self.memoContent {
                     let vc = DeletePopupViewController(
                         memoRepository: DefaultMemoRepository(
@@ -130,7 +130,7 @@ final class MemoEditViewController: UIViewController {
         }.disposed(by: disposeBag)
         
         completeButton.rx.tap.bind {
-            if let memoContent = self.memoContent {
+            if self.memoContent != nil {
                 self.patchMemo()
             } else {
                 self.postMemo()
@@ -148,7 +148,7 @@ final class MemoEditViewController: UIViewController {
                 } else {
                     self.enableCompleteButton()
                 }
-                if let memoContent = self.memoContent {
+                if self.memoContent != nil {
                     if self.updatedMemoContent == self.memoContent {
                         self.disableCompleteButton()
                     }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#21 
<br/>

### 🌟Motivation
공통 토스트 구현했습니다. 
<br/>

### 🌟Key Changes
- 토스트 케이스 enum으로 정의했습니다.
- 토스트를 띄우는 메서드를 UIViewController+ 에 정의했습니다.
- 토스트를 띄우고 싶은 시점에서 아래 메서드를 호출하면 됩니다.

```swift
showToast(.memoDelete)
```
<br/>

### 🌟Simulation
<img width="30%" src="https://github.com/Team-WSS/WSS-iOS/assets/68677647/7a02e7cf-9710-45e6-b222-7354b6943c45"/>
<img width="30%" src="https://github.com/Team-WSS/WSS-iOS/assets/68677647/cf3df8f7-c4ae-4fe0-8bac-e516de7aaa8b"/>
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
