### PR TITLE
[Network] #321 - 자동 로그인, 401 대응 토큰 재발급 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -1885,7 +1885,6 @@
 				39B75ACF2B59891C005DD8B9 /* sosocatTail.json */,
 				39B75AD32B59891D005DD8B9 /* villainessFan.json */,
 				39B75AD22B59891D005DD8B9 /* villainessTea.json */,
-				39AD55B22CAFDF6500CBDA7A /* scroll.json */,
 				39099EF22CD88A1200FCA8DE /* loading.json */,
 			);
 			path = Lottie;

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		3910137C2CCF5EC6001894E5 /* BirthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910137B2CCF5EC6001894E5 /* BirthPickerView.swift */; };
 		3910137E2CCF5FD8001894E5 /* BirthPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910137D2CCF5FD3001894E5 /* BirthPickerViewController.swift */; };
 		39119FA82C8C482800E9E6FA /* NovelDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39119FA72C8C482800E9E6FA /* NovelDetailService.swift */; };
-		39139A042CE0E8AF00BC40AE /* WSSURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */; };
+		39139A042CE0E8AF00BC40AE /* TokenCheckURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39139A032CE0E8AF00BC40AE /* TokenCheckURLProtocol.swift */; };
 		3916EC862B89B42C007835B5 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 3916EC852B89B42C007835B5 /* RxGesture */; };
 		3916EC892B89D23D007835B5 /* ModuleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3916EC882B89D23D007835B5 /* ModuleFactory.swift */; };
 		392A29232B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392A29222B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift */; };
@@ -558,7 +558,7 @@
 		3910137B2CCF5EC6001894E5 /* BirthPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthPickerView.swift; sourceTree = "<group>"; };
 		3910137D2CCF5FD3001894E5 /* BirthPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthPickerViewController.swift; sourceTree = "<group>"; };
 		39119FA72C8C482800E9E6FA /* NovelDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailService.swift; sourceTree = "<group>"; };
-		39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSURLProtocol.swift; sourceTree = "<group>"; };
+		39139A032CE0E8AF00BC40AE /* TokenCheckURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCheckURLProtocol.swift; sourceTree = "<group>"; };
 		3916EC882B89D23D007835B5 /* ModuleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleFactory.swift; sourceTree = "<group>"; };
 		392A29222B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNormalNovelInfoWithRatingView.swift; sourceTree = "<group>"; };
 		392A29262B4E96F30065EB97 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
@@ -2031,7 +2031,7 @@
 				A1654F0D2B540504004F78E8 /* APIConstants.swift */,
 				A1654F0E2B540504004F78E8 /* HTTPMethod.swift */,
 				396C7C5C2CB27AC2003C9712 /* ServerErrorResponse.swift */,
-				39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */,
+				39139A032CE0E8AF00BC40AE /* TokenCheckURLProtocol.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -3271,7 +3271,7 @@
 				A1CB373A2B72935900CB290F /* UITableViewCell+.swift in Sources */,
 				A1147A802B50638200141692 /* RecordViewController.swift in Sources */,
 				B9F7401D2C047E360018D0C6 /* NormalSearchViewModel.swift in Sources */,
-				39139A042CE0E8AF00BC40AE /* WSSURLProtocol.swift in Sources */,
+				39139A042CE0E8AF00BC40AE /* TokenCheckURLProtocol.swift in Sources */,
 				CD803B392C940989006EBAF8 /* CenterAlignedCollectionViewFlowLayout.swift in Sources */,
 				CD8747B72C9F050800D0ADAD /* NovelDateSelectModalDatePickerView.swift in Sources */,
 				39ABD5A02B54D0A900DEA94E /* RegisterNormalDatePicker.swift in Sources */,

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		3910137C2CCF5EC6001894E5 /* BirthPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910137B2CCF5EC6001894E5 /* BirthPickerView.swift */; };
 		3910137E2CCF5FD8001894E5 /* BirthPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910137D2CCF5FD3001894E5 /* BirthPickerViewController.swift */; };
 		39119FA82C8C482800E9E6FA /* NovelDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39119FA72C8C482800E9E6FA /* NovelDetailService.swift */; };
+		39139A042CE0E8AF00BC40AE /* WSSURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */; };
 		3916EC862B89B42C007835B5 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 3916EC852B89B42C007835B5 /* RxGesture */; };
 		3916EC892B89D23D007835B5 /* ModuleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3916EC882B89D23D007835B5 /* ModuleFactory.swift */; };
 		392A29232B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392A29222B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift */; };
@@ -557,6 +558,7 @@
 		3910137B2CCF5EC6001894E5 /* BirthPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthPickerView.swift; sourceTree = "<group>"; };
 		3910137D2CCF5FD3001894E5 /* BirthPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthPickerViewController.swift; sourceTree = "<group>"; };
 		39119FA72C8C482800E9E6FA /* NovelDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovelDetailService.swift; sourceTree = "<group>"; };
+		39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSSURLProtocol.swift; sourceTree = "<group>"; };
 		3916EC882B89D23D007835B5 /* ModuleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleFactory.swift; sourceTree = "<group>"; };
 		392A29222B4E89FD0065EB97 /* RegisterNormalNovelInfoWithRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNormalNovelInfoWithRatingView.swift; sourceTree = "<group>"; };
 		392A29262B4E96F30065EB97 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
@@ -2030,6 +2032,7 @@
 				A1654F0D2B540504004F78E8 /* APIConstants.swift */,
 				A1654F0E2B540504004F78E8 /* HTTPMethod.swift */,
 				396C7C5C2CB27AC2003C9712 /* ServerErrorResponse.swift */,
+				39139A032CE0E8AF00BC40AE /* WSSURLProtocol.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -3269,6 +3272,7 @@
 				A1CB373A2B72935900CB290F /* UITableViewCell+.swift in Sources */,
 				A1147A802B50638200141692 /* RecordViewController.swift in Sources */,
 				B9F7401D2C047E360018D0C6 /* NormalSearchViewModel.swift in Sources */,
+				39139A042CE0E8AF00BC40AE /* WSSURLProtocol.swift in Sources */,
 				CD803B392C940989006EBAF8 /* CenterAlignedCollectionViewFlowLayout.swift in Sources */,
 				CD8747B72C9F050800D0ADAD /* NovelDateSelectModalDatePickerView.swift in Sources */,
 				39ABD5A02B54D0A900DEA94E /* RegisterNormalDatePicker.swift in Sources */,

