### PR TITLE
[Feat] #319 - 비로그인시 홈뷰 내 유저 접근 제한 기능 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		B92A06652C495AFF00E27652 /* DetailSearchInfoGenreCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92A06642C495AFF00E27652 /* DetailSearchInfoGenreCollectionViewCell.swift */; };
 		B92A06672C49858800E27652 /* DetailSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92A06662C49858800E27652 /* DetailSearchHeaderView.swift */; };
 		B92A06692C49877700E27652 /* DetailSearchBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92A06682C49877700E27652 /* DetailSearchBottomView.swift */; };
+		B92D8AB72CE0591D005B35F7 /* InduceLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92D8AB62CE0591D005B35F7 /* InduceLoginViewController.swift */; };
 		B933BED32C4916DC00365077 /* KeywordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = B933BED22C4916DC00365077 /* KeywordBox.swift */; };
 		B948BDB92CCD8DD500A7C771 /* DetailSearchResultEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B948BDB82CCD8DD500A7C771 /* DetailSearchResultEmptyView.swift */; };
 		B96098802C27201B0084F697 /* NormalSearchResultCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B960987F2C27201B0084F697 /* NormalSearchResultCountView.swift */; };
@@ -320,7 +321,7 @@
 		B9E566032C0452C600DB51FF /* NormalSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E566022C0452C600DB51FF /* NormalSearchHeaderView.swift */; };
 		B9E566052C0452E500DB51FF /* NormalSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E566042C0452E500DB51FF /* NormalSearchResultView.swift */; };
 		B9F7401D2C047E360018D0C6 /* NormalSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F7401C2C047E360018D0C6 /* NormalSearchViewModel.swift */; };
-		B9FE59642BF11955005815AF /* HomeInduceLoginModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FE59632BF11955005815AF /* HomeInduceLoginModalView.swift */; };
+		B9FE59642BF11955005815AF /* InduceLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FE59632BF11955005815AF /* InduceLoginView.swift */; };
 		C9063A972BD3F868006AD8F9 /* HomeRealtimePopularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9063A962BD3F868006AD8F9 /* HomeRealtimePopularView.swift */; };
 		C95EADD92BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95EADD82BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift */; };
 		C96A0E1F2C9F2B9900A6EA87 /* FeedDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96A0E1E2C9F2B9000A6EA87 /* FeedDetailService.swift */; };
@@ -710,6 +711,7 @@
 		B92A06642C495AFF00E27652 /* DetailSearchInfoGenreCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchInfoGenreCollectionViewCell.swift; sourceTree = "<group>"; };
 		B92A06662C49858800E27652 /* DetailSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchHeaderView.swift; sourceTree = "<group>"; };
 		B92A06682C49877700E27652 /* DetailSearchBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchBottomView.swift; sourceTree = "<group>"; };
+		B92D8AB62CE0591D005B35F7 /* InduceLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InduceLoginViewController.swift; sourceTree = "<group>"; };
 		B933BED22C4916DC00365077 /* KeywordBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordBox.swift; sourceTree = "<group>"; };
 		B948BDB82CCD8DD500A7C771 /* DetailSearchResultEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchResultEmptyView.swift; sourceTree = "<group>"; };
 		B960987F2C27201B0084F697 /* NormalSearchResultCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchResultCountView.swift; sourceTree = "<group>"; };
@@ -752,7 +754,7 @@
 		B9E566022C0452C600DB51FF /* NormalSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchHeaderView.swift; sourceTree = "<group>"; };
 		B9E566042C0452E500DB51FF /* NormalSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchResultView.swift; sourceTree = "<group>"; };
 		B9F7401C2C047E360018D0C6 /* NormalSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchViewModel.swift; sourceTree = "<group>"; };
-		B9FE59632BF11955005815AF /* HomeInduceLoginModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInduceLoginModalView.swift; sourceTree = "<group>"; };
+		B9FE59632BF11955005815AF /* InduceLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InduceLoginView.swift; sourceTree = "<group>"; };
 		C9063A962BD3F868006AD8F9 /* HomeRealtimePopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRealtimePopularView.swift; sourceTree = "<group>"; };
 		C95EADD82BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRealTimePopularFeedView.swift; sourceTree = "<group>"; };
 		C96A0E1E2C9F2B9000A6EA87 /* FeedDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailService.swift; sourceTree = "<group>"; };
@@ -944,6 +946,7 @@
 		2C2491822B4ADC1D0096F255 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				B92D8AB82CE05924005B35F7 /* InduceLogin */,
 				39099EEF2CD8894F00FCA8DE /* NetworkView */,
 				391013782CCF5C33001894E5 /* BirthPicker */,
 				2CD2FE3C2C43BEF40033366C /* AlertButton */,
@@ -1883,7 +1886,6 @@
 				39B75ACF2B59891C005DD8B9 /* sosocatTail.json */,
 				39B75AD32B59891D005DD8B9 /* villainessFan.json */,
 				39B75AD22B59891D005DD8B9 /* villainessTea.json */,
-				39AD55B22CAFDF6500CBDA7A /* scroll.json */,
 				39099EF22CD88A1200FCA8DE /* loading.json */,
 			);
 			path = Lottie;
@@ -2081,7 +2083,6 @@
 				B9B0CBD52BE29EA0002F4CF6 /* HomeInterestView.swift */,
 				B9181BDB2BEBDFA80024C800 /* HomeTasteRecommendView.swift */,
 				B9CEDA0C2C01C97E00E62247 /* HomeUnregisterView.swift */,
