### PR TITLE
[Feat] #387 - 앱 최소버전보다 작을 시 앱 강제 업데이트 기능 구현 

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		B9E566052C0452E500DB51FF /* NormalSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E566042C0452E500DB51FF /* NormalSearchResultView.swift */; };
 		B9F7401D2C047E360018D0C6 /* NormalSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F7401C2C047E360018D0C6 /* NormalSearchViewModel.swift */; };
 		B9FE59642BF11955005815AF /* InduceLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FE59632BF11955005815AF /* InduceLoginView.swift */; };
+		B9FF40A92D170DFE00A2B93E /* AppVersionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FF40A82D170DFE00A2B93E /* AppVersionResult.swift */; };
 		C9063A972BD3F868006AD8F9 /* HomeRealtimePopularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9063A962BD3F868006AD8F9 /* HomeRealtimePopularView.swift */; };
 		C95EADD92BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95EADD82BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift */; };
 		C96A0E1F2C9F2B9900A6EA87 /* FeedDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96A0E1E2C9F2B9000A6EA87 /* FeedDetailService.swift */; };
@@ -789,6 +790,7 @@
 		B9E566042C0452E500DB51FF /* NormalSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchResultView.swift; sourceTree = "<group>"; };
 		B9F7401C2C047E360018D0C6 /* NormalSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalSearchViewModel.swift; sourceTree = "<group>"; };
 		B9FE59632BF11955005815AF /* InduceLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InduceLoginView.swift; sourceTree = "<group>"; };
+		B9FF40A82D170DFE00A2B93E /* AppVersionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionResult.swift; sourceTree = "<group>"; };
 		C9063A962BD3F868006AD8F9 /* HomeRealtimePopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRealtimePopularView.swift; sourceTree = "<group>"; };
 		C95EADD82BD4FE4C0060CF1A /* HomeRealTimePopularFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRealTimePopularFeedView.swift; sourceTree = "<group>"; };
 		C96A0E1E2C9F2B9000A6EA87 /* FeedDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailService.swift; sourceTree = "<group>"; };
@@ -2240,6 +2242,7 @@
 				CD514C952CD5DC22007A27A8 /* AuthResult.swift */,
 				396C7C572CB24F68003C9712 /* OnboardingResult.swift */,
 				E45FEFA62CFC08CA00B73D80 /* MyFeedResult.swift */,
+				B9FF40A82D170DFE00A2B93E /* AppVersionResult.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -3135,6 +3138,7 @@
 				CD803B3B2C940B88006EBAF8 /* NovelReviewKeywordView.swift in Sources */,
 				B933BED32C4916DC00365077 /* KeywordBox.swift in Sources */,
 				A1EF355E2B52FAE600A94C53 /* UserNovelService.swift in Sources */,
+				B9FF40A92D170DFE00A2B93E /* AppVersionResult.swift in Sources */,
 				A1654F142B540513004F78E8 /* NetworkingServiceError.swift in Sources */,
 				2C536C302C8F1FE0004C5740 /* MyPageDeleteIDCheckView.swift in Sources */,
 				A1654F102B540504004F78E8 /* HTTPMethod.swift in Sources */,

--- a/WSSiOS/WSSiOS/Info.plist
+++ b/WSSiOS/WSSiOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APPSTORE_ID</key>
+	<string>$(APPSTORE_ID)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>BUCKET_URL</key>

--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -29,6 +29,7 @@ protocol UserService {
                               lastUserNovelId: Int,
                               size: Int,
                               sortType: String) -> Single<UserNovelList>
+    func getAppMinimumVersion() -> Single<AppMinimumVersion>
 }
 
 final class DefaultUserService: NSObject, Networking {
@@ -347,7 +348,11 @@ extension DefaultUserService: UserService {
         }
     }
     
