### PR TITLE
[Fix] #244 - 일반탐색 내 데이터 중복 호출 및 중복 추가되는 오루 수정

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -84,6 +84,7 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
     private func bindViewModel() {
         let reachedBottom = rootView.resultView.scrollView.rx.didScroll
             .map { self.isNearBottomEdge() }
+            .distinctUntilChanged()
             .filter { $0 }
             .map { _ in () }
             .asObservable()

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -112,11 +112,7 @@ final class NormalSearchViewModel: ViewModelType {
                         self.currentPage.accept(nextPage)
                     })
             }
-            .subscribe(with: self, onNext: { owner, data in
-                let updatedList = owner.normalSearchList.value + data.novels
-                owner.normalSearchList.accept(updatedList)
-                owner.isLoadable.accept(data.isLoadable)
-            })
+            .subscribe()
             .disposed(by: disposeBag)
         
         input.normalSearchCellSelected


### PR DESCRIPTION
### ⭐️Issue
close #244 
<br/>

### 🌟Motivation
- 일반탐색에서 스크롤이 바닥에 닿았을 때 스크롤 감지를 여러번 하여 중복된 이벤트를 방출하는 이슈 해결했습니다.
- 데이터에 추가하는 코드가 중복 호출되어 같은 데이터가 2번씩 추가된 이슈 해결했습니다. 
<br/>

### 🌟Key Changes

<br/>

### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