--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window = UIWindow(windowScene: windowScene)
         
-        setRootToLoginViewController()
+        APIConstants.isLogined ? setRootToWSSTabBarController() : setRootToLoginViewController()
         
         self.window?.makeKeyAndVisible()
     }
@@ -37,7 +37,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func setRootToLoginViewController() {
         let navigationController = UINavigationController(rootViewController: ModuleFactory.shared.makeLoginViewController())
         navigationController.isNavigationBarHidden = true
-        window?.rootViewController = navigationController
+        guard let window else { return }
+        UIView.transition(with: window,
+                          duration: 0.3,
+                          options: .transitionCrossDissolve,
+                          animations: {
+            window.rootViewController = navigationController },
+                          completion: nil)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/WSSiOS/WSSiOS/Network/Auth/AuthService.swift
+++ b/WSSiOS/WSSiOS/Network/Auth/AuthService.swift
@@ -16,10 +16,6 @@ protocol AuthService {
 }
 
 final class DefaultAuthService: NSObject, Networking, AuthService {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-    
     func loginWithApple(userIdentifier: String, email: String?) -> RxSwift.Single<LoginResult> {
         guard let appleLoginBody = try? JSONEncoder().encode(AppleLoginBody(userIdentifier: userIdentifier, email: email)) else {
             return Single.error(NetworkServiceError.invalidRequestError)
@@ -33,7 +29,7 @@ final class DefaultAuthService: NSObject, Networking, AuthService {
 
             NetworkLogger.log(request: request)
 
-            return urlSession.rx.data(request: request)
+            return basicURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: LoginResult.self) }
                 .asSingle()
@@ -60,7 +56,7 @@ final class DefaultAuthService: NSObject, Networking, AuthService {
 
             NetworkLogger.log(request: request)
 
-            return urlSession.rx.data(request: request)
+            return basicURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: ReissueResult.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/Avatar/AvatarService.swift
+++ b/WSSiOS/WSSiOS/Network/Avatar/AvatarService.swift
@@ -16,9 +16,6 @@ protocol AvatarService {
 
 final class DefaultAvatarService: NSObject, Networking {
     private let avatarListQueryItems: [URLQueryItem] = [URLQueryItem(name: "avatarId", value: String(describing: 2))]
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
 }
 
 extension DefaultAvatarService: AvatarService {
@@ -31,7 +28,7 @@ extension DefaultAvatarService: AvatarService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: AvatarResult.self) }
                 .asSingle()
@@ -56,7 +53,7 @@ extension DefaultAvatarService: AvatarService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Avatar/AvatarService.swift
+++ b/WSSiOS/WSSiOS/Network/Avatar/AvatarService.swift
@@ -26,7 +26,7 @@ extension DefaultAvatarService: AvatarService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Avatar.getAvatarDetail.replacingOccurrences(of: "{avatarId}", with: String(avatarId)),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -51,7 +51,7 @@ extension DefaultAvatarService: AvatarService {
             let request = try makeHTTPRequest(method: .patch,
                                               path: URLs.Avatar.patchRepAvatar,
                                               queryItems: avatarListQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: avatarIdData)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Blocks/BlocksService.swift
+++ b/WSSiOS/WSSiOS/Network/Blocks/BlocksService.swift
@@ -25,7 +25,7 @@ extension DefaultBlocksService: BlocksService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.MyPage.Block.blocks,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -43,7 +43,7 @@ extension DefaultBlocksService: BlocksService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.MyPage.Block.userBlocks(blockID: blockID),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             

--- a/WSSiOS/WSSiOS/Network/Blocks/BlocksService.swift
+++ b/WSSiOS/WSSiOS/Network/Blocks/BlocksService.swift
@@ -14,11 +14,7 @@ protocol BlocksService {
     func deleteBlockUser(blockID: Int) -> Single<Void>
 }
 
-final class DefaultBlocksService: NSObject, Networking {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-}
+final class DefaultBlocksService: NSObject, Networking { }
 
 extension DefaultBlocksService: BlocksService {
     func getBlocksList() -> RxSwift.Single<BlockUserResult> {
@@ -30,7 +26,7 @@ extension DefaultBlocksService: BlocksService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: BlockUserResult.self) }
                 .asSingle()
@@ -49,7 +45,7 @@ extension DefaultBlocksService: BlocksService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Feed/FeedDetailService.swift
+++ b/WSSiOS/WSSiOS/Network/Feed/FeedDetailService.swift
@@ -34,7 +34,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Feed.getSingleFeed(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -53,7 +53,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Feed.getSingleFeedComments(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -72,7 +72,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Feed.postFeedLike(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -90,7 +90,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.Feed.deleteFeedLike(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -112,7 +112,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Feed.postComment(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: commentContent)
             
             NetworkLogger.log(request: request)
@@ -134,7 +134,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .put,
                                               path: URLs.Feed.putComment(feedId: feedId, commentId: commentId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: commentContent)
             
             NetworkLogger.log(request: request)
@@ -152,7 +152,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.Feed.deleteComment(feedId: feedId, commentId: commentId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -170,7 +170,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Feed.postSpoilerFeed(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -188,7 +188,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Feed.postImpertinenceFeed(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -206,7 +206,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.Feed.deleteFeed(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Feed/FeedDetailService.swift
+++ b/WSSiOS/WSSiOS/Network/Feed/FeedDetailService.swift
@@ -26,10 +26,6 @@ protocol FeedDetailService {
 }
 
 final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-    
     func getFeed(feedId: Int) -> Single<Feed> {
         do {
             let request = try makeHTTPRequest(method: .get,
@@ -39,7 +35,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: Feed.self) }
                 .asSingle()
@@ -58,7 +54,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: FeedComments.self) }
                 .asSingle()
@@ -77,7 +73,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -95,7 +91,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -117,7 +113,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -139,7 +135,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -157,7 +153,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -175,7 +171,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -193,7 +189,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             
@@ -211,7 +207,7 @@ final class DefaultFeedDetailService: NSObject, Networking, FeedDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
             

--- a/WSSiOS/WSSiOS/Network/Feed/FeedService.swift
+++ b/WSSiOS/WSSiOS/Network/Feed/FeedService.swift
@@ -28,10 +28,6 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
         ]
     }
 
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-
     func getFeedList(category: String, lastFeedId: Int, size: Int) -> RxSwift.Single<TotalFeed> {
         do {
             let request = try makeHTTPRequest(method: .get,
@@ -44,7 +40,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
 
             NetworkLogger.log(request: request)
 
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: TotalFeed.self) }
                 .asSingle()
@@ -67,7 +63,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -88,7 +84,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Feed/FeedService.swift
+++ b/WSSiOS/WSSiOS/Network/Feed/FeedService.swift
@@ -39,7 +39,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
                                               queryItems: makeFeedListQuery(category: category,
                                                                             lastFeedId: lastFeedId,
                                                                             size: size),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
 
             NetworkLogger.log(request: request)
@@ -62,7 +62,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Memo.postFeed,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: feedContentData)
             
             NetworkLogger.log(request: request)
@@ -83,7 +83,7 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
         do {
             let request = try makeHTTPRequest(method: .put,
                                               path: URLs.Memo.putFeed(feedId: feedId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: feedContentData)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Foundation/APIConstants.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/APIConstants.swift
@@ -16,10 +16,18 @@ struct APIConstants {
     static let fcm = "FcmToken"
     
     static let boundary = "Boundary-\(UUID().uuidString)"
-    static var isLogined: Bool = false
-    static var testToken: String {
-        isLogined ? (Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? "") : ""
+    
+    // Config의 Test Token을 사용한다면, 이 값을 true로,
+    // UserDefaults의 실제 토큰 값을 쓰려면 이 값을 false로 바꿀 것.
+    static let isTesting: Bool = false
+    
+    static var isLogined: Bool {
+        !accessToken.isEmpty
     }
+    static var accessToken: String {
+        isTesting ? testToken : UserDefaults.standard.value(forKey: StringLiterals.UserDefault.accessToken) as? String ?? ""
+    }
+    static var testToken: String = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? ""
 }
 
 extension APIConstants {
@@ -27,8 +35,8 @@ extension APIConstants {
         [contentType: applicationJSON]
     }
     
-    static var testTokenHeader: Dictionary<String, String> {
+    static var accessTokenHeader: Dictionary<String, String> {
         [contentType: applicationJSON,
-                auth: "Bearer " + testToken]
+                auth: "Bearer " + accessToken]
     }
 }

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol Networking {
+    var tokenCheckURLSession: URLSession { get }
+    
     func makeHTTPRequest(
         method: HTTPMethod,
         baseURL: String,
@@ -25,6 +27,14 @@ protocol Networking {
 }
 
 extension Networking {
+    var tokenCheckURLSession: URLSession {
+        // CustomURLProtocol을 URLSessionConfiguration에 등록
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = [TokenCheckURLProtocol.self] + (config.protocolClasses ?? [])
+        return URLSession(configuration: config,
+                          delegate: nil,
+                          delegateQueue: nil)
+    }
     
     func makeHTTPRequest(
         method: HTTPMethod,

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol Networking {
+    var basicURLSession: URLSession { get }
+    
     var tokenCheckURLSession: URLSession { get }
     
     func makeHTTPRequest(
@@ -27,6 +29,12 @@ protocol Networking {
 }
 
 extension Networking {
+    var basicURLSession: URLSession {
+        URLSession(configuration: URLSessionConfiguration.default,
+                   delegate: nil,
+                   delegateQueue: nil)
+    }
+    
     var tokenCheckURLSession: URLSession {
         // CustomURLProtocol을 URLSessionConfiguration에 등록
         let config = URLSessionConfiguration.default

--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -5,7 +5,6 @@
 //  Created by YunhakLee on 11/10/24.
 //
 
-import Foundation
 import RxSwift
 import UIKit
 
@@ -66,7 +65,7 @@ class TokenCheckURLProtocol: URLProtocol {
                             retryTask.resume()
                         }, onFailure: { owner, error in
                             print("====== Fail To Get New Token ====== ")
-                            // 실패 시 처리 (예: 로그인 화면으로 이동)
+                            // 실패 시 토큰을 삭제하고 로그인 VC로 이동
                             DispatchQueue.main.async {
                                 owner.deleteTokens()
                                 owner.moveToLoginViewController()
@@ -84,7 +83,7 @@ class TokenCheckURLProtocol: URLProtocol {
                     self.client?.urlProtocolDidFinishLoading(self)
                 }
             } else if let error = error {
-                // 에러 처리
+                // 일반적인 에러 처리
                 self.client?.urlProtocol(self, didFailWithError: error)
             }
         }

--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -109,7 +109,7 @@ class TokenCheckURLProtocol: URLProtocol {
             self.deleteTokens()
             self.moveToLoginViewController()
         }
-        //self.client?.urlProtocol(self, didFailWithError: error)
+        self.client?.urlProtocol(self, didFailWithError: error)
     }
     
     // 네트워크 요청 중단 시 호출됩니다.

--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -70,6 +70,7 @@ class TokenCheckURLProtocol: URLProtocol {
                                 owner.deleteTokens()
                                 owner.moveToLoginViewController()
                             }
+                            owner.client?.urlProtocol(self, didFailWithError: error)
                         })
                         .disposed(by: self.disposeBag)
                 } else {

--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  WSSURLProtocol.swift
+//  TokenCheckURLProtocol.swift
 //  WSSiOS
 //
 //  Created by YunhakLee on 11/10/24.
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import UIKit
 
-class WSSURLProtocol: URLProtocol {
+class TokenCheckURLProtocol: URLProtocol {
     
     private let disposeBag = DisposeBag()
     
@@ -97,7 +97,7 @@ class WSSURLProtocol: URLProtocol {
     }
 }
 
-extension WSSURLProtocol {
+extension TokenCheckURLProtocol {
     private func updateTokens(result: ReissueResult) {
         UserDefaults.standard.setValue(result.Authorization,
                                        forKey: StringLiterals.UserDefault.accessToken)

--- a/WSSiOS/WSSiOS/Network/Foundation/WSSURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/WSSURLProtocol.swift
@@ -1,0 +1,121 @@
+//
+//  WSSURLProtocol.swift
+//  WSSiOS
+//
+//  Created by YunhakLee on 11/10/24.
+//
+
+import Foundation
+import RxSwift
+import UIKit
+
+class WSSURLProtocol: URLProtocol {
+    
+    private let disposeBag = DisposeBag()
+    
+    // 해당 요청을 이 프로토콜이 처리할지 여부를 결정합니다.
+    // Handled에 값이 없는 경우에만(API를 처음 호출할 때만) 이 프로토콜이 처리한다.
+    // 한번 이 프로토콜에서 처리하고 나면, startLoading() 과정에서
+    // Handled 값은 true로 들어가므로 더이상 이 프로토콜이 처리하지 않음.
+    override class func canInit(with request: URLRequest) -> Bool {
+        if URLProtocol.property(forKey: "Handled", in: request) != nil {
+            return false
+        } else {
+            return true
+        }
+    }
+    
+    // 요청을 수정할 필요가 있을 때 호출됩니다.
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    // 실제 네트워크 요청 처리
+    override func startLoading() {
+        // 원래 요청으로 데이터 태스크 시작
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                // 상태 코드가 401인지 확인
+                if httpResponse.statusCode == 401 {
+                    print("====== Try To Get New Token ======")
+                    // 401 응답 시 토큰 갱신 로직 처리
+                    DefaultAuthService().reissueToken()
+                        .subscribe(with: self, onSuccess: { owner, result in
+                            print("====== Success To Get New Token ======")
+                            // 새로운 토큰 저장
+                            owner.updateTokens(result: result)
+                            
+                            // 갱신된 토큰으로 새로운 요청 생성
+                            guard let mutableRequest = (owner.request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+                                return
+                            }
+                            URLProtocol.setProperty(true, forKey: "Handled", in: mutableRequest)
+                            mutableRequest.setValue("Bearer " + result.Authorization, forHTTPHeaderField: APIConstants.auth)
+                            let newRequest = mutableRequest as URLRequest
+                            
+                            // 새로운 토큰으로 요청 재시도
+                            let retryTask = URLSession.shared.dataTask(with: newRequest) { data, response, error in
+                                if let data = data {
+                                    owner.client?.urlProtocol(owner, didLoad: data)
+                                }
+                                if let response = response {
+                                    owner.client?.urlProtocol(owner, didReceive: response, cacheStoragePolicy: .notAllowed)
+                                }
+                                owner.client?.urlProtocolDidFinishLoading(owner)
+                            }
+                            retryTask.resume()
+                        }, onFailure: { owner, error in
+                            print("====== Fail To Get New Token ====== ")
+                            // 실패 시 처리 (예: 로그인 화면으로 이동)
+                            DispatchQueue.main.async {
+                                owner.deleteTokens()
+                                owner.moveToLoginViewController()
+                            }
+                        })
+                        .disposed(by: self.disposeBag)
+                } else {
+                    // 401이 아닌 경우 일반적인 응답 처리
+                    if let data = data {
+                        self.client?.urlProtocol(self, didLoad: data)
+                    }
+                    if let response = response {
+                        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    }
+                    self.client?.urlProtocolDidFinishLoading(self)
+                }
+            } else if let error = error {
+                // 에러 처리
+                self.client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+        task.resume()
+    }
+    
+    // 네트워크 요청 중단 시 호출됩니다.
+    override func stopLoading() {
+        // 필요 시 작업 중단 처리
+    }
+}
+
+extension WSSURLProtocol {
+    private func updateTokens(result: ReissueResult) {
+        UserDefaults.standard.setValue(result.Authorization,
+                                       forKey: StringLiterals.UserDefault.accessToken)
+        UserDefaults.standard.setValue(result.refreshToken,
+                                       forKey: StringLiterals.UserDefault.refreshToken)
+    }
+    
+    private func deleteTokens() {
+        UserDefaults.standard.setValue(nil,
+                                       forKey: StringLiterals.UserDefault.accessToken)
+        UserDefaults.standard.setValue(nil,
+                                       forKey: StringLiterals.UserDefault.refreshToken)
+    }
+    
+    private func moveToLoginViewController() {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
+            return
+        }
+        sceneDelegate.setRootToLoginViewController()
+    }
+}

--- a/WSSiOS/WSSiOS/Network/Keyword/KeywordService.swift
+++ b/WSSiOS/WSSiOS/Network/Keyword/KeywordService.swift
@@ -29,7 +29,7 @@ final class DefaultKeywordService: NSObject, Networking, KeywordService {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Keyword.searchKeyword,
                                               queryItems: searchKeywordQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
 
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Keyword/KeywordService.swift
+++ b/WSSiOS/WSSiOS/Network/Keyword/KeywordService.swift
@@ -14,10 +14,6 @@ protocol KeywordService {
 }
 
 final class DefaultKeywordService: NSObject, Networking, KeywordService {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-
     func searchKeyword(query: String? = nil) -> RxSwift.Single<SearchKeywordResult> {
         var searchKeywordQueryItems: [URLQueryItem] = []
         
@@ -34,7 +30,7 @@ final class DefaultKeywordService: NSObject, Networking, KeywordService {
 
             NetworkLogger.log(request: request)
 
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: SearchKeywordResult.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/Memo/MemoService.swift
+++ b/WSSiOS/WSSiOS/Network/Memo/MemoService.swift
@@ -19,9 +19,6 @@ protocol MemoService {
 
 final class DefaultMemoService: NSObject, Networking {
     private var recordListSize = 1000
-    private var urlSession = URLSession(configuration: URLSessionConfiguration.default,
-                                        delegate: nil,
-                                        delegateQueue: nil)
 }
 
 extension DefaultMemoService: MemoService {
@@ -40,7 +37,7 @@ extension DefaultMemoService: MemoService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: RecordMemos.self) }
                 .asSingle()
         } catch {
@@ -61,7 +58,7 @@ extension DefaultMemoService: MemoService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: IsAvatarUnlocked.self) }
                 .asSingle()
         } catch {
@@ -78,7 +75,7 @@ extension DefaultMemoService: MemoService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: MemoDetail.self) }
                 .asSingle()
         } catch {
@@ -95,7 +92,7 @@ extension DefaultMemoService: MemoService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -116,7 +113,7 @@ extension DefaultMemoService: MemoService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Memo/MemoService.swift
+++ b/WSSiOS/WSSiOS/Network/Memo/MemoService.swift
@@ -35,7 +35,7 @@ extension DefaultMemoService: MemoService {
             let request = try makeHTTPRequest(method: .get,
                                                path: URLs.Memo.getMemoList,
                                                queryItems: recordListQueryItems,
-                                               headers: APIConstants.testTokenHeader,
+                                               headers: APIConstants.accessTokenHeader,
                                                body: nil)
             
             NetworkLogger.log(request: request)
@@ -56,7 +56,7 @@ extension DefaultMemoService: MemoService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.Memo.postMemo(userNovelId: userNovelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: memoContentData)
             
             NetworkLogger.log(request: request)
@@ -73,7 +73,7 @@ extension DefaultMemoService: MemoService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Memo.getMemo(memoId: memoId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -90,7 +90,7 @@ extension DefaultMemoService: MemoService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                                path: URLs.Memo.deleteMemo(memoId: memoId),
-                                               headers: APIConstants.testTokenHeader,
+                                               headers: APIConstants.accessTokenHeader,
                                                body: nil)
             
             NetworkLogger.log(request: request)
@@ -111,7 +111,7 @@ extension DefaultMemoService: MemoService {
         do {
             let request = try makeHTTPRequest(method: .patch,
                                               path: URLs.Memo.patchMemo(memoId: memoId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: memoContentData)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Notice/NoticeService.swift
+++ b/WSSiOS/WSSiOS/Network/Notice/NoticeService.swift
@@ -23,7 +23,7 @@ final class DefaultNoticeService: NSObject, Networking, NoticeService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Notice.getNotices,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Notice/NoticeService.swift
+++ b/WSSiOS/WSSiOS/Network/Notice/NoticeService.swift
@@ -28,7 +28,7 @@ final class DefaultNoticeService: NSObject, Networking, NoticeService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: Notices.self) }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Novel/NovelService.swift
+++ b/WSSiOS/WSSiOS/Network/Novel/NovelService.swift
@@ -24,7 +24,7 @@ extension DefaultNovelService: NovelService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                                path: URLs.Novel.getNovelInfo(novelId: novelId),
-                                               headers: APIConstants.testTokenHeader,
+                                               headers: APIConstants.accessTokenHeader,
                                                body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Novel/NovelService.swift
+++ b/WSSiOS/WSSiOS/Network/Novel/NovelService.swift
@@ -13,11 +13,7 @@ protocol NovelService {
     func getNovelInfo(novelId: Int) -> Single<NovelResult>
 }
 
-final class DefaultNovelService: NSObject, Networking {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-}
+final class DefaultNovelService: NSObject, Networking { }
 
 extension DefaultNovelService: NovelService {
     func getNovelInfo(novelId: Int) -> Single<NovelResult> {
@@ -29,7 +25,7 @@ extension DefaultNovelService: NovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map {NovelResult(
                     newNovelResult: try? JSONDecoder().decode(NewNovelResult.self, from: $0),
                     editNovelResult: try? JSONDecoder().decode(EditNovelResult.self, from: $0))

--- a/WSSiOS/WSSiOS/Network/NovelDetail/NovelDetailService.swift
+++ b/WSSiOS/WSSiOS/Network/NovelDetail/NovelDetailService.swift
@@ -18,11 +18,7 @@ protocol NovelDetailService {
     func deleteNovelReview(novelId: Int) -> Single<Void>
 }
 
-final class DefaultNovelDetailService: NSObject, Networking {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-}
+final class DefaultNovelDetailService: NSObject, Networking { }
 
 extension DefaultNovelDetailService: NovelDetailService {
     func deleteNovelReview(novelId: Int) -> Single<Void> {
@@ -34,7 +30,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -51,7 +47,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -68,7 +64,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -85,7 +81,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: NovelDetailHeaderResult.self) }
                 .asSingle()
@@ -103,7 +99,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: NovelDetailInfoResult.self) }
                 .asSingle()
@@ -126,7 +122,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: NovelDetailFeedResult.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/NovelDetail/NovelDetailService.swift
+++ b/WSSiOS/WSSiOS/Network/NovelDetail/NovelDetailService.swift
@@ -29,7 +29,7 @@ extension DefaultNovelDetailService: NovelDetailService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.NovelDetail.novelReview(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -46,7 +46,7 @@ extension DefaultNovelDetailService: NovelDetailService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.NovelDetail.novelIsInterest(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -63,7 +63,7 @@ extension DefaultNovelDetailService: NovelDetailService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.NovelDetail.novelIsInterest(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -80,7 +80,7 @@ extension DefaultNovelDetailService: NovelDetailService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.NovelDetail.novelDetailHeader(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -98,7 +98,7 @@ extension DefaultNovelDetailService: NovelDetailService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.NovelDetail.novelDetailInfo(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -121,7 +121,7 @@ extension DefaultNovelDetailService: NovelDetailService {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.NovelDetail.novelDetailFeed(novelId: novelId),
                                               queryItems: novelDetailFeedQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/NovelReview/NovelReviewService.swift
+++ b/WSSiOS/WSSiOS/Network/NovelReview/NovelReviewService.swift
@@ -28,10 +28,6 @@ protocol NovelReviewService {
 }
 
 final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-    
     func postNovelReview(novelId: Int,
                          userNovelRating: Float,
                          status: String,
@@ -51,7 +47,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -78,7 +74,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -95,7 +91,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: NovelReviewResult.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/NovelReview/NovelReviewService.swift
+++ b/WSSiOS/WSSiOS/Network/NovelReview/NovelReviewService.swift
@@ -46,7 +46,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
         do {
             let request = try makeHTTPRequest(method: .post,
                                               path: URLs.NovelReview.postNovelReview,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: novelReviewContentData)
             
             NetworkLogger.log(request: request)
@@ -73,7 +73,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
         do {
             let request = try makeHTTPRequest(method: .put,
                                               path: URLs.NovelReview.putNovelReview(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: novelReviewContentData)
             
             NetworkLogger.log(request: request)
@@ -90,7 +90,7 @@ final class DefaultNovelReviewService: NSObject, Networking, NovelReviewService 
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.NovelReview.getNovelReview(novelId: novelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Onboarding/OnboardingService.swift
+++ b/WSSiOS/WSSiOS/Network/Onboarding/OnboardingService.swift
@@ -14,11 +14,7 @@ protocol OnboardingService {
     func postUserProfile(userInfoResult: UserInfoResult) -> Single<Void>
 }
 
-final class DefaultOnboardingService: NSObject, Networking {
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
-}
+final class DefaultOnboardingService: NSObject, Networking { }
 
 extension DefaultOnboardingService: OnboardingService {
     func getNicknameisValid(_ nickname: String) -> Single<OnboardingResult> {
@@ -37,7 +33,7 @@ extension DefaultOnboardingService: OnboardingService {
             
             NetworkLogger.log(request: request)
             
-            return customUrlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: OnboardingResult.self) }
                 .asSingle()
@@ -61,7 +57,7 @@ extension DefaultOnboardingService: OnboardingService {
             
             NetworkLogger.log(request: request)
             
-            return customUrlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Onboarding/OnboardingService.swift
+++ b/WSSiOS/WSSiOS/Network/Onboarding/OnboardingService.swift
@@ -31,13 +31,13 @@ extension DefaultOnboardingService: OnboardingService {
                 method: .get,
                 path: URLs.Onboarding.nicknameCheck,
                 queryItems: nicknameisValidQueryItems,
-                headers: APIConstants.testTokenHeader,
+                headers: APIConstants.accessTokenHeader,
                 body: nil
             )
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return customUrlSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: OnboardingResult.self) }
                 .asSingle()
@@ -55,13 +55,13 @@ extension DefaultOnboardingService: OnboardingService {
             let request = try self.makeHTTPRequest(
                 method: .post,
                 path: URLs.Onboarding.postProfile,
-                headers: APIConstants.testTokenHeader,
+                headers: APIConstants.accessTokenHeader,
                 body: userInfo
             )
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return customUrlSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/Recommend/RecommendService.swift
+++ b/WSSiOS/WSSiOS/Network/Recommend/RecommendService.swift
@@ -16,12 +16,7 @@ protocol RecommendService {
     func getTasteRecommendNovels() -> Single<TasteRecommendNovels>
 }
 
-final class DefaultRecommendService: NSObject, Networking {
-    
-    private var urlSession = URLSession(configuration: URLSessionConfiguration.default,
-                                        delegate: nil,
-                                        delegateQueue: nil)
-}
+final class DefaultRecommendService: NSObject, Networking { }
 
 extension DefaultRecommendService: RecommendService {
     /// 오늘의 인기작 조회
@@ -34,7 +29,7 @@ extension DefaultRecommendService: RecommendService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: TodayPopularNovels.self) }
                 .asSingle()
@@ -54,7 +49,7 @@ extension DefaultRecommendService: RecommendService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: RealtimePopularFeeds.self) }
                 .asSingle()
@@ -74,7 +69,7 @@ extension DefaultRecommendService: RecommendService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: InterestFeeds.self) }
                 .asSingle()
@@ -94,7 +89,7 @@ extension DefaultRecommendService: RecommendService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: TasteRecommendNovels.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/Recommend/RecommendService.swift
+++ b/WSSiOS/WSSiOS/Network/Recommend/RecommendService.swift
@@ -29,7 +29,7 @@ extension DefaultRecommendService: RecommendService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Recommend.getTodayPopulars,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -49,7 +49,7 @@ extension DefaultRecommendService: RecommendService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Recommend.getRealtimePopulars,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -69,7 +69,7 @@ extension DefaultRecommendService: RecommendService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Recommend.getInterestFeeds,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -89,7 +89,7 @@ extension DefaultRecommendService: RecommendService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Recommend.getTasteRecommendNovels,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Search/SearchService.swift
+++ b/WSSiOS/WSSiOS/Network/Search/SearchService.swift
@@ -32,7 +32,7 @@ extension DefaultSearchService: SearchService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Search.sosoPick,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -58,7 +58,7 @@ extension DefaultSearchService: SearchService {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Search.normalSearch,
                                               queryItems: normalSearchQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -99,7 +99,7 @@ extension DefaultSearchService: SearchService {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Search.detailSearch,
                                               queryItems: detailSearchQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/Search/SearchService.swift
+++ b/WSSiOS/WSSiOS/Network/Search/SearchService.swift
@@ -20,12 +20,7 @@ protocol SearchService {
                             size: Int) -> Single<DetailSearchNovels>
 }
 
-final class DefaultSearchService: NSObject, Networking {
-    
-    private var urlSession = URLSession(configuration: URLSessionConfiguration.default,
-                                        delegate: nil,
-                                        delegateQueue: nil)
-}
+final class DefaultSearchService: NSObject, Networking { }
 
 extension DefaultSearchService: SearchService {
     func getSosopicks() -> Single<SosoPickNovels> {
@@ -37,7 +32,7 @@ extension DefaultSearchService: SearchService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: SosoPickNovels.self) }
                 .asSingle()
@@ -63,7 +58,7 @@ extension DefaultSearchService: SearchService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: NormalSearchNovels.self) }
                 .asSingle()
@@ -104,7 +99,7 @@ extension DefaultSearchService: SearchService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: DetailSearchNovels.self) }
                 .asSingle()

--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -29,10 +29,6 @@ final class DefaultUserService: NSObject, Networking {
             URLQueryItem(name: "birth", value: String(describing: birth))
         ]
     }
-    
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
 }
 
 extension DefaultUserService: UserService {
@@ -46,7 +42,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserResult.self) }
                 .asSingle()
@@ -71,7 +67,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -88,7 +84,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserCharacter.self) }
                 .asSingle()
@@ -106,7 +102,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserNovelStatus.self) }
                 .asSingle()
@@ -124,7 +120,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserInfo.self) }
                 .asSingle()
@@ -151,7 +147,7 @@ extension DefaultUserService: UserService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -40,7 +40,7 @@ extension DefaultUserService: UserService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.User.afterDelete,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             
@@ -66,7 +66,7 @@ extension DefaultUserService: UserService {
             let request = try makeHTTPRequest(method: .patch,
                                               path: URLs.User.patchUserNickname,
                                               queryItems: userNickNameQueryItems,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: userNickNameData)
             
             NetworkLogger.log(request: request)
@@ -83,7 +83,7 @@ extension DefaultUserService: UserService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.Avatar.getRepAvatar,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -101,7 +101,7 @@ extension DefaultUserService: UserService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.User.getUserNovelStatus,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -119,7 +119,7 @@ extension DefaultUserService: UserService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.User.userInfo,
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -146,7 +146,7 @@ extension DefaultUserService: UserService {
             let request = try makeHTTPRequest(method: .put,
                                               path: URLs.User.userInfo,
                                               queryItems: makeUserInfoQueryItems(gender: gender, birth: birth),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: userInfoData)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Network/UserNovel/UserNovelService.swift
+++ b/WSSiOS/WSSiOS/Network/UserNovel/UserNovelService.swift
@@ -29,10 +29,6 @@ final class DefaultUserNovelService: NSObject, Networking {
             URLQueryItem(name: "sortType", value: sortType)
         ]
     }
-    
-    private var urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default,
-                                                    delegate: nil,
-                                                    delegateQueue: nil)
 }
 
 extension DefaultUserNovelService: UserNovelService {
@@ -49,7 +45,7 @@ extension DefaultUserNovelService: UserNovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserNovelList.self) }
                 .asSingle()
@@ -67,7 +63,7 @@ extension DefaultUserNovelService: UserNovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
                                        to: UserNovelDetail.self) }
                 .asSingle()
@@ -85,7 +81,7 @@ extension DefaultUserNovelService: UserNovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {
@@ -111,7 +107,7 @@ extension DefaultUserNovelService: UserNovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: UserNovelId.self) }
                 .asSingle()
         } catch {
@@ -137,7 +133,7 @@ extension DefaultUserNovelService: UserNovelService {
             
             NetworkLogger.log(request: request)
             
-            return urlSession.rx.data(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Network/UserNovel/UserNovelService.swift
+++ b/WSSiOS/WSSiOS/Network/UserNovel/UserNovelService.swift
@@ -44,7 +44,7 @@ extension DefaultUserNovelService: UserNovelService {
                                                                              lastUserNovelId: lastUserNovelId,
                                                                              size: size,
                                                                              sortType: sortType),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -62,7 +62,7 @@ extension DefaultUserNovelService: UserNovelService {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.UserNovel.getUserNovel(userNovelId: userNovelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -80,7 +80,7 @@ extension DefaultUserNovelService: UserNovelService {
         do {
             let request = try makeHTTPRequest(method: .delete,
                                               path: URLs.UserNovel.deleteUserNovel(userNovelId: userNovelId),
-                                              headers: APIConstants.testTokenHeader,
+                                              headers: APIConstants.accessTokenHeader,
                                               body: nil)
             
             NetworkLogger.log(request: request)
@@ -106,7 +106,7 @@ extension DefaultUserNovelService: UserNovelService {
         do {
             let request = try makeHTTPRequest(method: .post,
                                                path: URLs.UserNovel.postUserNovel(novelId: novelId),
-                                               headers: APIConstants.testTokenHeader,
+                                               headers: APIConstants.accessTokenHeader,
                                                body: userNovelBasic)
             
             NetworkLogger.log(request: request)
@@ -132,7 +132,7 @@ extension DefaultUserNovelService: UserNovelService {
         do {
             let request = try makeHTTPRequest(method: .patch,
                                                path: URLs.UserNovel.patchUserNovel(userNovelId: userNovelId),
-                                               headers: APIConstants.testTokenHeader,
+                                               headers: APIConstants.accessTokenHeader,
                                                body: userNovelBasic)
             
             NetworkLogger.log(request: request)

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -38,7 +38,7 @@ enum StringLiterals {
         enum Title {
             static let home = "홈"
             static let search = "탐색"
-            static let feed = "피드"
+            static let feed = "수다"
             static let myPage = "My"
         }
     }

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -10,6 +10,7 @@ import Foundation
 enum URLs {
     enum Auth {
         static let loginWithApple = "/auth/login/apple"
+        static let reissue = "/reissue"
     }
     
     enum Onboarding {

--- a/WSSiOS/WSSiOS/Source/Data/DTO/AuthResult.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/AuthResult.swift
@@ -17,3 +17,12 @@ struct LoginResult: Codable {
     let refreshToken: String
     let isRegister: Bool
 }
+
+struct ReissueBody: Codable {
+    let refreshToken: String
+}
+
+struct ReissueResult: Codable {
+    let Authorization: String
+    let refreshToken: String
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewController/LoginViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewController/LoginViewController.swift
@@ -107,8 +107,7 @@ final class LoginViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 // 온보딩 뷰로 이동
-                print("Token: \(APIConstants.testToken)")
-                //owner.loginCompleted()
+                print("Token: \(APIConstants.accessToken)")
                 owner.pushToOnboardingViewController()
             })
             .disposed(by: disposeBag)
@@ -116,8 +115,8 @@ final class LoginViewController: UIViewController {
         output.navigateToHome
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
-                // 온보딩 뷰로 이동
-                print("Token: \(APIConstants.testToken)")
+                // 홈으로 이동
+                print("Token: \(APIConstants.accessToken)")
                 owner.loginCompleted()
             })
             .disposed(by: disposeBag)

--- a/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewModel/LoginViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewModel/LoginViewModel.swift
@@ -89,16 +89,12 @@ final class LoginViewModel: NSObject, ViewModelType {
             .subscribe(with: self, onNext: { owner, type in
                 switch type {
                 case .skip:
-                    APIConstants.isLogined = false
                     owner.navigateToHome.accept(())
                 case .kakao:
-                    APIConstants.isLogined = true
                     owner.navigateToOnboarding.accept(())
                 case .naver:
-                    APIConstants.isLogined = true
                     owner.navigateToOnboarding.accept(())
                 case .apple:
-                    APIConstants.isLogined = true
                     owner.requestAppleLogin() // 애플로그인 요청
                 }
             })
@@ -146,17 +142,6 @@ final class LoginViewModel: NSObject, ViewModelType {
             .subscribe(with: self, onNext: { owner, _ in
                 owner.autoScrollTrigger.accept(())
             })
-    }
-    
-    private func repositoryLoginMethod(type: LoginButtonType) -> Observable<LoginButtonType> {
-        // 레포지토리에 구현할 각 로그인 메서드. 아마 ..?
-        print("\(String(describing: type)) Login 성공")
-        if type == .skip {
-            APIConstants.isLogined = false
-        } else {
-            APIConstants.isLogined = true
-        }
-        return Observable.just(type)
     }
     
     private func requestAppleLogin() {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
close #321 
<br/>

### 🌟Motivation
- 자동 로그인을 구현합니다.
- 401 에러시 refresh Token으로 refresh & access Token을 자동으로 재발급 시도를 하며, 재발급에 실패할 경우 로그인 화면으로 이동합니다.
<br/>

### 🌟Key Changes

### **앞으로 Auth 서비스 외의 API 요청은 tokenCheckURLSession.rx.data(request:)로 해주시면 자동으로 토큰 체크 및 업데이트가 됩니다!**


### 자동 로그인
- APIConstants 의 타입 프로퍼티들을 수정하여 구현했습니다. 
- isTesting 값을 true나 false로 바꾸어서 사용할 토큰 값을 정합니다! 더 자세하게 설명하자면,
    - testToken은 Config에 저장해둔 토큰 값을 가져옵니다.
    - accessToken은 isTesting 값에 따라서 testToken을 가져오거나, UserDefaults의 실제 accessToken 값을 가져옵니다.
    - isLogined는 이 accessToken 값이 비어있는지에 따라 이미 로그인한 유저인지 아닌지 판단할 수 있게 합니다.
   
```swift
struct APIConstatns {
    // Config의 Test Token을 사용한다면, 이 값을 true로,
    // UserDefaults의 실제 토큰 값을 쓰려면 이 값을 false로 바꿀 것.
    static let isTesting: Bool = true
    
    static var isLogined: Bool {
        !accessToken.isEmpty
    }
    static var accessToken: String {
        isTesting ? testToken : UserDefaults.standard.value(forKey: StringLiterals.UserDefault.accessToken) as? String ?? ""
    }
    static var testToken: String = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.testToken) as? String ?? ""
}
```

- isLogined 값에 따라 바로 홈으로 이동하거나, 로그인VC로 이동하도록 하여 자동 로그인을 구현하였습니다.
```swift
class SceneDelegate: UIResponder, UIWindowSceneDelegate {
    
    var window: UIWindow?
    
    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        guard let windowScene = (scene as? UIWindowScene) else { return }
        
        self.window = UIWindow(windowScene: windowScene)
        
        APIConstants.isLogined ? setRootToWSSTabBarController() : setRootToLoginViewController()
        
        self.window?.makeKeyAndVisible()
    }
...
}
```

<br/>

### 401 대응 토큰 재발급
- 현재 서비스에 대한 401 처리를 모두 추가하지 않고 API 요청의 응답이 401이면 자동으로 토큰을 재발급 하도록 해야 합니다.
- Access Token은 30분마다 만료되고, Refresh Token은 2주마다 만료됩니다.
- 앱에 처음 진입할 때 뿐만 아니라, 30분이라는 짧은 유효기간으로 앱을 사용하다가도 만료될 수 있습니다 . .
- 따라서 모든 API 요청을 한 번 인터셉트 해서, 401 에러가 오는 경우 자동으로 토큰을 재발급하는 API를 시도해야 합니다 !

- 이를 위한 class가 바로 TokenCheckURLProtocol 입니다. 자세한 내용은 주석을 참고해 주세요!
https://github.com/Team-WSS/WSS-iOS/blob/9897a72772a1b512c14653863b486027ac868226/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift#L11-L120

- urlSession을 생성할 때 넣어주는 configuration에 TokenCheckURLProtocol을 넣어주면, 해당 class가 API 응답이 오기전에 결과를 인터셉트하여 먼저 확인한 뒤, 필요한 처리를 하고 다시 돌려줍니다. tokenCheckURLSession을 Networking protocol에 추가하고, 이를 사용해서 서비스가 통신하도록 전부 교체하였습니다. (Auth는 제외)

```swift 
protocol Networking {
    var tokenCheckURLSession: URLSession { get }
}

extension Networking {
    var tokenCheckURLSession: URLSession {
        // CustomURLProtocol을 URLSessionConfiguration에 등록
        let config = URLSessionConfiguration.default
        config.protocolClasses = [TokenCheckURLProtocol.self] + (config.protocolClasses ?? [])
        return URLSession(configuration: config,
                          delegate: nil,
                          delegateQueue: nil)
    }
}
```

- 

- 어떤 API가 Access Token을 통해 요청을 했는데 만료되어서 401 에러가 오는 경우 아래 과정이 진행됩니다.
- Reissue API를 통해, Access Token이 만료되었으므로 Refresh Token를 Request Body에 담아서 새로운 토큰 발급을 위한 API 요청을 합니다. (header에 토큰은 없이 요청함)
    - 요청이 성공하면, 유효기간이 새로 갱신된 30분 짜리 Access Token과 2주짜리 Refresh Token을 결과로 받아서 UserDefault에 저장합니다.
    그리고, 기존 API 요청의 Access Token 값을 새로 갱신된 Access Token으로 교체한 뒤 다시 API 요청을 합니다.
    - 요청이 실패하면, Refresh Token도 만료된 것이므로 UserDefault에 저장된 Access Token과 Refresh Token 모두 삭제하고, 로그인 화면으로 돌아가서 재 로그인하도록 합니다.


<br/>

### 🌟Simulation
- isTesting = true, testToken = "아무값"으로 두어서 테스트한 경우입니다.
- isLogined 는 true가 되기 때문에, 홈으로 진입하지만 유효하지 않은 토큰이므로 401 오류가 뜹니다.
- TokenCheckURLProtocol에서 토큰을 새로 발급받는 과정으로 들어가지만, refreshToken이 없어서 실패하고 결국 로그인 화면으로 돌아가는 것을 확인할 수 있습니다. (만약 실제로 로그인 해서 refresh Token이 있다면, accessToken이 재발급되어서 홈 진입 과정이 실패하지 않고 잘 이루어 질 겁니다!)
![Simulator Screen Recording - iPhone 15 Pro - 2024-11-12 at 00 19 17](https://github.com/user-attachments/assets/e1992cc2-a5f5-4e00-bc5c-a6678f73271a)

<br/>

### 🌟To Reviewer
- 이게 잘 된건지 테스트 해보고 싶은데.. 실제 로그인을 해볼 수 없어서 refresh Token으로 reIssue는 시도하지 못했네요. . . .
- 애플 로그인으로 시도해볼 수 있는 효원이 ..? 혹은 지원인가? 한번 테스트 해봐주면 좋을 것 같아용 . .
### **앞으로 Auth 서비스 외의 API 요청은 tokenCheckURLSession.rx.data(request:)로 해주시면 자동으로 토큰 체크 및 업데이트가 됩니다!**
- Service 자체 코드의 변화를 최소화 하려고 노력했는데,, 각 서비스가 자기가 직접 구현한 URLSession에 의존하고 있어서, 어쩔 수 없이 이를 모두 Networking 프로토콜에 구현해둔 URLSession을 사용하도록 교체했습니다.
토큰 자동 체크 및 업데이트가 필요한 API라면 tokenCheckURLSession을
필요하지 않다면 basicURLSession 을 사용하면 되는데, Auth 빼고는 다 tokenCheckURLSession을 쓰면 될겁니다!
- 서비스를 건드리지 않아도 되거나.. 하는 더 좋은 구현 방식이 있으면 제안 부탁드립니다 꼭이요 !

<br/>

### 🌟Reference
https://velog.io/@chuu1019/Access-Token과-Refresh-Token이란-무엇이고-왜-필요할까
<br/>
