### PR TITLE
[Fix] #227 - NovelDetail UI 수정 (본문에 보이는 변경사항이 다임)

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailHeaderView/NovelDetailHeaderAssistantView/NovelDetailHeaderReviewResultView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailHeaderView/NovelDetailHeaderAssistantView/NovelDetailHeaderReviewResultView.swift
@@ -126,10 +126,13 @@ final class NovelDetailHeaderReviewResultView: UIView {
         if !isUserNovelRatingExist && !isReadDateExist {
             readInfoButtonStackView.isHidden = true
         } else if !isUserNovelRatingExist {
+            readInfoButtonStackView.isHidden = false
             readInfoButtons[0].isHidden = true
+            readInfoButtons[1].isHidden = false
         } else if !isReadDateExist {
+            readInfoButtonStackView.isHidden = false
+            readInfoButtons[0].isHidden = false
             readInfoButtons[1].isHidden = true
         }
     }
-    
 }


### PR DESCRIPTION


<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
close #
<br/>

### 🌟Motivation
-  NovelDetail UI 수정이 있습니다.
<br/>

### 🌟Key Changes
- 효원이 코드리뷰를 하다가 발견했는데, 작품 평가뷰에 들어갔다가 다시 작품 상세로 돌아오는 경우 별점이나 날짜 정보를 나타내는 뷰가 나타나지 않아 문제가 있었습니다.
- hidden처리를 다시 풀어주지 않았기 때문으로, 아래와 같이 해결했습니다.
원래 코드
```swift
    func bindVisibility(_ isUserNovelRatingExist: Bool, _ isReadDateExist: Bool) {
        if !isUserNovelRatingExist && !isReadDateExist {
            readInfoButtonStackView.isHidden = true
        } else if !isUserNovelRatingExist {
            readInfoButtons[0].isHidden = true
        } else if !isReadDateExist {
            readInfoButtons[1].isHidden = true
        }
    }
```
바꾼 코드
```swift
    func bindVisibility(_ isUserNovelRatingExist: Bool, _ isReadDateExist: Bool) {
        if !isUserNovelRatingExist && !isReadDateExist {
            readInfoButtonStackView.isHidden = true
        } else if !isUserNovelRatingExist {
            readInfoButtonStackView.isHidden = false
            readInfoButtons[0].isHidden = true
            readInfoButtons[1].isHidden = false
        } else if !isReadDateExist {
            readInfoButtonStackView.isHidden = false
            readInfoButtons[0].isHidden = false
            readInfoButtons[1].isHidden = true
        }
    }
```
<br/>


### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
