### PR TITLE
[Fix] #297 - NormalSearch UI 수정 및 Cell 클릭 시 작품상세뷰로 이동

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchHeaderView.swift
@@ -87,7 +87,7 @@ final class NormalSearchHeaderView: UIView {
             $0.leading.equalTo(backButton.snp.trailing).offset(6)
             $0.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(42)
-            $0.bottom.equalToSuperview().inset(11)
+            $0.bottom.equalToSuperview().inset(12)
         }
         
         searchClearButton.snp.makeConstraints {

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchHeaderView.swift
@@ -15,7 +15,6 @@ final class NormalSearchHeaderView: UIView {
     //MARK: - Components
     
     let backButton = UIButton()
-    private let searchBackgroundView = UIView()
     let searchTextField = UITextField()
     let searchClearButton = UIButton()
     let searchButton = UIButton()
@@ -42,19 +41,21 @@ final class NormalSearchHeaderView: UIView {
             $0.setImage(.icNavigateLeft.withTintColor(.wssBlack), for: .normal)
         }
         
-        searchBackgroundView.do {
-            $0.backgroundColor = .wssWhite
+        searchTextField.do {
+            $0.returnKeyType = .done
+            $0.autocorrectionType = .no
+            $0.spellCheckingType = .no
+            $0.tintColor = .wssBlack
+            $0.backgroundColor = .wssGray50
+            $0.textColor = .wssBlack
+            $0.placeholder = StringLiterals.NovelReview.KeywordSearch.placeholder
+            $0.font = .Body4
             $0.layer.cornerRadius = 14
             $0.layer.borderColor = UIColor.wssGray70.cgColor
-            $0.layer.borderWidth = 1
-        }
-        
-        searchTextField.do {
-            $0.textColor = .wssBlack
-            $0.font = .Label1
-            $0.rightView = searchClearButton
-            $0.rightViewMode = .whileEditing
-            $0.tintColor = .wssBlack
+            $0.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 16.0, height: 0.0))
+            $0.rightView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 82.0, height: 0.0))
+            $0.leftViewMode = .always
+            $0.rightViewMode = .always
         }
         
         searchClearButton.do {
@@ -68,37 +69,46 @@ final class NormalSearchHeaderView: UIView {
     }
     
     private func setHierarchy() {
-        searchBackgroundView.addSubviews(searchTextField,
-                                         searchButton)
         self.addSubviews(backButton,
-                         searchBackgroundView)
+                         searchTextField,
+                         searchClearButton,
+                         searchButton)
     }
     
     private func setLayout() {
         backButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(10)
-            $0.leading.equalToSuperview().inset(16)
-            $0.size.equalTo(24)
+            $0.leading.equalToSuperview().inset(6)
+            $0.size.equalTo(44)
         }
         
         searchTextField.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(16)
-        }
-        
-        searchButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalTo(searchTextField.snp.trailing).offset(15)
-            $0.trailing.equalToSuperview().inset(15)
-            $0.size.equalTo(25)
-        }
-        
-        searchBackgroundView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(2)
-            $0.leading.equalTo(backButton.snp.trailing).offset(16)
+            $0.top.equalTo(backButton.snp.top)
+            $0.leading.equalTo(backButton.snp.trailing).offset(6)
             $0.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(42)
             $0.bottom.equalToSuperview().inset(11)
