### PR TITLE
[Chore] #151 - Line Height 피그마 상의 디자인과 동일하게 작동하도록 수정

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Assets.xcassets/Color/WSSGray70.colorset/Contents.json
+++ b/WSSiOS/WSSiOS/Resource/Assets.xcassets/Color/WSSGray70.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE3",
-          "green" : "0xDF",
-          "red" : "0xDF"
+          "blue" : "0xF2",
+          "green" : "0xEE",
+          "red" : "0xEE"
         }
       },
       "idiom" : "universal"

--- a/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
@@ -17,11 +17,11 @@ extension UILabel {
     
     func applyFontAttribute(text: String?, lineHeightMultiple: CGFloat, kerningPixel: Double, font: UIFont) {
         self.do {
+            $0.font = font
             $0.makeAttribute(with: text)?
                 .lineHeight(lineHeightMultiple)
                 .kerning(kerningPixel: kerningPixel)
                 .applyAttribute()
-            $0.font = font
         }
     }
     

--- a/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
@@ -10,9 +10,9 @@ import UIKit
 extension UILabel {
     func applyWSSFont(_ font: WSSFont, with text: String?) {
         self.applyFontAttribute(text: text,
-                       lineHeightMultiple: font.lineHeightMultiple,
-                       kerningPixel: font.kerningPixel,
-                       font: font.font)
+                                lineHeightMultiple: font.lineHeightMultiple,
+                                kerningPixel: font.kerningPixel,
+                                font: font.font)
     }
     
     func applyFontAttribute(text: String?, lineHeightMultiple: CGFloat, kerningPixel: Double, font: UIFont) {
@@ -256,27 +256,27 @@ extension TextAttributeSet {
     }
     
     func lineHeight(_ multiple: CGFloat) -> TextAttributeSet {
-            let lineHeight = self.label.font.pointSize * multiple
-            
-            let style = NSMutableParagraphStyle().then {
-                $0.maximumLineHeight = lineHeight
-                $0.minimumLineHeight = lineHeight
-            }
-            
-            self.attributedString.addAttribute(
-                .paragraphStyle,
-                value: style,
-                range: NSRange(location: 0, length: attributedString.length)
-            )
-            
-            self.attributedString.addAttribute(
-                .baselineOffset,
-                value: (lineHeight - self.label.font.lineHeight) / 2,
-                range: NSRange(location: 0, length: attributedString.length)
-            )
-            
-            return self
+        let lineHeight = self.label.font.pointSize * multiple
+        
+        let style = NSMutableParagraphStyle().then {
+            $0.maximumLineHeight = lineHeight
+            $0.minimumLineHeight = lineHeight
         }
+        
+        self.attributedString.addAttribute(
+            .paragraphStyle,
+            value: style,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+        
+        self.attributedString.addAttribute(
+            .baselineOffset,
+            value: (lineHeight - self.label.font.lineHeight) / 2,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+        
+        return self
+    }
     
     func applyAttribute() {
         self.label.attributedText = self.attributedString

--- a/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UILabel+.swift
@@ -18,7 +18,7 @@ extension UILabel {
     func applyFontAttribute(text: String?, lineHeightMultiple: CGFloat, kerningPixel: Double, font: UIFont) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(lineHeightMultiple)
+                .lineHeight(lineHeightMultiple)
                 .kerning(kerningPixel: kerningPixel)
                 .applyAttribute()
             $0.font = font
@@ -28,7 +28,7 @@ extension UILabel {
     func fontHeadline1Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.4)
+                .lineHeight(1.4)
                 .kerning(kerningPixel: -1.2)
                 .applyAttribute()
             $0.font = .HeadLine1
@@ -38,7 +38,7 @@ extension UILabel {
     func fontTitle1Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.4)
+                .lineHeight(1.4)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.font = .Title1
@@ -48,7 +48,7 @@ extension UILabel {
     func fontTitle2Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.4)
+                .lineHeight(1.4)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.font = .Title2
@@ -67,7 +67,7 @@ extension UILabel {
     func fontBody1Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.4)
+                .lineHeight(1.4)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.font = .Body1
@@ -77,7 +77,7 @@ extension UILabel {
     func fontBody2Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.5)
+                .lineHeight(1.5)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.font = .Body2
@@ -87,7 +87,7 @@ extension UILabel {
     func fontBody3Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.5)
+                .lineHeight(1.5)
                 .kerning(kerningPixel: -0.4)
                 .applyAttribute()
             $0.font = .Body3
@@ -97,7 +97,7 @@ extension UILabel {
     func fontBody4Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.45)
+                .lineHeight(1.45)
                 .kerning(kerningPixel: -0.4)
                 .applyAttribute()
             $0.font = .Body4
@@ -107,7 +107,7 @@ extension UILabel {
     func fontBody4_2Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.45)
+                .lineHeight(1.45)
                 .kerning(kerningPixel: -0.4)
                 .applyAttribute()
             $0.font = .Body4_2
@@ -117,7 +117,7 @@ extension UILabel {
     func fontBody5Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.45)
+                .lineHeight(1.45)
                 .applyAttribute()
             $0.font = .Body5
         }
@@ -126,7 +126,7 @@ extension UILabel {
     func fontBody5_2Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.45)
+                .lineHeight(1.45)
                 .applyAttribute()
             $0.font = .Body5_2
         }
@@ -135,7 +135,7 @@ extension UILabel {
     func fontLabel1Attribute(with text: String) {
         self.do {
             $0.makeAttribute(with: text)?
-                .lineHeightMultiple(1.45)
+                .lineHeight(1.45)
                 .kerning(kerningPixel: -0.4)
                 .applyAttribute()
             $0.font = .Label1
@@ -255,17 +255,28 @@ extension TextAttributeSet {
         return self
     }
     
-    func lineHeightMultiple(_ multiple: CGFloat) -> TextAttributeSet {
-        let style = NSMutableParagraphStyle()
-        style.lineHeightMultiple = multiple
-        self.attributedString.addAttribute(
-            .paragraphStyle,
-            value: style,
-            range: NSRange(location: 0, length: attributedString.length)
-        )
-        
-        return self
-    }
+    func lineHeight(_ multiple: CGFloat) -> TextAttributeSet {
+            let lineHeight = self.label.font.pointSize * multiple
+            
+            let style = NSMutableParagraphStyle().then {
+                $0.maximumLineHeight = lineHeight
+                $0.minimumLineHeight = lineHeight
+            }
+            
+            self.attributedString.addAttribute(
+                .paragraphStyle,
+                value: style,
+                range: NSRange(location: 0, length: attributedString.length)
+            )
+            
+            self.attributedString.addAttribute(
+                .baselineOffset,
+                value: (lineHeight - self.label.font.lineHeight) / 2,
+                range: NSRange(location: 0, length: attributedString.length)
+            )
+            
+            return self
+        }
     
     func applyAttribute() {
         self.label.attributedText = self.attributedString

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedAssistantView/FeedDetailContentView.swift
@@ -55,7 +55,7 @@ final class FeedDetailContentView: UIView {
         detailContentLabel.do {
             $0.text = isSpolier ? StringLiterals.Feed.spoilerText : content
             $0.makeAttribute(with: $0.text)?
-                .lineHeightMultiple(1.5)
+                .lineHeight(1.5)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.textColor = isSpolier ? .wssSecondary100 : .wssBlack

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedGenreViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedGenreViewController.swift
@@ -80,7 +80,7 @@ extension FeedGenreViewController: UICollectionViewDelegateFlowLayout {
         let feedContentLabel = UILabel().then {
             $0.text = text
             $0.makeAttribute(with: $0.text)?
-                .lineHeightMultiple(1.5)
+                .lineHeight(1.5)
                 .kerning(kerningPixel: -0.6)
                 .applyAttribute()
             $0.font = .Body2


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
close #151 
<br/>

### 🌟Motivation
- 안녕하세요.. 바꾼 Line Height Multiple로 작업하다보니 한줄 짜리 라벨에도 위쪽에만 행간만큼 Inset이 생기는 등 몇가지 문제가 있더라구요..? 그래서 사람들은 도대체 어떻게 하나 하고 찾아봤습니다.

<br/>

### 🌟Key Changes
- 그 결과 피그마 상의 line Height(percentage)에 맞게 lineHeight를 잡고 거기에 baseLineOffset을 줘서 글씨를 가운데 정렬로 바꿔주는 형태로 하더라구요.. 이렇게 하니까 피그마 상의 글씨영역 inset까지 다 동일하게 잘 맞더라구요!!?
- lineHeight를 고정 값으로 주는 거긴 하지만, 폰트가 바뀌는 일도 없기도 하고 피그마 상의 라벨과 동일하게 할 수 있는 최선의 방법이라 생각합니다.
- 폰트 크기 값을 받아서 baseLineOffset을 고정으로 줘야 하는거라 lineHeightMultiple을 그대로 쓸 수 없어서, LineHeight로 변경했어요
<br/>

### 🌟Simulation
이렇게 글씨가 예쁘게 중앙정렬 된 모습을 확인 할 수 있어요. 
- lineHeightMultiple만 하면 글씨가 Label 영역의 아래쪽에 붙어있게 되구요, 
- LineSpacing만 주는 경우는 두 줄 간의 간격만 설정하는 거라 한줄일 때 Label 영역이 피그마와 다르게 글씨에 딱 붙어서 잡히고, 위아래 여백이 없더라구요..


![Screenshot 2024-06-09 at 19 05 36](https://github.com/Team-WSS/WSS-iOS/assets/87518742/6dfdac0f-838a-4133-b5dc-b4a4c5594c44)

<br/>

### 🌟To Reviewer
- 아주 간단한 변경사항입니다!! 
<br/>