-    func getUserNovelList(userId: Int, readStatus: String, lastUserNovelId: Int, size: Int, sortType: String) -> RxSwift.Single<UserNovelList> {
+    func getUserNovelList(userId: Int,
+                          readStatus: String,
+                          lastUserNovelId: Int,
+                          size: Int,
+                          sortType: String) -> Single<UserNovelList> {
             do {
                 let request = try makeHTTPRequest(method: .get,
                                                   path: URLs.User.getUserNovel(userId: userId),
@@ -368,4 +373,24 @@ extension DefaultUserService: UserService {
                 return Single.error(error)
             }
         }
+    
+    func getAppMinimumVersion() -> Single<AppMinimumVersion> {
+        let appMinimumVersionQueryItem: [URLQueryItem] = [URLQueryItem(name: "os", value: "ios")]
+        do {
+            let request = try makeHTTPRequest(method: .get,
+                                              path: URLs.User.getAppMinimumVersion,
+                                              queryItems: appMinimumVersionQueryItem,
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+
+            NetworkLogger.log(request: request)
+
+            return tokenCheckURLSession.rx.data(request: request)
+                .map { try self.decode(data: $0,
+                                       to: AppMinimumVersion.self) }
+                .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
 }

--- a/WSSiOS/WSSiOS/Resource/Constants/Config/Config.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Config/Config.swift
@@ -14,6 +14,7 @@ enum Config {
             static let testToken = "TEST_TOKEN"
             static let bucketURL = "BUCKET_URL"
             static let kakaoAppKey = "KAKAO_APP_KEY"
+            static let appStoreID = "APPSTORE_ID"
         }
     }
     

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -667,6 +667,10 @@ enum StringLiterals {
         static let title = "업데이트 알림"
         static let content = "웹소소 세계에 변화가 생겼어요!\n지금 업데이트해보세요."
         static let buttonTitle = "업데이트"
-        static let appStoreURL = ""
+        
+        static var appStoreID: String {
+            return Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.appStoreID) as? String ?? "Error"
+        }
+        static let appStoreURL = "itms-apps://itunes.apple.com/app/\(appStoreID)"
     }
 }

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -662,4 +662,11 @@ enum StringLiterals {
         static let blckedUser = "차단한 유저"
         static let blockedComment = "차단한 유저의 댓글"
     }
+    
+    enum AppMinimumVersion {
+        static let title = "업데이트 알림"
+        static let content = "웹소소 세계에 변화가 생겼어요!\n지금 업데이트해보세요."
+        static let buttonTitle = "업데이트"
+        static let appStoreURL = ""
+    }
 }

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -668,6 +668,9 @@ enum StringLiterals {
         static let content = "웹소소 세계에 변화가 생겼어요!\n지금 업데이트해보세요."
         static let buttonTitle = "업데이트"
         
+        static var bundleVersion: String {
+            return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        }
         static var appStoreID: String {
             return Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.appStoreID) as? String ?? "Error"
         }

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -44,8 +44,9 @@ enum URLs {
             return "\(userBasePath)/\(userId)/feeds"
         }
         static func getUserNovel(userId: Int) -> String {
-                    return "\(userBasePath)/\(userId)/novels"
-                }
+            return "\(userBasePath)/\(userId)/novels"
+        }
+        static let getAppMinimumVersion = "/minimum-version"
     }
     
     enum Novel {

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -201,13 +201,15 @@ extension UIViewController {
                                       contentText: String?,
                                       leftTitle: String?,
                                       rightTitle: String?,
-                                      rightBackgroundColor: CGColor?) -> Observable<AlertButtonType> {
+                                      rightBackgroundColor: CGColor?,
+                                      isDismissable: Bool = true) -> Observable<AlertButtonType> {
         let alertViewController = WSSAlertViewController(iconImage: iconImage,
                                                          titleText: titleText,
                                                          contentText: contentText,
                                                          leftTitle: leftTitle,
                                                          rightTitle: rightTitle,
-                                                         rightBackgroundColor: rightBackgroundColor)
+                                                         rightBackgroundColor: rightBackgroundColor,
+                                                         isDismissable: isDismissable)
         alertViewController.modalPresentationStyle = .overFullScreen
         alertViewController.modalTransitionStyle = .crossDissolve
         

--- a/WSSiOS/WSSiOS/Source/Data/DTO/AppVersionResult.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/AppVersionResult.swift
@@ -1,0 +1,13 @@
+//
+//  AppVersionResult.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 12/21/24.
+//
+
+import Foundation
+
+struct AppMinimumVersion: Decodable {
+    var minimumVersion: String
+    var updateDate: String
+}

--- a/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository.swift
@@ -32,6 +32,7 @@ protocol UserRepository {
                           lastUserNovelId: Int,
                           size: Int,
                           sortType: String) -> Observable<UserNovelList>
+    func getAppMinimumVersion() -> Observable<AppMinimumVersion>
 }
 
 struct DefaultUserRepository: UserRepository {
@@ -132,11 +133,16 @@ struct DefaultUserRepository: UserRepository {
     }
     
     func getUserNovelList(userId: Int, readStatus: String, lastUserNovelId: Int, size: Int, sortType: String) -> Observable<UserNovelList> {
-            return userService.getUserNovelList(userId: userId,
-                                                readStatus: readStatus,
-                                                lastUserNovelId: lastUserNovelId,
-                                                size: size,
-                                                sortType: sortType)
+        return userService.getUserNovelList(userId: userId,
+                                            readStatus: readStatus,
+                                            lastUserNovelId: lastUserNovelId,
+                                            size: size,
+                                            sortType: sortType)
+        .asObservable()
+    }
+    
+    func getAppMinimumVersion() -> Observable<AppMinimumVersion> {
+        return userService.getAppMinimumVersion()
             .asObservable()
-        }
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/AlertButton/WSSAlertViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/AlertButton/WSSAlertViewController.swift
@@ -28,6 +28,8 @@ final class WSSAlertViewController: UIViewController {
     private var rightTitle: String?
     private var rightBackgroundColor: CGColor?
     
+    private var isDismissable: Bool
+    
     private let leftButtonTapSubject = PublishSubject<Void>()
     var leftButtonTap: Observable<Void> {
         return leftButtonTapSubject.asObservable()
@@ -49,7 +51,8 @@ final class WSSAlertViewController: UIViewController {
          contentText: String?,
          leftTitle: String?,
          rightTitle: String?,
-         rightBackgroundColor: CGColor?) {
+         rightBackgroundColor: CGColor?,
+         isDismissable: Bool) {
         
         self.alertIconImage = iconImage
         self.alertTitle = titleText
@@ -57,6 +60,7 @@ final class WSSAlertViewController: UIViewController {
         self.leftTitle = leftTitle
         self.rightTitle = rightTitle
         self.rightBackgroundColor = rightBackgroundColor
+        self.isDismissable = isDismissable
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -87,7 +91,9 @@ final class WSSAlertViewController: UIViewController {
             .bind(with: self, onNext: { owner, _ in
                 owner.leftButtonTapSubject.onNext(())
                 print("\(String(describing: owner.leftTitle))Button Tap 💖")
-                owner.dismiss(animated: true)
+                if owner.isDismissable {
+                    owner.dismiss(animated: true)
+                }
             })
             .disposed(by: disposeBag)
         
@@ -96,7 +102,9 @@ final class WSSAlertViewController: UIViewController {
             .bind(with: self, onNext: { owner, _ in
                 owner.rightButtonTapSubject.onNext(())
                 print("\(String(describing: owner.rightTitle))Button Tap 💖")
-                owner.dismiss(animated: true)
+                if owner.isDismissable {
+                    owner.dismiss(animated: true)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -237,7 +237,8 @@ final class HomeViewController: UIViewController {
                                                          contentText: StringLiterals.AppMinimumVersion.content,
                                                          leftTitle: nil,
                                                          rightTitle: StringLiterals.AppMinimumVersion.buttonTitle,
-                                                         rightBackgroundColor: UIColor.wssPrimary100.cgColor)
+                                                         rightBackgroundColor: UIColor.wssPrimary100.cgColor,
+                                                         isDismissable: false)
             }
             .subscribe(with: self, onNext: { owner, buttonType in
                 guard let url = URL(string: StringLiterals.AppMinimumVersion.appStoreURL) else { return }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -228,6 +228,24 @@ final class HomeViewController: UIViewController {
                 owner.rootView.showLoadingView(isShow: isShow)
             })
             .disposed(by: disposeBag)
+        
+        output.showUpdateVersionAlertView
+            .observe(on: MainScheduler.instance)
+            .flatMapLatest { _ -> Observable<AlertButtonType> in
+                return self.presentToAlertViewController(iconImage: .icWarning,
+                                                         titleText: StringLiterals.AppMinimumVersion.title,
+                                                         contentText: StringLiterals.AppMinimumVersion.content,
+                                                         leftTitle: nil,
+                                                         rightTitle: StringLiterals.AppMinimumVersion.buttonTitle,
+                                                         rightBackgroundColor: UIColor.wssPrimary100.cgColor)
+            }
+            .subscribe(with: self, onNext: { owner, buttonType in
+                guard let url = URL(string: StringLiterals.AppMinimumVersion.appStoreURL) else { return }
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     //MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -242,9 +242,7 @@ final class HomeViewController: UIViewController {
             }
             .subscribe(with: self, onNext: { owner, buttonType in
                 guard let url = URL(string: StringLiterals.AppMinimumVersion.appStoreURL) else { return }
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                }
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -147,7 +147,7 @@ extension HomeViewModel {
         input.viewWillAppearEvent
             .flatMapLatest { self.getAppMinimumVersion() }
             .subscribe(with: self, onNext: { owner, versionInfo in
-                let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+                let currentVersion = StringLiterals.AppMinimumVersion.bundleVersion
                 if currentVersion < versionInfo.minimumVersion {
                     owner.showUpdateVersionAlertView.accept(())
                 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -148,7 +148,7 @@ extension HomeViewModel {
             .flatMapLatest { self.getAppMinimumVersion() }
             .subscribe(with: self, onNext: { owner, versionInfo in
                 let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-                if currentVersion != versionInfo.minimumVersion {
+                if currentVersion < versionInfo.minimumVersion {
                     owner.showUpdateVersionAlertView.accept(())
                 }
             })

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -43,6 +43,7 @@ final class HomeViewModel: ViewModelType {
     let showInduceLoginModalView = PublishRelay<Void>()
     
     private let showLoadingView = PublishRelay<Bool>()
+    private let showUpdateVersionAlertView = PublishRelay<Void>()
     
     // MARK: - Inputs
     
@@ -79,6 +80,7 @@ final class HomeViewModel: ViewModelType {
         let pushToAnnouncementViewController: Observable<Void>
         let showInduceLoginModalView: Observable<Void>
         let showLoadingView: Observable<Bool>
+        let showUpdateVersionAlertView: Observable<Void>
     }
     
     //MARK: - init
@@ -139,6 +141,16 @@ extension HomeViewModel {
             }, onError: { owner, error in
                 owner.realtimePopularList.onError(error)
                 owner.showLoadingView.accept(false)
+            })
+            .disposed(by: disposeBag)
+        
+        input.viewWillAppearEvent
+            .flatMapLatest { self.getAppMinimumVersion() }
+            .subscribe(with: self, onNext: { owner, versionInfo in
+                let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+                if currentVersion != versionInfo.minimumVersion {
+                    owner.showUpdateVersionAlertView.accept(())
+                }
             })
             .disposed(by: disposeBag)
         
@@ -228,7 +240,8 @@ extension HomeViewModel {
                       pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
                       pushToAnnouncementViewController: pushToAnnouncementViewController.asObservable(),
                       showInduceLoginModalView: showInduceLoginModalView.asObservable(),
-                      showLoadingView: showLoadingView.asObservable())
+                      showLoadingView: showLoadingView.asObservable(),
+                      showUpdateVersionAlertView: showUpdateVersionAlertView.asObservable())
     }
     
     //MARK: - API
@@ -256,5 +269,10 @@ extension HomeViewModel {
     // 취향추천 작품 조회
     func getTasteRecommendNovels() -> Observable<TasteRecommendNovels> {
         return recommendRepository.getTasteRecommendNovels()
+    }
+    
+    // 앱 최소 버전 조회
+    func getAppMinimumVersion() -> Observable<AppMinimumVersion> {
+        return userRepository.getAppMinimumVersion()
     }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #387 
<br/>

### 🌟Motivation
- 앱 최소버전보다 작을 시 앱 강제 업데이트 기능 구현했습니다. 
<br/>

### 🌟Key Changes
#### 📓 앱스토어 링크에 필요한 앱스토어 아이디 `Config`에 저장
레퍼런스 찾아보니까 앱스토어 아이디는 대체로 숨기더라고요! 
Debug, Release Config 파일 내에 추가해주시면 됩니다. (카톡 확인 ♡)

#### 📓 `WSSAlertViewController` 내 `isDismissable` 변수 추가 
앱 버전 업데이트 알럿이 뜰 때에는 업데이트 하기 전까진 계속 알럿이 떠야해서 버튼을 선택하면 `dismiss`되게 하는 걸 선택적으로 적용될 수 있도록 변수를 추가했습니다. 
```
final class WSSAlertViewController: UIViewController {
    
    //MARK: - Properties

    private var isDismissable: Bool
    
    private func bindGesture() {
    rootView.leftButton.rx.tap
        .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
        .bind(with: self, onNext: { owner, _ in
            owner.leftButtonTapSubject.onNext(())
            print("\(String(describing: owner.leftTitle))Button Tap 💖")
            if owner.isDismissable {
                owner.dismiss(animated: true)
            }
        })
        .disposed(by: disposeBag)
        
    rootView.rightButton.rx.tap
        .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
        .bind(with: self, onNext: { owner, _ in
            owner.rightButtonTapSubject.onNext(())
            print("\(String(describing: owner.rightTitle))Button Tap 💖")
            if owner.isDismissable {
                owner.dismiss(animated: true)
            }
        })
        .disposed(by: disposeBag)
}
```
`isDismissable` 기본 값은 `true`로 설정해두고 예외상황일때에는 `false`로 설정될 수 있도록 했습니다. 
```
func presentToAlertViewController(iconImage: UIImage?,
                                      titleText: String?,
                                      contentText: String?,
                                      leftTitle: String?,
                                      rightTitle: String?,
                                      rightBackgroundColor: CGColor?,
                                      isDismissable: Bool = true) -> Observable<AlertButtonType> {
        let alertViewController = WSSAlertViewController(iconImage: iconImage,
                                                         titleText: titleText,
                                                         contentText: contentText,
                                                         leftTitle: leftTitle,
                                                         rightTitle: rightTitle,
                                                         rightBackgroundColor: rightBackgroundColor,
                                                         isDismissable: isDismissable)
        alertViewController.modalPresentationStyle = .overFullScreen
        alertViewController.modalTransitionStyle = .crossDissolve
```
<br/>

### 🌟Simulation
#### ⚠️주의⚠️ 시뮬레이터에서 돌리면 앱스토어 링크가 유효하지 않다고 합니다! 실기기에서 돌려야 잘 동작해요.
#### 어떻게 알았냐고요? 저도 알고싶지 않았음.
https://github.com/user-attachments/assets/290e9ef1-cf6d-4fdb-84ed-a7467b346bff


<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference
[[Swift iOS] url scheme 스키마 사용하여 외부 앱 실행 및 앱스토어 이동](https://hongssup.tistory.com/227)
[iOS 앱 강제 업데이트 요구하기](https://ggasoon2.tistory.com/67)
<br/>
