### PR TITLE
[Refactor] #125 - DeletePopup MVVM 패턴 적용

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		CD3E5AA22B55190400C0A659 /* UserNovelResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AA12B55190400C0A659 /* UserNovelResult.swift */; };
 		CD3E5AAB2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AAA2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift */; };
 		CD3E5AB32B565DFF00C0A659 /* NovelMemoResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E5AB22B565DFF00C0A659 /* NovelMemoResult.swift */; };
+		CD6613782B8B313700B90B2B /* DeletePopupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6613772B8B313700B90B2B /* DeletePopupViewModel.swift */; };
 		CDE596D62B57708D00D99DA1 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE596D52B57708D00D99DA1 /* UIViewController+.swift */; };
 		CDE596D82B5770CE00D99DA1 /* WSSToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE596D72B5770CE00D99DA1 /* WSSToastView.swift */; };
 		CDE596DA2B57C4BE00D99DA1 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE596D92B57C4BE00D99DA1 /* UITextView+.swift */; };
@@ -357,6 +358,7 @@
 		CD3E5AA12B55190400C0A659 /* UserNovelResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNovelResult.swift; sourceTree = "<group>"; };
 		CD3E5AAA2B56173C00C0A659 /* NovelDetailMemoSettingButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailMemoSettingButtonView.swift; sourceTree = "<group>"; };
 		CD3E5AB22B565DFF00C0A659 /* NovelMemoResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelMemoResult.swift; sourceTree = "<group>"; };
+		CD6613772B8B313700B90B2B /* DeletePopupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePopupViewModel.swift; sourceTree = "<group>"; };
 		CDE596D52B57708D00D99DA1 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		CDE596D72B5770CE00D99DA1 /* WSSToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSToastView.swift; sourceTree = "<group>"; };
 		CDE596D92B57C4BE00D99DA1 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
@@ -1149,6 +1151,7 @@
 		CD3E5A912B55097600C0A659 /* DeletePopup */ = {
 			isa = PBXGroup;
 			children = (
+				CD6613762B8B312800B90B2B /* DeletePopupViewModel */,
 				CD3E5A932B55098400C0A659 /* DeletePopupViewController */,
 				CD3E5A922B55097D00C0A659 /* DeletePopupView */,
 				CD3E5A952B55099E00C0A659 /* DeletePopupView.swift */,
@@ -1178,6 +1181,14 @@
 				CD3E5A972B5509A500C0A659 /* DeletePopupContentView.swift */,
 			);
 			path = DeletePopupAssistantView;
+			sourceTree = "<group>";
+		};
+		CD6613762B8B312800B90B2B /* DeletePopupViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CD6613772B8B313700B90B2B /* DeletePopupViewModel.swift */,
+			);
+			path = DeletePopupViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1318,6 +1329,7 @@
 				CD39F2B62B4FE0E200B73A5C /* NovelDetailView.swift in Sources */,
 				CD39F2E42B50F23B00B73A5C /* NovelDetailInfoPlatformView.swift in Sources */,
 				CD39F2BD2B4FE98500B73A5C /* NovelDetailHeaderView.swift in Sources */,
