### PR TITLE
[Fix] #99 - 1.5차 QA 결과 반영

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryBaseViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryBaseViewController.swift
@@ -118,7 +118,9 @@ final class LibraryBaseViewController: UIViewController {
         .observe(on: MainScheduler.instance)
         .subscribe(with: self, onNext: { owner, data in
             owner.novelTotalCount = data.userNovelCount
-            owner.delegate?.sendData(data: owner.novelTotalCount)
+            if readStatus == owner.readStatusData {
+                owner.delegate?.sendData(data: owner.novelTotalCount)
+            }
             owner.novelListRelay.accept(data.userNovels)
         }, onError: { error, _  in
             print(error)

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryBaseViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryBaseViewController.swift
@@ -118,9 +118,7 @@ final class LibraryBaseViewController: UIViewController {
         .observe(on: MainScheduler.instance)
         .subscribe(with: self, onNext: { owner, data in
             owner.novelTotalCount = data.userNovelCount
-            if readStatus == owner.readStatusData {
-                owner.delegate?.sendData(data: owner.novelTotalCount)
-            }
+            owner.delegate?.sendData(data: owner.novelTotalCount)
             owner.novelListRelay.accept(data.userNovels)
         }, onError: { error, _  in
             print(error)

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -211,7 +211,6 @@ extension LibraryViewController: UIPageViewControllerDataSource {
 
 extension LibraryViewController: NovelDelegate {
     func sendData(data: Int) {
-        print(data)
         libraryDescriptionView.libraryNovelCountLabel.text = "\(data)개"
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -156,18 +156,23 @@ final class LibraryViewController: UIViewController {
             .bind(with: self, onNext: { owner, _ in 
                 owner.libraryListView.isHidden.toggle()
             })
+            .disposed(by: disposeBag)
         
         libraryListView.libraryNewestButton.rx.tap
             .bind(with: self) { owner , _ in
                 owner.updatePages(sort: owner.sortTypeList[0])
                 owner.libraryDescriptionView.libraryNovelListButton.setTitle(StringLiterals.Library.newest, for: .normal)
+                owner.libraryListView.isHidden.toggle()
             }
+            .disposed(by: disposeBag)
         
         libraryListView.libraryOldesttButton.rx.tap
             .bind(with: self) { owner , _ in
                 owner.updatePages(sort: owner.sortTypeList[1])
                 owner.libraryDescriptionView.libraryNovelListButton.setTitle(StringLiterals.Library.oldest, for: .normal)
+                owner.libraryListView.isHidden.toggle()
             }
+            .disposed(by: disposeBag)
     }
     
     private func updatePages(sort: String) {
@@ -206,6 +211,7 @@ extension LibraryViewController: UIPageViewControllerDataSource {
 
 extension LibraryViewController: NovelDelegate {
     func sendData(data: Int) {
+        print(data)
         libraryDescriptionView.libraryNovelCountLabel.text = "\(data)개"
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Record/RecordViewController/RecordViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Record/RecordViewController/RecordViewController.swift
@@ -57,6 +57,7 @@ final class RecordViewController: UIViewController {
         
         bindDataToRecordTableView()
         setNavigationBar()
+        setNotificationCenter()
     }
     
     private func setUI() {
@@ -190,5 +191,18 @@ final class RecordViewController: UIViewController {
             }
         })
         .disposed(by: disposeBag)
+    }
+    
+    private func setNotificationCenter() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.deletedMemo(_:)),
+            name: NSNotification.Name("DeletedMemo"),
+            object: nil
+        )
+    }
+    
+    @objc func deletedMemo(_ notification: Notification) {
+        showToast(.memoDelete)
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#99 
<br/>

### 🌟Motivation
명진과 가볍게 진행한 1.5차 QA 결과 반영
<br/>

### 🌟Key Changes
- 기록 뷰에서 메모 read 뷰에 갔다가 메모 삭제하면 삭제 토스트가 안 뜸
- 등록 뷰에서 상단 네비게이션 바 구분선이 사라지지 않는 문제 해결

<br/>

### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
