### PR TITLE
[Fix] #342 - 일반탐색 내 무한스크롤 로직 수정 | 홈뷰 내 UI 디테일 반영

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
@@ -66,9 +66,13 @@ final class HomeInterestView: UIView {
     
     func updateView(_ isLogined: Bool, _ message: InterestMessage) {
         if isLogined {
+            // 로그인
             switch message {
             case .noInterestNovels:
-                titleLabel.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInInterest)
+                // 유저의 선호장르가 없을 때
+                if let nickname = userNickname {
+                    titleLabel.applyWSSFont(.headline1, with: "\(nickname)\(StringLiterals.Home.Title.interest)")
+                }
                 self.addSubviews(titleLabel,
                                  unregisterView)
                 titleLabel.snp.makeConstraints {
@@ -84,6 +88,7 @@ final class HomeInterestView: UIView {
                 interestEmptyView.removeFromSuperview()
                 subTitleLabel.removeFromSuperview()
             case .noAssociatedFeeds:
+                // 유저의 선호장르에 대한 글이 하나도 없을 때
                 titleLabel.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInInterest)
                 interestCollectionView.removeFromSuperview()
                 self.addSubviews(titleLabel,
@@ -100,6 +105,7 @@ final class HomeInterestView: UIView {
                 unregisterView.removeFromSuperview()
                 subTitleLabel.removeFromSuperview()
             case .none:
+                // 관심글이 존재할 때
                 if let nickname = userNickname {
                     titleLabel.applyWSSFont(.headline1, with: "\(nickname)\(StringLiterals.Home.Title.interest)")
                 }
@@ -123,6 +129,7 @@ final class HomeInterestView: UIView {
                 interestEmptyView.removeFromSuperview()
             }
         } else {
+            // 비로그인
             titleLabel.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInInterest)
             self.addSubviews(titleLabel,
                              unregisterView)

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeInterestView.swift
@@ -69,7 +69,7 @@ final class HomeInterestView: UIView {
             // 로그인
             switch message {
             case .noInterestNovels:
-                // 유저의 선호장르가 없을 때
+                // 유저의 관심작품이 없을 때
                 if let nickname = userNickname {
                     titleLabel.applyWSSFont(.headline1, with: "\(nickname)\(StringLiterals.Home.Title.interest)")
                 }
@@ -88,7 +88,7 @@ final class HomeInterestView: UIView {
                 interestEmptyView.removeFromSuperview()
                 subTitleLabel.removeFromSuperview()
             case .noAssociatedFeeds:
-                // 유저의 선호장르에 대한 글이 하나도 없을 때
+                // 유저의 관심작품에 대한 글이 하나도 없을 때
                 titleLabel.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInInterest)
                 interestCollectionView.removeFromSuperview()
                 self.addSubviews(titleLabel,

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeInterestCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeInterestCollectionViewCell.swift
@@ -195,7 +195,8 @@ final class HomeInterestCollectionViewCell: UICollectionViewCell {
             $0.lineBreakStrategy = .hangulWordPriority
             $0.numberOfLines = 2
         }
-        self.novelAverageRatingLabel.applyWSSFont(.body5, with: String(format: "%.1f", data.novelRating))
+        let roundedRating = round(data.novelRating * 10) / 10
+        self.novelAverageRatingLabel.applyWSSFont(.body5, with: String(roundedRating))
         self.novelRatingNumberLabel.applyWSSFont(.body5, with: "(\(data.novelRatingCount))")
         
         self.userProfileImageView.kfSetImage(url: makeBucketImageURLString(path: data.userAvatarImage))

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeTasteRecommendCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeTasteRecommendCollectionViewCell.swift
@@ -152,7 +152,8 @@ final class HomeTasteRecommendCollectionViewCell: UICollectionViewCell {
             $0.numberOfLines = 1
         }
         self.likeCountLabel.applyWSSFont(.body5, with: String(data.novelLikeCount))
-        self.ratingAverageLabel.applyWSSFont(.body5, with: String(format: "%.1f", data.novelRating))
+        let roundedRating = round(data.novelRating * 10) / 10
+        self.ratingAverageLabel.applyWSSFont(.body5, with: String(roundedRating))
         self.ratingCountLabel.applyWSSFont(.body5, with: "(\(data.novelRatingCount))")
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -85,8 +85,6 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
         let reachedBottom = rootView.resultView.scrollView.rx.didScroll
             .map { self.isNearBottomEdge() }
             .distinctUntilChanged()
-            .filter { $0 }
-            .map { _ in () }
             .asObservable()
         
         let collectionViewSwipeGesture = rootView.resultView.normalSearchCollectionView.rx.swipeGesture([.up, .down])


### PR DESCRIPTION
### ⭐️Issue
close #342 
<br/>

### 🌟Motivation
 - 일반탐색: `isFetching` 변수를 추가하여 무한스크롤 중복 요청 방지 반영했습니다.
 - 홈뷰: 관심글 내 상황에 대한 타이틀 분기처리를 수정했습니다. 
 - 홈뷰: 관심글 및 취향추천에서 작품평점값을 소수점 첫째자리에서 반올림한 값이 보여지도록 수정했습니다. 
<br/>

### 🌟Key Changes
네트워크 요청이 진행 중일떄에는 이외의 데이터가 fetching 되지 않도록 `isFetching` 이라는 변수를 추가했습니다. 
하쿠야고마워~
<br/>

### 🌟Simulation
- 홈뷰 관심글 수정사항 반영
비로그인일 때 : 관심글
유저의 관심작품이 없을 때: \(유저 닉네임)님의 관심글
관심작품은 있으나 그에 해당하는 글이 없을 때: 관심글 


https://github.com/user-attachments/assets/b0de1813-0222-48e8-aecc-6f8dddf787fa


<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