+        }
+        
+        searchClearButton.snp.makeConstraints {
+            $0.trailing.equalTo(searchButton.snp.leading)
+            $0.centerY.equalTo(searchTextField.snp.centerY)
+            $0.size.equalTo(36)
+        }
+        
+        searchButton.snp.makeConstraints {
+            $0.trailing.equalTo(searchTextField.snp.trailing).offset(-10)
+            $0.centerY.equalTo(searchTextField.snp.centerY)
+            $0.size.equalTo(36)
+        }
+    }
+    
+    // MARK: - Custom Method
+    
+    func updateSearchTextField(isEditing: Bool) {
+        searchTextField.do {
+            $0.backgroundColor = isEditing ? .wssWhite : .wssGray50
+            $0.layer.borderWidth = isEditing ? 1 : 0
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -95,6 +95,8 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
         
         let input = NormalSearchViewModel.Input(
             searchTextUpdated: rootView.headerView.searchTextField.rx.text.orEmpty,
+            searchTextFieldEditingDidBegin: rootView.headerView.searchTextField.rx.controlEvent(.editingDidBegin).asControlEvent(),
+            searchTextFieldEditingDidEnd: rootView.headerView.searchTextField.rx.controlEvent(.editingDidEnd).asControlEvent(),
             returnKeyDidTap: rootView.headerView.searchTextField.rx.controlEvent(.editingDidEndOnExit),
             searchButtonDidTap: rootView.headerView.searchButton.rx.tap,
             clearButtonDidTap: rootView.headerView.searchClearButton.rx.tap,
@@ -162,7 +164,7 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
             })
             .disposed(by: disposeBag)
         
-        output.backButtonEnabled
+        output.popViewController
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .subscribe(with: self, onNext: { owner, _ in
                 owner.popToLastViewController()
@@ -189,10 +191,15 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
             })
             .disposed(by: disposeBag)
         
+        output.isSearchTextFieldEditing
+            .subscribe(with: self, onNext: { owner, isEditing in
+                owner.rootView.headerView.updateSearchTextField(isEditing: isEditing)
+            })
+            .disposed(by: disposeBag)
+        
         output.endEditing
             .subscribe(with: self, onNext: { owner, _ in
                 owner.view.endEditing(true)
-                owner.rootView.headerView.updateSearchTextField(isEditing: true)
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -183,16 +183,16 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
             })
             .disposed(by: disposeBag)
         
-        output.normalSearchCellEnabled
-            .subscribe(with: self, onNext: { owner, indexPath in
-                //TODO: API 연결 후 수정 예정
-                owner.pushToDetailViewController(novelId: 0)
+        output.pushToNovelDetailViewController
+            .subscribe(with: self, onNext: { owner, novelId in
+                owner.pushToDetailViewController(novelId: novelId)
             })
             .disposed(by: disposeBag)
         
         output.endEditing
             .subscribe(with: self, onNext: { owner, _ in
                 owner.view.endEditing(true)
+                owner.rootView.headerView.updateSearchTextField(isEditing: true)
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -22,7 +22,8 @@ final class NormalSearchViewModel: ViewModelType {
     private let isLoadable = BehaviorRelay<Bool>(value: false)
     private let resultCount = PublishSubject<Int>()
     private let normalSearchList = BehaviorRelay<[NormalSearchNovel]>(value: [])
-    private let normalSearchCellIndexPath = PublishRelay<IndexPath>()
+
+    private let pushToNovelDetailViewController = PublishRelay<Int>()
     
     //MARK: - Inputs
     
@@ -50,7 +51,7 @@ final class NormalSearchViewModel: ViewModelType {
         let backButtonEnabled: Observable<Void>
         let inquiryButtonEnabled: Observable<Void>
         let normalSearchCollectionViewHeight: Driver<CGFloat>
-        let normalSearchCellEnabled: Observable<IndexPath>
+        let pushToNovelDetailViewController: Observable<Int>
         let endEditing: Observable<Void>
     }
     
@@ -117,7 +118,8 @@ final class NormalSearchViewModel: ViewModelType {
         
         input.normalSearchCellSelected
             .subscribe(with: self, onNext: { owner, indexPath in
-                owner.normalSearchCellIndexPath.accept(indexPath)
+                let novelId = owner.normalSearchList.value[indexPath.row].novelId
+                owner.pushToNovelDetailViewController.accept(novelId)
             })
             .disposed(by: disposeBag)
         
@@ -141,7 +143,7 @@ final class NormalSearchViewModel: ViewModelType {
                       backButtonEnabled: backButtonEnabled.asObservable(),
                       inquiryButtonEnabled: inquiryButtonEnabled.asObservable(),
                       normalSearchCollectionViewHeight: normalSearchCollectionViewHeight,
-                      normalSearchCellEnabled: normalSearchCellIndexPath.asObservable(),
+                      pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
                       endEditing: endEditing)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -25,7 +25,6 @@ final class NormalSearchViewModel: ViewModelType {
 
     private let pushToNovelDetailViewController = PublishRelay<Int>()
     private let isSearchTextFieldEditing = BehaviorRelay<Bool>(value: false)
-    private let showEmptyView = PublishRelay<Bool>()
     
     //MARK: - Inputs
     
@@ -110,7 +109,6 @@ final class NormalSearchViewModel: ViewModelType {
         input.searchTextFieldEditingDidBegin
             .subscribe(with: self, onNext: { owner, _ in
                 owner.isSearchTextFieldEditing.accept(true)
-                owner.showEmptyView.accept(false)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -24,11 +24,15 @@ final class NormalSearchViewModel: ViewModelType {
     private let normalSearchList = BehaviorRelay<[NormalSearchNovel]>(value: [])
 
     private let pushToNovelDetailViewController = PublishRelay<Int>()
+    private let isSearchTextFieldEditing = BehaviorRelay<Bool>(value: false)
+    private let showEmptyView = PublishRelay<Bool>()
     
     //MARK: - Inputs
     
     struct Input {
         let searchTextUpdated: ControlProperty<String>
+        let searchTextFieldEditingDidBegin: ControlEvent<Void>
+        let searchTextFieldEditingDidEnd: ControlEvent<Void>
         let returnKeyDidTap: ControlEvent<Void>
         let searchButtonDidTap: ControlEvent<Void>
         let clearButtonDidTap: ControlEvent<Void>
@@ -48,10 +52,11 @@ final class NormalSearchViewModel: ViewModelType {
         let scrollToTop: Observable<Void>
         let scrollToTopAndendEditing: Observable<Void>
         let clearButtonEnabled: Observable<Void>
-        let backButtonEnabled: Observable<Void>
+        let popViewController: Observable<Void>
         let inquiryButtonEnabled: Observable<Void>
         let normalSearchCollectionViewHeight: Driver<CGFloat>
         let pushToNovelDetailViewController: Observable<Int>
+        let isSearchTextFieldEditing: Observable<Bool>
         let endEditing: Observable<Void>
     }
     
@@ -102,6 +107,19 @@ final class NormalSearchViewModel: ViewModelType {
             .subscribe()
             .disposed(by: disposeBag)
         
+        input.searchTextFieldEditingDidBegin
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.isSearchTextFieldEditing.accept(true)
+                owner.showEmptyView.accept(false)
+            })
+            .disposed(by: disposeBag)
+        
+        input.searchTextFieldEditingDidEnd
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.isSearchTextFieldEditing.accept(false)
+            })
+            .disposed(by: disposeBag)
+        
         input.reachedBottom
             .withLatestFrom(isLoadable)
             .filter { $0 }
@@ -126,7 +144,7 @@ final class NormalSearchViewModel: ViewModelType {
         let returnKeyEnabled = input.returnKeyDidTap.asObservable()
         let searchButtonEnabled = input.searchButtonDidTap.asObservable()
         let clearButtonEnabled = input.clearButtonDidTap.asObservable()
-        let backButtonEnabled = input.backButtonDidTap.asObservable()
+        let popViewController = input.backButtonDidTap.asObservable()
         let inquiryButtonEnabled = input.inquiryButtonDidTap.asObservable()
         
         let normalSearchCollectionViewHeight = input.normalSearchCollectionViewContentSize
@@ -140,10 +158,11 @@ final class NormalSearchViewModel: ViewModelType {
                       scrollToTop: returnKeyEnabled.asObservable(),
                       scrollToTopAndendEditing: searchButtonEnabled.asObservable(),
                       clearButtonEnabled: clearButtonEnabled.asObservable(),
-                      backButtonEnabled: backButtonEnabled.asObservable(),
+                      popViewController: popViewController.asObservable(),
                       inquiryButtonEnabled: inquiryButtonEnabled.asObservable(),
                       normalSearchCollectionViewHeight: normalSearchCollectionViewHeight,
                       pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
+                      isSearchTextFieldEditing: isSearchTextFieldEditing.asObservable(),
                       endEditing: endEditing)
     }
 }


### PR DESCRIPTION
### ⭐️Issue
close #297 
<br/>

### 🌟Motivation
- NormalSearch 내 TextField UI 수정했습니다.
- Cell 클릭 시 해당 Cell에 대한 작품상세뷰로 이동하도록 반영했습니다. 
<br/>

### 🌟Key Changes
#### editing 여부에 따른 textField UI 변경
기존엔 editing 에 따른 UI 변화가 없었습니다. 
효원이가 구현해 둔 textField UI 및 update함수 반영했습니다 👍
<br/>


### 🌟Simulation

https://github.com/user-attachments/assets/8124eb3b-142b-40a2-9b91-0298724c0068


<br/>

### 🌟To Reviewer
- 없습니다
<br/>

### 🌟Reference
- 없습니다
<br/>
