### PR TITLE
[Fix] #85 - 메모/정보 뷰 1차 QA 반영

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -55,6 +55,8 @@ final class LibraryViewController: UIViewController {
         setHierarchy()
         setLayout()
         setAction()
+        
+        addNotificationCenter()
     }
     
     //MARK: - set NavigationBar
@@ -219,6 +221,29 @@ extension LibraryViewController {
             $0.width.equalTo(100)
             $0.height.equalTo(104)
         }
+    }
+    
+    //MARK: - notification
+    
+    private func addNotificationCenter() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.showNovelDetail(_:)),
+            name: NSNotification.Name("ShowNovelDetail"),
+            object: nil
+        )
+    }
+    
+    @objc
+    func showNovelDetail(_ notification: Notification) {
+        guard let userNovelId = notification.object as? Int else { return }
+        self.navigationController?.pushViewController(NovelDetailViewController(
+            repository: DefaultUserNovelRepository(
+                userNovelService: DefaultUserNovelService()
+            ),
+            userNovelId: userNovelId,
+            selectedMenu: 1
+        ), animated: true)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailView.swift
@@ -121,33 +121,33 @@ final class NovelDetailView: UIView {
         }
     }
     
-    func memoButtonDidTap() {
-        self.novelDetailInfoView.removeFromSuperview()
-        self.contentView.addArrangedSubview(self.novelDetailMemoView)
-        self.novelDetailTabView.do {
-            $0.memoButton.isSelected = true
-            $0.infoButton.isSelected = false
-            $0.highlightMemoButton()
-        }
-        self.stickyNovelDetailTabView.do {
-            $0.memoButton.isSelected = true
-            $0.infoButton.isSelected = false
-            $0.highlightMemoButton()
-        }
-    }
-    
-    func infoButtonDidTap() {
-        self.novelDetailMemoView.removeFromSuperview()
-        self.contentView.addArrangedSubview(self.novelDetailInfoView)
-        self.novelDetailTabView.do {
-            $0.memoButton.isSelected = false
-            $0.infoButton.isSelected = true
-            $0.highlightInfoButton()
-        }
-        self.stickyNovelDetailTabView.do {
-            $0.memoButton.isSelected = false
-            $0.infoButton.isSelected = true
-            $0.highlightInfoButton()
+    func changeCurrentMenu(menu: Int) {
+        if menu == 0 {
+            self.novelDetailInfoView.removeFromSuperview()
+            self.contentView.addArrangedSubview(self.novelDetailMemoView)
+            self.novelDetailTabView.do {
+                $0.memoButton.isSelected = true
+                $0.infoButton.isSelected = false
+                $0.highlightMemoButton()
+            }
+            self.stickyNovelDetailTabView.do {
+                $0.memoButton.isSelected = true
+                $0.infoButton.isSelected = false
+                $0.highlightMemoButton()
+            }
+        } else {
+            self.novelDetailMemoView.removeFromSuperview()
+            self.contentView.addArrangedSubview(self.novelDetailInfoView)
+            self.novelDetailTabView.do {
+                $0.memoButton.isSelected = false
+                $0.infoButton.isSelected = true
+                $0.highlightInfoButton()
+            }
+            self.stickyNovelDetailTabView.do {
+                $0.memoButton.isSelected = false
+                $0.infoButton.isSelected = true
+                $0.highlightInfoButton()
+            }
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
@@ -35,9 +35,10 @@ final class NovelDetailViewController: UIViewController {
     
     // MARK: - Life Cycle
     
-    init(repository: UserNovelRepository, userNovelId: Int) {
+    init(repository: UserNovelRepository, userNovelId: Int, selectedMenu: Int = 0) {
         self.repository = repository
         self.userNovelId = userNovelId
+        self.selectedMenu.onNext(selectedMenu)
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -165,10 +166,7 @@ final class NovelDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         backButton.rx.tap.bind {
-//            self.navigationController?.popToRootViewController(animated: true)
-//            self.navigationController?.tabBarController?.selectedIndex = 1
-            // 부드러운 애니메이션을 원한다면 .. (홈화면 또는 서재로 돌아간다.)
-            self.navigationController?.popToRootViewController(animated: true)
+            self.navigationController?.popViewController(animated: true)
         }.disposed(by: disposeBag)
         
         novelSettingButton.rx.tap.bind {
@@ -191,6 +189,7 @@ final class NovelDetailViewController: UIViewController {
         
         rootView.novelDetailMemoSettingButtonView.novelEditButon.rx.tap.bind {
             self.rootView.novelDetailMemoSettingButtonView.isHidden = true
+            self.selectedMenu.onNext(1)
             self.navigationController?.pushViewController(
                 RegisterNormalViewController(
                     novelRepository: DefaultNovelRepository(
@@ -214,33 +213,31 @@ final class NovelDetailViewController: UIViewController {
         }.disposed(by: disposeBag)
         
         selectedMenu
-            .subscribe(onNext: { selectedMenu in
+            .subscribe(with: self, onNext: { owner, selectedMenu in
                 if selectedMenu == 0 {
                     self.rootView.createMemoButton.isHidden = false
+                    self.rootView.changeCurrentMenu(menu: 0)
                 } else {
                     self.rootView.createMemoButton.isHidden = true
+                    self.rootView.changeCurrentMenu(menu: 1)
                 }
             })
             .disposed(by: disposeBag)
         
         rootView.novelDetailTabView.memoButton.rx.tap.bind {
             self.selectedMenu.onNext(0)
-            self.rootView.memoButtonDidTap()
         }.disposed(by: disposeBag)
         
         rootView.novelDetailTabView.infoButton.rx.tap.bind {
             self.selectedMenu.onNext(1)
-            self.rootView.infoButtonDidTap()
         }.disposed(by: disposeBag)
         
         rootView.stickyNovelDetailTabView.memoButton.rx.tap.bind {
             self.selectedMenu.onNext(0)
-            self.rootView.memoButtonDidTap()
         }.disposed(by: disposeBag)
         
         rootView.stickyNovelDetailTabView.infoButton.rx.tap.bind {
             self.selectedMenu.onNext(1)
-            self.rootView.infoButtonDidTap()
         }.disposed(by: disposeBag)
         
         rootView.novelDetailMemoView.memoTableView.rx.observe(CGSize.self, "contentSize")
@@ -249,7 +246,7 @@ final class NovelDetailViewController: UIViewController {
             .disposed(by: disposeBag)
 
         memoTableViewHeight
-            .subscribe(onNext: { height in
+            .subscribe(with: self, onNext: { owner, height in
                 self.rootView.novelDetailMemoView.updateTableViewHeight(height: height)
             })
             .disposed(by: disposeBag)
@@ -260,7 +257,7 @@ final class NovelDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         platformCollectionViewHeight
-            .subscribe(onNext: { height in
+            .subscribe(with: self, onNext: { owner, height in
                 self.rootView.novelDetailInfoView.novelDetailInfoPlatformView.updateCollectionViewHeight(height: height)
             })
             .disposed(by: disposeBag)

--- a/WSSiOS/WSSiOS/Source/Presentation/Register/RegisterNormal/RegisterNormalViewController/RegisterNormalViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Register/RegisterNormal/RegisterNormalViewController/RegisterNormalViewController.swift
@@ -156,7 +156,18 @@ final class RegisterNormalViewController: UIViewController {
                                            userNovelReadEndDate: requestEndDate)
         .observe(on: MainScheduler.instance)
         .subscribe(with: self, onNext: { owner, data in
-            self.navigationController?.pushViewController(NovelDetailViewController(repository: DefaultUserNovelRepository(userNovelService: DefaultUserNovelService()), userNovelId: self.userNovelId), animated: true)
+            if self.navigationController?.tabBarController?.selectedIndex == 0 {
+                let tabBar = WSSTabBarController()
+                tabBar.selectedIndex = 1
+                let navigationController = UINavigationController(rootViewController: tabBar)
+                navigationController.isNavigationBarHidden = true
+                self.view.window?.rootViewController = navigationController
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    NotificationCenter.default.post(name: NSNotification.Name("ShowNovelDetail"), object: self.userNovelId)
+                }
+            } else {
+                self.navigationController?.popViewController(animated: true)
+            }
         }, onError: { owner, error in
             print(error)
         })


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#85
<br/>

### 🌟Motivation
메모뷰 1차 QA 반영완료
<br/>

### 🌟Key Changes
- 공백 입력시 메모 등록 버튼 비활성화 했습니다.
- 검색뷰에서 이미 등록한 작품 클릭해 수정 시, 서재뷰로 이동 후 해당 작품 디테일 뷰 push 하도록 구현했습니다.
- 작품 디테일 뷰에서 작품 정보 수정 시, pop 하도록 구현했습니다.
- 작품 정보 수정 시 정보 탭을 띄우도록 수정했습니다.
<br/>


### 🌟Simulation

<img width="30%" src="https://github.com/Team-WSS/WSS-iOS/assets/68677647/3fc56398-3001-4866-a21f-fa968289081a"/>
<img width="30%" src="https://github.com/Team-WSS/WSS-iOS/assets/68677647/4bb43c2a-d0db-4c8a-973a-1b85aabec72b"/>
<br/>

### 🌟To Reviewer
- 뷰 이동 코드가 막 매끄럽진 않은데유,, 나중에 수정합시당
<br/>

### 🌟Reference

<br/>
