### PR TITLE
[Network] #227 - 1차 QA를 위한 로그인 분기처리

### DIFF
--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -14,12 +14,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        self.window = UIWindow(windowScene: windowScene)
+        
+       setRootToLoginViewController()
+        
+        self.window?.makeKeyAndVisible()
+    }
+    
+    func setRootToWSSTabBarController() {
+        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
+        navigationController.isNavigationBarHidden = true
+        window?.rootViewController = navigationController
+    }
+
+    func setRootToLoginViewController() {
         let navigationController = UINavigationController(rootViewController: ModuleFactory.shared.makeLoginViewController())
         navigationController.isNavigationBarHidden = true
-        
-        self.window = UIWindow(windowScene: windowScene)
-        self.window?.rootViewController = navigationController
-        self.window?.makeKeyAndVisible()
+        window?.rootViewController = navigationController
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/WSSiOS/WSSiOS/Network/Foundation/APIConstants.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/APIConstants.swift
@@ -16,7 +16,10 @@ struct APIConstants {
     static let fcm = "FcmToken"
     
     static let boundary = "Boundary-\(UUID().uuidString)"
-    static let testToken = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? ""
+    static var isLogined: Bool = false
+    static var testToken: String {
+        isLogined ? (Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? "") : ""
+    }
 }
 
 extension APIConstants {

--- a/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewController/LoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewController/LoginViewController.swift
@@ -102,6 +102,7 @@ final class LoginViewController: UIViewController {
             .bind(with: self, onNext: { owner, _ in
                 // 온보딩 뷰로 이동
                 print("온보딩 뷰로 이동")
+                print("Token: \(APIConstants.testToken)")
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewController/LoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewController/LoginViewController.swift
@@ -101,8 +101,8 @@ final class LoginViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 // 온보딩 뷰로 이동
-                print("온보딩 뷰로 이동")
                 print("Token: \(APIConstants.testToken)")
+                owner.loginCompleted()
             })
             .disposed(by: disposeBag)
     }
@@ -137,6 +137,13 @@ final class LoginViewController: UIViewController {
     private func setCarouselViewInitialState() {
         rootView.carouselView.bannerCollectionView.setContentOffset(CGPoint(x: LoginBannerMetric.width, y: 0), animated: false)
         viewModel.resumeAutoScroll()
+    }
+    
+    private func loginCompleted() {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
+            return
+        }
+        sceneDelegate.setRootToWSSTabBarController()
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewModel/LoginViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewModel/LoginViewModel.swift
@@ -110,6 +110,11 @@ final class LoginViewModel: ViewModelType {
     func repositoryLoginMethod(type: LoginButtonType) -> Observable<Void> {
         // 레포지토리에 구현할 각 로그인 메서드. 아마 ..?
         print("\(String(describing: type)) Login 성공")
+        if type == .skip {
+            APIConstants.isLogined = false
+        } else {
+            APIConstants.isLogined = true
+        }
         return Observable.just(())
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewModel/LoginViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Onboarding/Login/LoginViewModel/LoginViewModel.swift
@@ -107,7 +107,7 @@ final class LoginViewModel: ViewModelType {
             })
     }
     
-    func repositoryLoginMethod(type: LoginButtonType) -> Observable<Void> {
+    private func repositoryLoginMethod(type: LoginButtonType) -> Observable<Void> {
         // 레포지토리에 구현할 각 로그인 메서드. 아마 ..?
         print("\(String(describing: type)) Login 성공")
         if type == .skip {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
close #
<br/>

### 🌟Motivation
1차 QA만을 위한 로그인 분기처리입니다.
<br/>

### 🌟Key Changes
- APIConstants에서 원래 config에 있던 토큰 값을 가져왔으므로, 여기에 로그인 여부 타입변수를 추가하고, 로그인 변수 값에 따라 토큰 값을 다르게 내려주도록 했습니다.

```swift
struct APIConstants {
...
    static var isLogined: Bool = false
    static var testToken: String {
        isLogined ? (Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? "") : ""
    }
}
```
- 둘러보기를 하면 로그인을 생략한 것이므로, 토큰값이 ""이 되도록 했습니다.

```swift
final class LoginViewModel: ViewModelType {
...
    input.loginButtonDidTap
            .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
            .flatMapLatest { type in
                self.repositoryLoginMethod(type: type)
            }
            .subscribe(with: self, onNext: { owner, _ in
                // Login 작업 종료 후
                print("Login 성공 및 종료")
                owner.loginSuccess.accept(())
            })
            .disposed(by: disposeBag)
...
    private func repositoryLoginMethod(type: LoginButtonType) -> Observable<Void> {
        // 레포지토리에 구현할 각 로그인 메서드. 아마 ..?
        print("\(String(describing: type)) Login 성공")
        if type == .skip {
            APIConstants.isLogined = false
        } else {
            APIConstants.isLogined = true
        }
        return Observable.just(())
    }
}
```


- 온보딩 뷰가 아직 작업중이므로, 일단 로그인 화면에서 바로 홈 화면으로 이동하도록 했습니다.
```swift
final class LoginViewController: UIViewController {
...
        output.navigateToOnboarding
            .observe(on: MainScheduler.instance)
            .bind(with: self, onNext: { owner, _ in
                // 온보딩 뷰로 이동
                print("Token: \(APIConstants.testToken)")
                owner.loginCompleted()
            })
            .disposed(by: disposeBag)
...

    private func loginCompleted() {
        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
            return
        }
        sceneDelegate.setRootToWSSTabBarController()
    }
}
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-09-27 at 17 00 16](https://github.com/user-attachments/assets/b9aea67f-99fc-4697-b22f-54d0d0d0bbce)

<br/>

### 🌟To Reviewer
- 1차 QA를 위해서 임시로 로그인 구현을 해두었습니다. 정말 로그인을 한다면 이렇게 하는게 아니겠지요 .,., 일단 임시로 잘 돌아가는지만 확인해주세요!
<br/>

### 🌟Reference

<br/>
