### PR TITLE
[Fix] #378 - 카카오톡 설치 안된 경우 카카오 계정 로그인 되도록 구현

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewModel/LoginViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Login/LoginViewModel/LoginViewModel.swift
@@ -169,6 +169,14 @@ final class LoginViewModel: NSObject, ViewModelType {
     
     private func loginWithKakao(disposeBag: DisposeBag) {
         if (UserApi.isKakaoTalkLoginAvailable()) {
+            loginWithKakaoTalk(disposeBag: disposeBag)
+        } else {
+            loginWithKakaoAccount(disposeBag: disposeBag)
+        }
+    }
+    
+    private func loginWithKakaoTalk(disposeBag: DisposeBag) {
+        if (UserApi.isKakaoTalkLoginAvailable()) {
             UserApi.shared.rx.loginWithKakaoTalk()
                 .flatMapLatest{ oauthToken in
                     return self.authRepository.loginWithKakao(oauthToken)
@@ -183,6 +191,22 @@ final class LoginViewModel: NSObject, ViewModelType {
                 })
                 .disposed(by: disposeBag)
         }
+    }
+    
+    private func loginWithKakaoAccount(disposeBag: DisposeBag) {
+        UserApi.shared.rx.loginWithKakaoAccount()
+            .flatMapLatest{ oauthToken in
+                return self.authRepository.loginWithKakao(oauthToken)
+            }
+            .do(onNext: { _ in
+                print("LoginWithKakao Success.")
+            })
+            .subscribe(with: self, onNext: { owner, result in
+                owner.loginSuccess(result: result)
+            }, onError: { owner, error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
close #378 
<br/>

### 🌟Motivation
- 리젝사유인 카카오톡 미설치시 카카오계정 로그인을 구현합니다.

<br/>

### 🌟Key Changes
- 아주 약간의 수정만 있습니다.
- 
<br/>

### 🌟Simulation
- 카카오 계정 로그인
![Simulator Screen Recording - iPhone 16 Pro - 2024-12-06 at 19 48 30](https://github.com/user-attachments/assets/a2d5712e-aa59-474c-a7e2-a2dcc0cef4ba)
<br/>

### 🌟To Reviewer
- 카카오톡 설치 여부를 확인하고, 카카오톡이 없는 경우 카카오 계정 로그인이 가능하도록 수정했습니다.
<br/>

### 🌟Reference
- 카카오 개발자 공식 문서
<br/>