+				CD6613782B8B313700B90B2B /* DeletePopupViewModel.swift in Sources */,
 				CD39F2E62B50F2E900B73A5C /* NovelDetailInfoPlatformCollectionViewCell.swift in Sources */,
 				CDE596D82B5770CE00D99DA1 /* WSSToastView.swift in Sources */,
 				A1A1F9D42B4873B500705F44 /* SearchEmptyView.swift in Sources */,

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -122,11 +122,12 @@ extension UIViewController {
     
     func presentDeleteUserNovelViewController(userNovelId: Int) {
         let viewController = DeletePopupViewController(
-            userNovelRepository: DefaultUserNovelRepository(
-                userNovelService: DefaultUserNovelService()
-            ),
-            popupStatus: .novelDelete,
-            userNovelId: userNovelId
+            viewModel: DeletePopupViewModel(
+                userNovelRepository: DefaultUserNovelRepository(
+                    userNovelService: DefaultUserNovelService()
+                ),
+                userNovelId: userNovelId),
+            popupStatus: .novelDelete
         )
         viewController.modalPresentationStyle = .overFullScreen
         viewController.modalTransitionStyle = .crossDissolve
@@ -135,11 +136,12 @@ extension UIViewController {
     
     func presentMemoDeleteViewController(memoId: Int) {
         let viewController = DeletePopupViewController(
-            memoRepository: DefaultMemoRepository(
-                memoService: DefaultMemoService()
-            ),
-            popupStatus: .memoDelete,
-            memoId: memoId
+            viewModel: DeletePopupViewModel(
+                memoRepository: DefaultMemoRepository(
+                    memoService: DefaultMemoService()
+                ),
+                memoId: memoId),
+            popupStatus: .memoDelete
         )
         viewController.modalPresentationStyle = .overFullScreen
         viewController.modalTransitionStyle = .crossDissolve
@@ -148,8 +150,10 @@ extension UIViewController {
     
     func presentMemoEditCancelViewController() {
         let viewController = DeletePopupViewController(
-            memoRepository: DefaultMemoRepository(
-                memoService: DefaultMemoService()
+            viewModel: DeletePopupViewModel(
+                memoRepository: DefaultMemoRepository(
+                    memoService: DefaultMemoService()
+                )
             ),
             popupStatus: .memoEditCancel
         )

--- a/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewController/DeletePopupViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewController/DeletePopupViewController.swift
@@ -51,7 +51,7 @@ final class DeletePopupViewController: UIViewController {
     private func bindViewModel() {
         let input = DeletePopupViewModel.Input(
             popupStatus: self.popupStatus,
-            deleteButtonDidTapEvent: rootView.deletePopupContentView.deleteButton.rx.tap.throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance).asObservable()
+            deleteButtonDidTap: rootView.deletePopupContentView.deleteButton.rx.tap
         )
 
         let output = self.deletePopupViewModel.transform(from: input, disposeBag: self.disposeBag)

--- a/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewModel/DeletePopupViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewModel/DeletePopupViewModel.swift
@@ -30,8 +30,7 @@ final class DeletePopupViewModel: ViewModelType {
 
     struct Input {
         let popupStatus: PopupStatus
-        let deleteButtonDidTapEvent: Observable<Void>
-        
+        let deleteButtonDidTap: ControlEvent<Void>
     }
 
     struct Output {
@@ -45,32 +44,32 @@ final class DeletePopupViewModel: ViewModelType {
         
         switch input.popupStatus {
         case .memoEditCancel:
-            input.deleteButtonDidTapEvent
-                .subscribe(with: self, onNext: { owner, _ in
+            input.deleteButtonDidTap
+                .subscribe(onNext: {
                     output.canceledEdit.accept(true)
-                }, onError: { owner, error in
+                }, onError: { error in
                     print(error)
                 })
                 .disposed(by: disposeBag)
         case .memoDelete:
-            input.deleteButtonDidTapEvent
+            input.deleteButtonDidTap
                 .flatMapLatest {
                     self.deleteMemo()
                 }
-                .subscribe(with: self, onNext: { owner, _ in
+                .subscribe(onNext: {
                     output.deletedMemo.accept(true)
-                }, onError: { owner, error in
+                }, onError: { error in
                     print(error)
                 })
                 .disposed(by: disposeBag)
         case .novelDelete:
-            input.deleteButtonDidTapEvent
+            input.deleteButtonDidTap
                 .flatMapLatest {
                     self.deleteUserNovel()
                 }
-                .subscribe(with: self, onNext: { owner, _ in
+                .subscribe(onNext: {
                     output.deletedNovel.accept(true)
-                }, onError: { owner, error in
+                }, onError: { error in
                     print(error)
                 })
                 .disposed(by: disposeBag)

--- a/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewModel/DeletePopupViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/DeletePopup/DeletePopupViewModel/DeletePopupViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  DeletePopupViewModel.swift
+//  WSSiOS
+//
+//  Created by Hyowon Jeon on 2/25/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class DeletePopupViewModel: ViewModelType {
+
+    struct Input {
+    }
+
+    struct Output {
+    }
+
+    func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+
+        return output
+    }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
#125
<br/>

### 🌟Motivation
DeletePopupViewController에 MVVM 패턴을 적용했습니다.
<br/>

### 🌟Key Changes
- NovelDetailViewModel을 추가해 기존 비즈니스 로직을 ViewModel로 이동시켰습니다.
- PopupStatus를 Input으로 받아 케이스를 나눠 deleteButtonDidTapEvent를 subscribe 해주었습니다.
<br/>

### 🌟Simulation
없어용가리
<br/>

### 🌟To Reviewer
popupStatus도 viewModel이 들고 있는게 맞다는 생각이 들지만,, 뷰컨에서 rootView 초기화시 popupStatus가 필요해 일단 뷰컨에서 들고 있도록 구현했쌉다 🤓
<br/>
