### PR TITLE
[Fix] #397 - 소소픽 데이터 조회 실시간 반영되도록 수정 

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewController/SearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewController/SearchViewController.swift
@@ -56,12 +56,6 @@ final class SearchViewController: UIViewController {
         bindViewModel()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     //MARK: - UI
     
     private func setUI() {

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewController/SearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewController/SearchViewController.swift
@@ -18,6 +18,8 @@ final class SearchViewController: UIViewController {
     private let viewModel: SearchViewModel
     private let disposeBag = DisposeBag()
     
+    private let viewWillAppearEvent = PublishRelay<Void>()
+    
     //MARK: - Components
     
     private let rootView = SearchView()
@@ -42,6 +44,7 @@ final class SearchViewController: UIViewController {
         
         showTabBar()
         setNavigationBar()
+        viewWillAppearEvent.accept(())
     }
     
     override func viewDidLoad() {
@@ -79,6 +82,7 @@ final class SearchViewController: UIViewController {
     
     private func bindViewModel() {
         let input = SearchViewModel.Input(
+            viewWillAppearEvent: viewWillAppearEvent.asObservable(),
             searhBarDidTap: rootView.searchbarView.rx.tapGesture().when(.recognized).asObservable(),
             induceButtonDidTap: rootView.searchDetailInduceView.rx.tapGesture().when(.recognized).asObservable(),
             sosoPickCellSelected: rootView.sosopickView.sosopickCollectionView.rx.itemSelected.asObservable(),

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewModel/SearchViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/Search/SearchViewModel/SearchViewModel.swift
@@ -12,7 +12,7 @@ import RxCocoa
 import RxGesture
 
 final class SearchViewModel: ViewModelType {
-
+    
     //MARK: - Properties
     
     private let searchRepository: SearchRepository
@@ -23,6 +23,7 @@ final class SearchViewModel: ViewModelType {
     //MARK: - Inputs
     
     struct Input {
+        let viewWillAppearEvent: Observable<Void>
         let searhBarDidTap: Observable<UITapGestureRecognizer>
         let induceButtonDidTap: Observable<UITapGestureRecognizer>
         let sosoPickCellSelected: Observable<IndexPath>
@@ -42,7 +43,7 @@ final class SearchViewModel: ViewModelType {
     }
     
     //MARK: - init
-  
+    
     init(searchRepository: SearchRepository) {
         self.searchRepository = searchRepository
     }
@@ -60,7 +61,10 @@ extension SearchViewModel {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        self.getSosoPickNovels()
+        input.viewWillAppearEvent
+            .flatMapLatest {
+                self.getSosoPickNovels()
+            }
             .do(onNext: { _ in
                 output.showLoadingView.accept(true)
             })


### PR DESCRIPTION
### ⭐️Issue
- close #397 
<br/>

### 🌟Motivation
- 소소픽 데이터 조회 실시간 반영되도록 수정했습니다. 
- SearchVC 내 viewWillDisappear 코드 제거 했습니다. 
<br/>

### 🌟Key Changes
#### SearchVC 내 viewWillDisappear 코드 삭제
기존에 Notification 코드를 짜면서 `addObserver` 를 할용할 때 작성해두었던 메모리 해제 코드를 다 지우지 않았던 것 같습니다. 
지금은 `rx.notification` 을 활용하여 `.disposed(disposeBag)` 로 메모리 해제를 하고 있어서 해당 코드가 필요 없다는 판단에 삭제했습니다 !
```swift
override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)

    NotificationCenter.default.removeObserver(self)
}
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2024-12-27 at 19 17 33](https://github.com/user-attachments/assets/b212a56e-5ab4-4597-bd57-4267e8feb9f1)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