-				B9FE59632BF11955005815AF /* HomeInduceLoginModalView.swift */,
 			);
 			path = HomeAssistantView;
 			sourceTree = "<group>";
@@ -2204,6 +2205,15 @@
 				B92A06642C495AFF00E27652 /* DetailSearchInfoGenreCollectionViewCell.swift */,
 			);
 			path = DetailSearchCell;
+			sourceTree = "<group>";
+		};
+		B92D8AB82CE05924005B35F7 /* InduceLogin */ = {
+			isa = PBXGroup;
+			children = (
+				B9FE59632BF11955005815AF /* InduceLoginView.swift */,
+				B92D8AB62CE0591D005B35F7 /* InduceLoginViewController.swift */,
+			);
+			path = InduceLogin;
 			sourceTree = "<group>";
 		};
 		B96098832C2741DE0084F697 /* FeedDetail */ = {
@@ -3258,7 +3268,7 @@
 				39F850762C319BE500E93EBC /* NovelDetailInfoReviewEmptyView.swift in Sources */,
 				2CFE04332B66A45A0048F77A /* UICollectionViewCell+.swift in Sources */,
 				2C81DF8B2CA15F6F00148F97 /* MyPageChangeUserBirthTableViewCell.swift in Sources */,
-				B9FE59642BF11955005815AF /* HomeInduceLoginModalView.swift in Sources */,
+				B9FE59642BF11955005815AF /* InduceLoginView.swift in Sources */,
 				2CB613F32B575E4500FC3F89 /* MyPageInfoViewController.swift in Sources */,
 				393CAC3C2CA6AFD8004B4DB6 /* OnboardingBottomButtonView.swift in Sources */,
 				2C9CBDB12C5BB4340084481F /* BlocksService.swift in Sources */,
@@ -3386,6 +3396,7 @@
 				CD2D0AAD2C7EF1A2007CF1F1 /* NovelReviewViewController.swift in Sources */,
 				A1654F1A2B54052E004F78E8 /* Config.swift in Sources */,
 				CD863EEB2CA5CECD0037DC08 /* NovelDetailFeedReactView.swift in Sources */,
+				B92D8AB72CE0591D005B35F7 /* InduceLoginViewController.swift in Sources */,
 				CDEFE8272C9708870002D987 /* FeedNovelConnectModalViewModel.swift in Sources */,
 				2CD911582C0D8A21006B8D72 /* FeedPageBar.swift in Sources */,
 				CD39F2D82B50DA6300B73A5C /* TrashNovelDetailInfoDescriptionView.swift in Sources */,

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -22,8 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func setRootToWSSTabBarController() {
-        let isLoggedIn = APIConstants.isLogined
-        let navigationController = UINavigationController(rootViewController: WSSTabBarController(isLoggedIn: isLoggedIn))
+        let navigationController = UINavigationController(rootViewController: WSSTabBarController())
         navigationController.isNavigationBarHidden = true
         guard let window else { return }
         UIView.transition(with: window,

--- a/WSSiOS/WSSiOS/Info.plist
+++ b/WSSiOS/WSSiOS/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>TEST_TOKEN</key>
-	<string>$(TEST_TOKEN)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>BUCKET_URL</key>
@@ -13,6 +11,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>TEST_TOKEN</key>
+	<string>$(TEST_TOKEN)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -81,7 +81,7 @@ extension UIViewController {
     
     func moveToNovelDetailViewController(userNovelId: Int) {
         if self.navigationController?.tabBarController?.selectedIndex == 0 {
-            let tabBar = WSSTabBarController(isLoggedIn: true)
+            let tabBar = WSSTabBarController()
             tabBar.selectedIndex = 1
             let navigationController = UINavigationController(rootViewController: tabBar)
             navigationController.setNavigationBarHidden(true, animated: true)
@@ -374,6 +374,12 @@ extension UIViewController {
                 previousViewInfo: previousViewInfo,
                 selectedFilteredQuery: selectedFilteredQuery))
         self.presentModalViewController(detailSearchViewController)
+    }
+    
+    func pushToInduceLoginViewController() {
+        let viewController = InduceLoginViewController()
+        
+        self.navigationController?.pushViewController(viewController, animated: false)
     }
 }
 

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -168,6 +168,10 @@ extension UIViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
+    func popToLastViewControllerWithoutAnimation() {
+        self.navigationController?.popViewController(animated: false)
+    }
+    
     func popToRootViewController() {
         self.navigationController?.popToRootViewController(animated: true)
     }

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -168,10 +168,6 @@ extension UIViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
-    func popToLastViewControllerWithoutAnimation() {
-        self.navigationController?.popViewController(animated: false)
-    }
-    
     func popToRootViewController() {
         self.navigationController?.popToRootViewController(animated: true)
     }

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -380,10 +380,15 @@ extension UIViewController {
         self.presentModalViewController(detailSearchViewController)
     }
     
-    func pushToInduceLoginViewController() {
+    func presentInduceLoginViewController() {
         let viewController = InduceLoginViewController()
+        viewController.modalPresentationStyle = .overFullScreen
         
-        self.navigationController?.pushViewController(viewController, animated: false)
+        self.present(viewController, animated: false)
+    }
+    
+    func dismissViewController() {
+        self.dismiss(animated: false)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Data/Repository/RecommendRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/RecommendRepository.swift
@@ -12,7 +12,7 @@ import RxSwift
 protocol RecommendRepository {
     func getTodayPopularNovels() -> Observable<TodayPopularNovels>
     func getRealtimePopularFeeds() -> Observable<RealtimePopularFeeds>
-    func getInterestNovels() -> Observable<InterestFeeds>
+    func getInterestFeeds() -> Observable<InterestFeeds>
     func getTasteRecommendNovels() -> Observable<TasteRecommendNovels>
 }
 
@@ -32,7 +32,7 @@ struct DefaultRecommendRepository: RecommendRepository {
         return recommendService.getRealtimePopularFeeds().asObservable()
     }
     
-    func getInterestNovels() -> Observable<InterestFeeds> {
+    func getInterestFeeds() -> Observable<InterestFeeds> {
         return recommendService.getInterestFeeds().asObservable()
     }
     
@@ -96,7 +96,7 @@ struct TestRecommendRepository: RecommendRepository {
             RealtimePopularFeed(feedId: 1, feedContent: "주인공이 당연히 엘로디인 줄 알았는데.... 표지에 두명이 나온 이유가 있구나..... 당연히 주인공이 하나일거라고 생각하면 안 되는 거구나..ㅠㅠㅠ 신데렐라와 멧밭쥐 두 주인공의 넘 아름다운 이야기야 따흑 근데 세라 친어머니 죽고 재혼한 건데 계보에도 안 올릴 수가 있나... 외가가 망해 없어지기라도 했나?", feedLikeCount: 123, feedCommentCount: 234, isSpoiler: false)]))
     }
     
-    func getInterestNovels() -> Observable<InterestFeeds> {
+    func getInterestFeeds() -> Observable<InterestFeeds> {
         return Observable.just(InterestFeeds(recommendFeeds: [
             InterestFeed(novelId: 1, novelTitle: "신데렐라는 이 멧밭쥐가 데려갑니다", novelImage: "https://i.pinimg.com/736x/53/95/06/539506e93756577d5068c9dfca600be5.jpg", novelRating: 4.21, novelRatingCount: 1003, userNickname: "구리스", userAvatarImage: "https://i.pinimg.com/474x/b3/17/f3/b317f39796d1974de83f01f4ffeb32c3.jpg", userFeedContent: "주인공이 당연히 엘로디인 줄 알았는데.... 표지에 두명이 나온 이유가 있구나..... 당연히 주인공이 하나일거라고 생각하면 안 되는 거구나..ㅠㅠㅠ 신데렐라와 멧밭쥐 두 주인공의 넘 아름다운 이야기야 따흑 근데 세라 친어머니 죽고 재혼한 건데 계보에도 안 올릴 수가 있나... 외가가 망해 없어지기라도 했나?"),
             InterestFeed(novelId: 1, novelTitle: "신데렐라는 이 멧밭쥐가 데려갑니다", novelImage: "https://i.pinimg.com/736x/53/95/06/539506e93756577d5068c9dfca600be5.jpg", novelRating: 4.21, novelRatingCount: 1003, userNickname: "구리스", userAvatarImage: "https://i.pinimg.com/474x/b3/17/f3/b317f39796d1974de83f01f4ffeb32c3.jpg", userFeedContent: "주인공이 당연히 엘로디인 줄 알았는데.... 표지에 두명이 나온 이유가 있구나..... 당연히 주인공이 하나일거라고 생각하면 안 되는 거구나..ㅠㅠㅠ 신데렐라와 멧밭쥐 두 주인공의 넘 아름다운 이야기야 따흑 근데 세라 친어머니 죽고 재혼한 건데 계보에도 안 올릴 수가 있나... 외가가 망해 없어지기라도 했나?"),

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
@@ -1,5 +1,5 @@
 //
-//  HomeInduceLoginModalView.swift
+//  InduceLoginView.swift
 //  WSSiOS
 //
 //  Created by Seoyeon Choi on 5/13/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HomeInduceLoginModalView: UIView {
+final class InduceLoginView: UIView {
     
     //MARK: - UI Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
@@ -44,8 +44,6 @@ final class InduceLoginView: UIView {
     }
     
     private func setUI() {
-        self.isOpaque = false
-        
         backgroundView.do {
             $0.backgroundColor = .wssBlack60
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginView.swift
@@ -44,6 +44,8 @@ final class InduceLoginView: UIView {
     }
     
     private func setUI() {
+        self.isOpaque = false
+        
         backgroundView.do {
             $0.backgroundColor = .wssBlack60
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
@@ -57,7 +57,7 @@ final class InduceLoginViewController: UIViewController {
         
         rootView.cancelButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
-                owner.popToLastViewControllerWithoutAnimation()
+                owner.dismissViewController()
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
@@ -7,10 +7,14 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
+
 final class InduceLoginViewController: UIViewController {
     
     //MARK: - Properties
     
+    private let disposeBag = DisposeBag()
     
     //MARK: - UI Components
     
@@ -33,12 +37,28 @@ final class InduceLoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setAction()
+        
     }
     
     private func setUI() {
-        self.view.backgroundColor = .wssWhite
+        
     }
     
-    //MARK: - Bind
-    
+    private func setAction() {
+        rootView.loginButton.rx.tap
+            .bind(with: self, onNext: { owner, _ in
+                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
+                    return
+                }
+                sceneDelegate.setRootToLoginViewController()
+            })
+            .disposed(by: disposeBag)
+        
+        rootView.cancelButton.rx.tap
+            .bind(with: self, onNext: { owner, _ in
+                owner.popToLastViewControllerWithoutAnimation()
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
@@ -1,0 +1,44 @@
+//
+//  InduceLoginViewController.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 11/10/24.
+//
+
+import UIKit
+
+final class InduceLoginViewController: UIViewController {
+    
+    //MARK: - Properties
+    
+    
+    //MARK: - UI Components
+    
+    private let rootView = InduceLoginView()
+    
+    //MARK: - Life Cycle
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    private func setUI() {
+        self.view.backgroundColor = .wssWhite
+    }
+    
+    //MARK: - Bind
+    
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/InduceLogin/InduceLoginViewController.swift
@@ -38,12 +38,9 @@ final class InduceLoginViewController: UIViewController {
         super.viewDidLoad()
         
         setAction()
-        
     }
     
-    private func setUI() {
-        
-    }
+    //MARK: - Custom Methods
     
     private func setAction() {
         rootView.loginButton.rx.tap

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
@@ -10,11 +10,8 @@ import UIKit
 import Then
 
 final class WSSTabBarController: UITabBarController {
-    
-    private let isLoggedIn: Bool
-    
-    init(isLoggedIn: Bool) {
-        self.isLoggedIn = isLoggedIn
+
+    init() {
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -68,7 +65,7 @@ final class WSSTabBarController: UITabBarController {
         var navigationControllers = [UINavigationController]()
         
         for item in WSSTabBarItem.allCases {
-            let viewController = item.itemViewController(isLoggedIn: isLoggedIn)
+            let viewController = item.itemViewController()
             let navigationController = createNavigationController(
                 normalImage: item.normalItemImage,
                 selectedImage: item.selectedItemImage,

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
@@ -50,10 +50,14 @@ enum WSSTabBarItem: CaseIterable {
         }
     }
     
-    func itemViewController(isLoggedIn: Bool) -> UIViewController {
+    func itemViewController() -> UIViewController {
         switch self {
         case .home:
-            return HomeViewController(viewModel: HomeViewModel(recommendRepository: DefaultRecommendRepository(recommendService: DefaultRecommendService()), isLoggedIn: isLoggedIn), isLoggedIn: isLoggedIn)
+            return HomeViewController(viewModel: HomeViewModel(
+                recommendRepository: DefaultRecommendRepository(
+                    recommendService: DefaultRecommendService()
+                )
+            ))
             
         case .search:
             return SearchViewController(viewModel: SearchViewModel(searchRepository: DefaultSearchRepository(searchService: DefaultSearchService())))

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
@@ -24,12 +24,12 @@ final class HomeInterestView: UIView {
     
     //MARK: - Life Cycle
     
-    init(isLoggedIn: Bool) {
+    init() {
         super.init(frame: .zero)
         
-        setUI(isLoggedIn: isLoggedIn)
+        setUI()
         setHierarchy()
-        setLayout(isLoggedIn: isLoggedIn)
+        setLayout()
     }
     
     @available(*, unavailable)
@@ -37,9 +37,9 @@ final class HomeInterestView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setUI(isLoggedIn: Bool) {
+    private func setUI() {
         titleLabel.do {
-            $0.applyWSSFont(.headline1, with: isLoggedIn ? "일이삼사오육칠팔구십\(StringLiterals.Home.Title.interest)" : StringLiterals.Home.Title.notLoggedInInterest)
+            $0.applyWSSFont(.headline1, with: "일이삼사오육칠팔구십\(StringLiterals.Home.Title.interest)")
             $0.textColor = .wssBlack
         }
         
@@ -59,17 +59,6 @@ final class HomeInterestView: UIView {
             $0.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
             interestCollectionView.setCollectionViewLayout($0, animated: false)
         }
-        
-        if isLoggedIn {
-            subTitleLabel.isHidden = false
-            unregisterView.isHidden = true
-            interestCollectionView.isHidden = false
-        }
-        else {
-            subTitleLabel.isHidden = true
-            unregisterView.isHidden = false
-            interestCollectionView.isHidden = true
-        }
     }
     
     private func setHierarchy() {
@@ -79,7 +68,7 @@ final class HomeInterestView: UIView {
                          unregisterView)
     }
     
-    private func setLayout(isLoggedIn: Bool) {
+    private func setLayout() {
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
@@ -90,19 +79,16 @@ final class HomeInterestView: UIView {
             $0.leading.equalTo(titleLabel.snp.leading)
         }
         
-        if isLoggedIn {
-            interestCollectionView.snp.makeConstraints {
-                $0.top.equalTo(subTitleLabel.snp.bottom)
-                $0.leading.trailing.bottom.equalToSuperview()
-                $0.height.equalTo(301)
-            }
+        interestCollectionView.snp.makeConstraints {
+            $0.top.equalTo(subTitleLabel.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(301)
         }
-        else {
-            unregisterView.snp.makeConstraints {
-                $0.top.equalTo(titleLabel.snp.bottom).offset(11)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.bottom.equalToSuperview()
-            }
+        
+        unregisterView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
@@ -20,6 +20,9 @@ final class HomeInterestView: UIView {
     let interestCollectionView = UICollectionView(frame: .zero,
                                                   collectionViewLayout: UICollectionViewLayout())
     private let interestCollectionViewLayout = UICollectionViewFlowLayout()
+    
+    private let isLoggedIn = APIConstants.isLogined
+    private let userNickname = UserDefaults.standard.string(forKey: StringLiterals.UserDefault.userNickname)
     let unregisterView = HomeUnregisterView(.interest)
     
     //MARK: - Life Cycle
@@ -39,7 +42,7 @@ final class HomeInterestView: UIView {
     
     private func setUI() {
         titleLabel.do {
-            $0.applyWSSFont(.headline1, with: "일이삼사오육칠팔구십\(StringLiterals.Home.Title.interest)")
+            $0.applyWSSFont(.headline1, with: isLoggedIn ? "\(userNickname ?? "")\(StringLiterals.Home.Title.interest)" : StringLiterals.Home.Title.notLoggedInInterest)
             $0.textColor = .wssBlack
         }
         
@@ -58,6 +61,17 @@ final class HomeInterestView: UIView {
             $0.itemSize = CGSize(width: 280, height: 251)
             $0.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
             interestCollectionView.setCollectionViewLayout($0, animated: false)
+        }
+        
+        if isLoggedIn {
+            subTitleLabel.isHidden = false
+            unregisterView.isHidden = true
+            interestCollectionView.isHidden = false
+        }
+        else {
+            subTitleLabel.isHidden = true
+            unregisterView.isHidden = false
+            interestCollectionView.isHidden = true
         }
     }
     
@@ -79,16 +93,18 @@ final class HomeInterestView: UIView {
             $0.leading.equalTo(titleLabel.snp.leading)
         }
         
-        interestCollectionView.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.height.equalTo(301)
-        }
-        
-        unregisterView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview()
+        if isLoggedIn {
+            interestCollectionView.snp.makeConstraints {
+                $0.top.equalTo(subTitleLabel.snp.bottom)
+                $0.leading.trailing.bottom.equalToSuperview()
+                $0.height.equalTo(301)
+            }
+        } else {
+            unregisterView.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(11)
+                $0.leading.trailing.equalToSuperview().inset(20)
+                $0.bottom.equalToSuperview()
+            }
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
@@ -19,6 +19,8 @@ final class HomeTasteRecommendView: UIView {
     let tasteRecommendCollectionView = UICollectionView(frame: .zero,
                                                         collectionViewLayout: UICollectionViewLayout())
     private let tasteRecommendCollectionViewLayout = UICollectionViewFlowLayout()
+    
+    private let isLoggedIn = APIConstants.isLogined
     let unregisterView = HomeUnregisterView(.tasteRecommend)
     
     //MARK: - Life Cycle
@@ -59,6 +61,16 @@ final class HomeTasteRecommendView: UIView {
             $0.itemSize = CGSize(width: (UIScreen.main.bounds.width - 49) / 2, height: 300)
             tasteRecommendCollectionView.setCollectionViewLayout($0, animated: false)
         }
+        
+        if isLoggedIn {
+            subTitleLabel.isHidden = false
+            tasteRecommendCollectionView.isHidden = false
+            unregisterView.isHidden = true
+        } else {
+            subTitleLabel.isHidden = true
+            tasteRecommendCollectionView.isHidden = true
+            unregisterView.isHidden = false
+        }
     }
     
     private func setHierarchy() {
@@ -78,17 +90,24 @@ final class HomeTasteRecommendView: UIView {
             $0.leading.equalTo(titleLabel.snp.leading)
         }
         
-        tasteRecommendCollectionView.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(0)
-            $0.bottom.equalToSuperview()
-        }
-        
-        unregisterView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(56)
+        if isLoggedIn {
+            subTitleLabel.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(2)
+                $0.leading.equalTo(titleLabel.snp.leading)
+            }
+            
+            tasteRecommendCollectionView.snp.makeConstraints {
+                $0.top.equalTo(subTitleLabel.snp.bottom).offset(20)
+                $0.leading.trailing.equalToSuperview().inset(20)
+                $0.height.equalTo(0)
+                $0.bottom.equalToSuperview()
+            }
+        } else {
+            unregisterView.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(11)
+                $0.leading.trailing.equalToSuperview().inset(20)
+                $0.bottom.equalToSuperview().inset(56)
+            }
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
@@ -58,6 +58,7 @@ final class HomeTasteRecommendView: UIView {
             $0.scrollDirection = .vertical
             $0.minimumLineSpacing = 18
             $0.minimumInteritemSpacing = 9
+            $0.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 40, right: 0)
             $0.itemSize = CGSize(width: (UIScreen.main.bounds.width - 49) / 2, height: 300)
             tasteRecommendCollectionView.setCollectionViewLayout($0, animated: false)
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
@@ -23,12 +23,12 @@ final class HomeTasteRecommendView: UIView {
     
     //MARK: - Life Cycle
     
-    init(isLoggedIn: Bool) {
+    init() {
         super.init(frame: .zero)
         
-        setUI(isLoggedIn: isLoggedIn)
+        setUI()
         setHierarchy()
-        setLayout(isLoggedIn: isLoggedIn)
+        setLayout()
     }
     
     @available(*, unavailable)
@@ -36,7 +36,7 @@ final class HomeTasteRecommendView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setUI(isLoggedIn: Bool) {
+    private func setUI() {
         titleLabel.do {
             $0.applyWSSFont(.headline1, with: StringLiterals.Home.Title.recommend)
             $0.textColor = .wssBlack
@@ -59,17 +59,6 @@ final class HomeTasteRecommendView: UIView {
             $0.itemSize = CGSize(width: (UIScreen.main.bounds.width - 49) / 2, height: 300)
             tasteRecommendCollectionView.setCollectionViewLayout($0, animated: false)
         }
-        
-        if isLoggedIn {
-            subTitleLabel.isHidden = false
-            tasteRecommendCollectionView.isHidden = false
-            unregisterView.isHidden = true
-        }
-        else {
-            subTitleLabel.isHidden = true
-            tasteRecommendCollectionView.isHidden = true
-            unregisterView.isHidden = false
-        }
     }
     
     private func setHierarchy() {
@@ -79,31 +68,27 @@ final class HomeTasteRecommendView: UIView {
                          unregisterView)
     }
     
-    private func setLayout(isLoggedIn: Bool) {
+    private func setLayout() {
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
         }
-
-        if isLoggedIn {
-            subTitleLabel.snp.makeConstraints {
-                $0.top.equalTo(titleLabel.snp.bottom).offset(2)
-                $0.leading.equalTo(titleLabel.snp.leading)
-            }
-            
-            tasteRecommendCollectionView.snp.makeConstraints {
-                $0.top.equalTo(subTitleLabel.snp.bottom).offset(20)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.height.equalTo(0)
-                $0.bottom.equalToSuperview()
-            }
+        subTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(2)
+            $0.leading.equalTo(titleLabel.snp.leading)
         }
-        else {
-            unregisterView.snp.makeConstraints {
-                $0.top.equalTo(titleLabel.snp.bottom).offset(11)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.bottom.equalToSuperview().inset(56)
-            }
+        
+        tasteRecommendCollectionView.snp.makeConstraints {
+            $0.top.equalTo(subTitleLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(0)
+            $0.bottom.equalToSuperview()
+        }
+        
+        unregisterView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(56)
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeView.swift
@@ -19,20 +19,17 @@ final class HomeView: UIView {
     let headerView = HomeHeaderView()
     let todayPopularView = HomeTodayPopularView()
     let realtimePopularView = HomeRealtimePopularView()
-    let interestView: HomeInterestView
-    let tasteRecommendView: HomeTasteRecommendView
-    let induceLoginModalView = HomeInduceLoginModalView()
+    let interestView = HomeInterestView()
+    let tasteRecommendView = HomeTasteRecommendView()
     
     //MARK: - Life Cycle
     
-    init(frame: CGRect, isLoggedIn: Bool) {
-        self.interestView = HomeInterestView(isLoggedIn: isLoggedIn)
-        self.tasteRecommendView = HomeTasteRecommendView(isLoggedIn: isLoggedIn)
+    override init(frame: CGRect) {
         super.init(frame: frame)
         
         setUI()
         setHierarchy()
-        setLayout(isLoggedIn: isLoggedIn)
+        setLayout()
     }
     
     @available(*, unavailable)
@@ -44,16 +41,11 @@ final class HomeView: UIView {
         scrollView.do {
             $0.showsVerticalScrollIndicator = false
         }
-        
-        induceLoginModalView.do {
-            $0.isHidden = true
-        }
     }
     
     private func setHierarchy() {
         self.addSubviews(headerView,
-                         scrollView,
-                         induceLoginModalView)
+                         scrollView)
         self.scrollView.addSubview(contentView)
         contentView.addSubviews(todayPopularView,
                                 realtimePopularView,
@@ -61,7 +53,7 @@ final class HomeView: UIView {
                                 tasteRecommendView)
     }
     
-    private func setLayout(isLoggedIn: Bool) {
+    private func setLayout() {
         headerView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide.snp.top)
             $0.height.equalTo(50)
@@ -73,11 +65,7 @@ final class HomeView: UIView {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom)
         }
-        
-        induceLoginModalView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
+
         contentView.snp.makeConstraints {
             $0.top.equalTo(scrollView.contentLayoutGuide).inset(18)
             $0.leading.trailing.bottom.equalTo(scrollView.contentLayoutGuide)
@@ -100,7 +88,7 @@ final class HomeView: UIView {
         }
         
         tasteRecommendView.snp.makeConstraints {
-            $0.top.equalTo(interestView.snp.bottom).offset(isLoggedIn ? 36 : 56)
+            $0.top.equalTo(interestView.snp.bottom).offset(36)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -17,8 +17,7 @@ final class HomeViewController: UIViewController {
     
     private let viewModel: HomeViewModel
     private let disposeBag = DisposeBag()
-    
-    private let isLoggedIn: Bool
+
     private let viewWillAppearEvent = PublishRelay<Void>()
     
     //MARK: - UI Components
@@ -27,10 +26,9 @@ final class HomeViewController: UIViewController {
     
     //MARK: - Life Cycle
     
-    init(viewModel: HomeViewModel, isLoggedIn: Bool) {
+    init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
-        self.isLoggedIn = isLoggedIn
-        self.rootView = HomeView(frame: .zero, isLoggedIn: isLoggedIn)
+        self.rootView = HomeView(frame: .zero)
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -96,8 +94,6 @@ final class HomeViewController: UIViewController {
             announcementButtonTapped: rootView.headerView.announcementButton.rx.tap,
             registerInterestNovelButtonTapped: rootView.interestView.unregisterView.registerButton.rx.tap,
             setPreferredGenresButtonTapped: rootView.tasteRecommendView.unregisterView.registerButton.rx.tap,
-            induceModalViewLoginButtonTapped: rootView.induceLoginModalView.loginButton.rx.tap,
-            induceModalViewCancelButtonTapped: rootView.induceLoginModalView.cancelButton.rx.tap,
             todayPopularCellSelected: rootView.todayPopularView.todayPopularCollectionView.rx.itemSelected,
             interestCellSelected: rootView.interestView.interestCollectionView.rx.itemSelected,
             tasteRecommendCellSelected: rootView.tasteRecommendView.tasteRecommendCollectionView.rx.itemSelected,
@@ -169,21 +165,6 @@ final class HomeViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.navigateToLoginView
-            .bind(with: self, onNext: { owner, _ in
-                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
-                    return
-                }
-                sceneDelegate.setRootToLoginViewController()
-            })
-            .disposed(by: disposeBag)
-        
-        output.showInduceLoginModalView
-            .drive(with: self, onNext: { owner, isShow in
-                owner.showInduceLoginModalView(isShow)
-            })
-            .disposed(by: disposeBag)
-        
         output.navigateToNovelDetailInfoView
             .withLatestFrom(Observable.combineLatest(output.todayPopularList,
                                                      output.interestList,
@@ -213,13 +194,6 @@ final class HomeViewController: UIViewController {
                 owner.rootView.tasteRecommendView.updateCollectionViewHeight(height: height)
             })
             .disposed(by: disposeBag)
-        
-    }
-    
-    //MARK: - Custom Method
-    
-    private func showInduceLoginModalView(_ isShow: Bool) {
-        rootView.induceLoginModalView.isHidden = !isShow
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -123,7 +123,7 @@ final class HomeViewController: UIViewController {
                                 print("Invalid feedId: \(feedId)")
                             }
                         } else {
-                            self.viewModel.pushToInduceLoginViewController.accept(())
+                            self.viewModel.presentInduceLoginViewController.accept(())
                         }
                     }
                 }
@@ -194,9 +194,9 @@ final class HomeViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.pushToInduceLoginViewController
+        output.presentInduceLoginViewController
             .bind(with: self, onNext: { owner, _ in
-                owner.pushToInduceLoginViewController()
+                owner.presentInduceLoginViewController()
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -16,7 +16,6 @@ final class HomeViewModel: ViewModelType {
     
     private let recommendRepository: RecommendRepository
     private let disposeBag = DisposeBag()
-    private let isLoggedIn: Bool
     private let showInduceLoginModalView = BehaviorRelay<Bool>(value: false)
     
     private let todayPopularList = PublishSubject<[TodayPopularNovel]>()
@@ -36,8 +35,6 @@ final class HomeViewModel: ViewModelType {
         let announcementButtonTapped: ControlEvent<Void>
         let registerInterestNovelButtonTapped: ControlEvent<Void>
         let setPreferredGenresButtonTapped: ControlEvent<Void>
-        let induceModalViewLoginButtonTapped: ControlEvent<Void>
-        let induceModalViewCancelButtonTapped: ControlEvent<Void>
         let todayPopularCellSelected: ControlEvent<IndexPath>
         let interestCellSelected: ControlEvent<IndexPath>
         let tasteRecommendCellSelected: ControlEvent<IndexPath>
@@ -54,17 +51,14 @@ final class HomeViewModel: ViewModelType {
         var tasteRecommendList: Observable<[TasteRecommendNovel]>
         let navigateToAnnouncementView: Observable<Void>
         let navigateToNormalSearchView: Observable<Void>
-        let navigateToLoginView: Observable<Void>
-        let showInduceLoginModalView: Driver<Bool>
         let navigateToNovelDetailInfoView: Observable<(IndexPath, Int)>
         let tasteRecommendCollectionViewHeight: Driver<CGFloat>
     }
     
     //MARK: - init
     
-    init(recommendRepository: RecommendRepository, isLoggedIn: Bool) {
+    init(recommendRepository: RecommendRepository) {
         self.recommendRepository = recommendRepository
-        self.isLoggedIn = isLoggedIn
     }
 }
 
@@ -95,7 +89,6 @@ extension HomeViewModel {
             })
             .disposed(by: disposeBag)
         
-        if isLoggedIn {
             recommendRepository.getInterestNovels()
                 .subscribe(with: self, onNext: { owner, data in
                     owner.interestList.onNext(data.recommendFeeds)
@@ -111,17 +104,10 @@ extension HomeViewModel {
                     owner.tasteRecommendList.onError(error)
                 })
                 .disposed(by: disposeBag)
-        }
         
         input.setPreferredGenresButtonTapped
             .subscribe(with: self, onNext: { owner, _ in
                 owner.showInduceLoginModalView.accept(true)
-            })
-            .disposed(by: disposeBag)
-        
-        input.induceModalViewCancelButtonTapped
-            .subscribe(with: self, onNext: { owner, _ in
-                owner.showInduceLoginModalView.accept(false)
             })
             .disposed(by: disposeBag)
         
@@ -145,7 +131,6 @@ extension HomeViewModel {
         
         let navigateToAnnouncementView = input.announcementButtonTapped.asObservable()
         let navigateToNormalSearchView = input.registerInterestNovelButtonTapped.asObservable()
-        let navigateToLoginView = input.induceModalViewLoginButtonTapped.asObservable()
         
         let navigateToNovelDetailInfoView = Observable.merge(
             todayPopularCellIndexPath.map { indexPath in (indexPath, 0) },
@@ -163,8 +148,6 @@ extension HomeViewModel {
                       tasteRecommendList: tasteRecommendList.asObservable(),
                       navigateToAnnouncementView: navigateToAnnouncementView,
                       navigateToNormalSearchView: navigateToNormalSearchView,
-                      navigateToLoginView: navigateToLoginView,
-                      showInduceLoginModalView: showInduceLoginModalView.asDriver(),
                       navigateToNovelDetailInfoView: navigateToNovelDetailInfoView,
                       tasteRecommendCollectionViewHeight: tasteRecommendCollectionViewHeight)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -28,7 +28,7 @@ final class HomeViewModel: ViewModelType {
     private let todayPopularCellIndexPath = PublishRelay<IndexPath>()
     private let interestCellIndexPath = PublishRelay<IndexPath>()
     private let tasteRecommendCellIndexPath = PublishRelay<IndexPath>()
-    let pushToInduceLoginViewController = PublishRelay<Void>()
+    let presentInduceLoginViewController = PublishRelay<Void>()
     private let pushToAnnouncementViewController = PublishRelay<Void>()
     
     // MARK: - Inputs
@@ -60,7 +60,7 @@ final class HomeViewModel: ViewModelType {
         
         // 비로그인
         let pushToNormalSearchViewController: Observable<Void>
-        let pushToInduceLoginViewController: Observable<Void>
+        let presentInduceLoginViewController: Observable<Void>
     }
     
     //MARK: - init
@@ -117,7 +117,7 @@ extension HomeViewModel {
         
         input.setPreferredGenresButtonTapped
             .subscribe(with: self, onNext: { owner, _ in
-                owner.pushToInduceLoginViewController.accept(())
+                owner.presentInduceLoginViewController.accept(())
             })
             .disposed(by: disposeBag)
         
@@ -126,7 +126,7 @@ extension HomeViewModel {
                 if owner.isLoggedIn {
                     owner.todayPopularCellIndexPath.accept(indexPath)
                 } else {
-                    owner.pushToInduceLoginViewController.accept(())
+                    owner.presentInduceLoginViewController.accept(())
                 }
             })
             .disposed(by: disposeBag)
@@ -148,7 +148,7 @@ extension HomeViewModel {
                 if owner.isLoggedIn {
                     owner.pushToAnnouncementViewController.accept(())
                 } else {
-                    owner.pushToInduceLoginViewController.accept(())
+                    owner.presentInduceLoginViewController.accept(())
                 }
             })
             .disposed(by: disposeBag)
@@ -173,7 +173,7 @@ extension HomeViewModel {
                       pushToNovelDetailInfoViewController: pushToNovelDetailInfoViewController,
                       tasteRecommendCollectionViewHeight: tasteRecommendCollectionViewHeight,
                       pushToNormalSearchViewController: pushToNormalSearchViewController,
-                      pushToInduceLoginViewController: pushToInduceLoginViewController.asObservable())
+                      presentInduceLoginViewController: presentInduceLoginViewController.asObservable())
     }
     
     //MARK: - API


### PR DESCRIPTION
### ⭐️Issue
close #319 
<br/>

### 🌟Motivation
비로그인시 홈뷰 내 유저 접근 제한 기능 구현했습니다. 
`HomeViewModel`, `HomeViewController` 내 코드 정리 했습니다. 
<br/>

### 🌟Key Changes
### AS-IS
이전에 `HomeViewModel`, `HomeViewController`에 있던 로그인 여부에 따른 코드를 제거했습니다. 
`isLoggedIn`이라는 변수를 매개변수로 넘겨주었는데, 이미 `APIConstants`에 정의되어있었어서 제거했습니다. 
이전 PR에서는 검색뷰 접근도 제한했는데 확인해보니, 작품상세뷰도 비로그인시 넘어갈 수 있어서 열어두었습니다. 

### TO-BE
1. `Presentation` > `Base` > `InduceLogin` 폴더에 로그인 유도 모달뷰와 뷰컨트롤러를 추가했습니다. 
2. `UIViewController+` 익스텐션에 해당 뷰컨을 `present`, `dismiss` 하는 함수를 구현했습니다. 
```
    func presentInduceLoginViewController() {
        let viewController = InduceLoginViewController()
        viewController.modalPresentationStyle = .overFullScreen
        
        self.present(viewController, animated: false)
    }
    
    func dismissViewController() {
        self.dismiss(animated: false)
    }
```

3. `InduceLoginViewController` 에는 버튼 탭 이벤트 두개만 있어서 따로 뷰모델을 생성하지 않고 바로 뷰컨트롤러에 바인딩 해주었습니다. 
<br/>


### 🌟Simulation

https://github.com/user-attachments/assets/cdc05950-047f-432d-9d28-d62c41102aea


<br/>

### 🌟To Reviewer
- 이전 코드는 기능 구현이 잘못되었고 코드도 정리가 되지 않아서 새로 이슈파서 진행했습니다!!! 
<br/>

### 🌟Reference

<br/>
