### PR TITLE
[Fix] #376 - 삭제된 글 클릭 시 모달 Alert 기능 구현 

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -308,6 +308,8 @@
 		B974EA472CC902E800169639 /* DetailSearchResultHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B974EA462CC902E800169639 /* DetailSearchResultHeaderView.swift */; };
 		B974EA492CC905BB00169639 /* DetailSearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B974EA482CC905BB00169639 /* DetailSearchResultViewController.swift */; };
 		B98748632C3581A70039ACE5 /* NormalSearchCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E565FB2C04526000DB51FF /* NormalSearchCollectionViewCell.swift */; };
+		B99FBE3E2D21B6E500787D1C /* FeedDetailUnknownUserErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FBE3D2D21B6E500787D1C /* FeedDetailUnknownUserErrorView.swift */; };
+		B99FBE402D21B98700787D1C /* FeedDetailUnknownUserErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FBE3F2D21B98700787D1C /* FeedDetailUnknownUserErrorViewController.swift */; };
 		B9A0FD6C2BFCF0080004252E /* HomeRealtimePopularCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A0FD6B2BFCF0080004252E /* HomeRealtimePopularCollectionViewCell.swift */; };
 		B9AC1BD02BF0B33E006EDE92 /* HomeNoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AC1BCF2BF0B33E006EDE92 /* HomeNoticeViewController.swift */; };
 		B9AC1BD22BF0B485006EDE92 /* HomeNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AC1BD12BF0B485006EDE92 /* HomeNoticeView.swift */; };
@@ -769,6 +771,8 @@
 		B974EA442CC9029100169639 /* DetailSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchResultView.swift; sourceTree = "<group>"; };
 		B974EA462CC902E800169639 /* DetailSearchResultHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchResultHeaderView.swift; sourceTree = "<group>"; };
 		B974EA482CC905BB00169639 /* DetailSearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchResultViewController.swift; sourceTree = "<group>"; };
+		B99FBE3D2D21B6E500787D1C /* FeedDetailUnknownUserErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailUnknownUserErrorView.swift; sourceTree = "<group>"; };
+		B99FBE3F2D21B98700787D1C /* FeedDetailUnknownUserErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailUnknownUserErrorViewController.swift; sourceTree = "<group>"; };
 		B9A0FD6B2BFCF0080004252E /* HomeRealtimePopularCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRealtimePopularCollectionViewCell.swift; sourceTree = "<group>"; };
 		B9AC1BCF2BF0B33E006EDE92 /* HomeNoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNoticeViewController.swift; sourceTree = "<group>"; };
 		B9AC1BD12BF0B485006EDE92 /* HomeNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNoticeView.swift; sourceTree = "<group>"; };
@@ -2343,6 +2347,7 @@
 			isa = PBXGroup;
 			children = (
 				B96098872C27421F0084F697 /* FeedDetailViewController.swift */,
+				B99FBE3F2D21B98700787D1C /* FeedDetailUnknownUserErrorViewController.swift */,
 			);
 			path = FeedDetailViewController;
 			sourceTree = "<group>";
@@ -2438,6 +2443,7 @@
 				B96F0F932C298F3F00DA5483 /* FeedDetailReplyView.swift */,
 				C9D56ED52C9D2B4D00FEDFDA /* FeedDetailReplyWritingView.swift */,
 				C9CE229A2CBD5ECE00996225 /* FeedDetailDropdownView.swift */,
+				B99FBE3D2D21B6E500787D1C /* FeedDetailUnknownUserErrorView.swift */,
 			);
 			path = FeedDetailAssistantView;
 			sourceTree = "<group>";
@@ -3116,6 +3122,7 @@
 				39099EF52CD8AF6D00FCA8DE /* WSSNetworkErrorView.swift in Sources */,
 				2C536C2E2C8F1F21004C5740 /* MyPageDeleteIDReasonView.swift in Sources */,
 				395928A02C99527500E7B17B /* LoginSkipButton.swift in Sources */,
+				B99FBE402D21B98700787D1C /* FeedDetailUnknownUserErrorViewController.swift in Sources */,
 				B971D8792C0388E0008934D8 /* SearchRepository.swift in Sources */,
 				E407466E2CE897C7005D75D5 /* MyPageGenrePreferencesTopView.swift in Sources */,
 				CDC03F512CA6C5CD002D301F /* NovelReviewResult.swift in Sources */,
@@ -3243,6 +3250,7 @@
 				CDC03F4D2CA6C492002D301F /* NovelReviewService.swift in Sources */,
 				2CD2FE402C43E7B60033366C /* WSSAlertViewController.swift in Sources */,
 				2C8F89512C50E5200056895B /* MyPageDeleteIDReasonTableViewCell.swift in Sources */,
+				B99FBE3E2D21B6E500787D1C /* FeedDetailUnknownUserErrorView.swift in Sources */,
 				2CD2291E2B42E685005400BE /* SceneDelegate.swift in Sources */,
 				CDF27CDA2CA253B30072C0F7 /* AttractivePoint.swift in Sources */,
 				2CD911612C0D8B71006B8D72 /* FeedViewModel.swift in Sources */,

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -661,6 +661,8 @@ enum StringLiterals {
         static let spoilerComment = "스포일러가 포함된 댓글 보기"
         static let blckedUser = "차단한 유저"
         static let blockedComment = "차단한 유저의 댓글"
+        
+        static let notFoundFeed = "해당 글을 찾을 수 없어요"
     }
     
     enum AppMinimumVersion {

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -461,6 +461,14 @@ extension UIViewController {
                 profileData: useData))
         self.navigationController?.pushViewController(viewController, animated: false)
     }
+    
+    func presentToFeedDetailUnknownUserErrorViewController() {
+        let feedDetailUnknownUserErrorViewController = FeedDetailUnknownUserErrorViewController()
+        feedDetailUnknownUserErrorViewController.modalPresentationStyle = .overFullScreen
+        feedDetailUnknownUserErrorViewController.modalTransitionStyle = .crossDissolve
+        
+        self.present(feedDetailUnknownUserErrorViewController, animated: true)
+    }
 }
 
 extension UIViewController: @retroactive UIGestureRecognizerDelegate {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailUnknownUserErrorView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailUnknownUserErrorView.swift
@@ -1,0 +1,97 @@
+//
+//  FeedDetailUnknownUserErrorView.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 12/30/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedDetailUnknownUserErrorView: UIView {
+    
+    //MARK: - UI Components
+    
+    private let backgroundView = UIView()
+    private let stackView = UIStackView()
+    private let errorContentLabel = UILabel()
+    let confirmationButton = UIButton()
+    private let confirmationButtonLabel = UILabel()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.backgroundColor = .wssBlack.withAlphaComponent(0.6)
+        
+        backgroundView.do {
+            $0.backgroundColor = .wssWhite
+            $0.layer.cornerRadius = 12
+        }
+        
+        stackView.do {
+            $0.axis = .vertical
+            $0.alignment = .center
+            $0.spacing = 24
+        }
+        
+        errorContentLabel.do {
+            $0.applyWSSFont(.title2, with: StringLiterals.FeedDetail.notFoundFeed)
+            $0.textColor = .wssBlack
+        }
+        
+        confirmationButton.do {
+            $0.layer.backgroundColor = UIColor.wssGray70.cgColor
+            $0.layer.cornerRadius = 8
+        }
+        
+        confirmationButtonLabel.do {
+            $0.isUserInteractionEnabled = false
+            $0.applyWSSFont(.body4, with: StringLiterals.FeedDetail.confirm)
+            $0.textColor = .wssGray300
+        }
+    }
+    
+    private func setHierarchy() {
+        self.addSubview(backgroundView)
+        backgroundView.addSubview(stackView)
+        stackView.addArrangedSubviews(errorContentLabel,
+                                      confirmationButton)
+        confirmationButton.addSubview(confirmationButtonLabel)
+    }
+    
+    private func setLayout() {
+        backgroundView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(41.5)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(29)
+        }
+        
+        confirmationButton.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+        
+        confirmationButtonLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
@@ -29,6 +29,7 @@ final class FeedDetailView: UIView {
     private let replyBottomView = UIView()
     
     private let loadingView = WSSLoadingView()
+    private let networkErrorView = WSSNetworkErrorView()
     
     // MARK: - Life Cycle
     
@@ -79,6 +80,10 @@ final class FeedDetailView: UIView {
         loadingView.do {
             $0.isHidden = true
         }
+        
+        networkErrorView.do {
+            $0.isHidden = true
+        }
     }
     
     private func setHierarchy() {
@@ -86,7 +91,8 @@ final class FeedDetailView: UIView {
                          replyWritingView,
                          replyBottomView,
                          dropdownView,
-                         loadingView)
+                         loadingView,
+                         networkErrorView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(profileView,
                                 feedContentView,
@@ -146,6 +152,10 @@ final class FeedDetailView: UIView {
         loadingView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+        
+        networkErrorView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
     
     //MARK: - Custom Methods
@@ -157,5 +167,9 @@ final class FeedDetailView: UIView {
     
     func showLoadingView(isShow: Bool) {
         loadingView.isHidden = !isShow
+    }
+    
+    func showNetworkErrorView() {
+        networkErrorView.isHidden = false
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownUserErrorViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownUserErrorViewController.swift
@@ -34,9 +34,9 @@ final class FeedDetailUnknownUserErrorViewController: UIViewController {
         rootView.confirmationButton.rx.tap
             .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
-                owner.dismiss(animated: true)
                 NotificationCenter.default.post(name: owner.popFeedDetailViewControllerNotificationName,
                                                 object: nil)
+                owner.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownUserErrorViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownUserErrorViewController.swift
@@ -1,0 +1,43 @@
+//
+//  FeedDetailUnknownUserErrorViewController.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 12/30/24.
+//
+
+import UIKit
+
+import RxSwift
+
+final class FeedDetailUnknownUserErrorViewController: UIViewController {
+    
+    //MARK: - Properties
+    
+    private let disposeBag = DisposeBag()
+    private let popFeedDetailViewControllerNotificationName = Notification.Name("PopFeedDetailViewControllerNotificationName")
+    
+    //MARK: - UI Components
+    
+    private let rootView = FeedDetailUnknownUserErrorView()
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        bindAction()
+    }
+    
+    private func bindAction() {
+        rootView.confirmationButton.rx.tap
+            .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, _ in
+                owner.dismiss(animated: true)
+                NotificationCenter.default.post(name: owner.popFeedDetailViewControllerNotificationName,
+                                                object: nil)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -500,6 +500,20 @@ final class FeedDetailViewController: UIViewController {
                 owner.rootView.showLoadingView(isShow: isShow)
             })
             .disposed(by: disposeBag)
+        
+        output.showNetworkErrorView
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, _ in
+                owner.rootView.showNetworkErrorView()
+            })
+            .disposed(by: disposeBag)
+        
+        output.showUnknownUserAlertView
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, _ in
+                
+            })
+            .disposed(by: disposeBag)
     }
 }
 extension FeedDetailViewController: UICollectionViewDelegateFlowLayout {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -129,7 +129,8 @@ final class FeedDetailViewController: UIViewController {
             profileViewDidTap: profileViewDidTap.asObservable(),
             commentdotsButtonDidTap: commentDotsButtonDidTap.asObservable(),
             commentDropdownDidTap: commentDropdownButtonDidTap,
-            reloadComments: reloadComments.asObservable()
+            reloadComments: reloadComments.asObservable(),
+            popFeedDetailViewControllerNotification: NotificationCenter.default.rx.notification(Notification.Name("PopFeedDetailViewControllerNotificationName")).asObservable()
         )
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         
@@ -158,7 +159,8 @@ final class FeedDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.popViewController
-            .drive(with: self, onNext: { owner, _ in
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, _ in
                 owner.popToLastViewController()
             })
             .disposed(by: disposeBag)
@@ -511,7 +513,7 @@ final class FeedDetailViewController: UIViewController {
         output.showUnknownUserAlertView
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
-                
+                owner.presentToFeedDetailUnknownUserErrorViewController()
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -69,6 +69,8 @@ final class FeedDetailViewModel: ViewModelType {
     
     let pushToUserPageViewController = PublishRelay<Int>()
     private let showLoadingView = PublishRelay<Bool>()
+    private let showNetworkErrorView = PublishRelay<Void>()
+    private let showUnknownUserAlertView = PublishRelay<Void>()
     
     //MARK: - Life Cycle
     
@@ -155,6 +157,8 @@ final class FeedDetailViewModel: ViewModelType {
         
         let pushToUserPageViewController: Observable<Int>
         let showLoadingView: Observable<Bool>
+        let showNetworkErrorView: Observable<Void>
+        let showUnknownUserAlertView: Observable<Void>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -469,7 +473,9 @@ final class FeedDetailViewModel: ViewModelType {
                       myCommentEditing: myCommentEditing.asObservable(),
                       showCommentDeleteAlertView: showCommentDeleteAlertView.asObservable(),
                       pushToUserPageViewController: pushToUserPageViewController.asObservable(),
-                      showLoadingView: showLoadingView.asObservable())
+                      showLoadingView: showLoadingView.asObservable(),
+                      showNetworkErrorView: showNetworkErrorView.asObservable(),
+                      showUnknownUserAlertView: showUnknownUserAlertView.asObservable())
     }
     
     //MARK: - API

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchViewController.swift
@@ -58,9 +58,9 @@ final class DetailSearchViewController: UIViewController, UIScrollViewDelegate {
         rootView.detailSearchInfoView.genreCollectionView
             .register(DetailSearchInfoGenreCollectionViewCell.self,
                       forCellWithReuseIdentifier: DetailSearchInfoGenreCollectionViewCell.cellIdentifier)
-        rootView.detailSearchKeywordView.novelSelectedKeywordListView.selectedKeywordCollectionView
         
         //키워드뷰
+        rootView.detailSearchKeywordView.novelSelectedKeywordListView.selectedKeywordCollectionView
             .register(NovelSelectedKeywordCollectionViewCell.self,
                       forCellWithReuseIdentifier: NovelSelectedKeywordCollectionViewCell.cellIdentifier)
         rootView.detailSearchKeywordView.novelKeywordSelectSearchResultView.searchResultCollectionView


### PR DESCRIPTION
### ⭐️Issue
- close #376 
<br/>

### 🌟Motivation
- 삭제된 글 클릭 시 모달 Alert 기능 구현했습니다. 
<br/>

### 🌟Key Changes
#### 📓 `FeedDetailUnknownUserErrorView` 구현 
기존 `WSSAlertViewController` 를 사용하려 했는데, 폰트가 달라서 그냥 새로 하나 만들었습니다. 좀 더 좋은 방법이 있었을까요.. 🥲
<br/>

#### 📓 확인 버튼 클릭 시 `FeedDetailVC` `pop()`을 위한 `notification` 적용
알럿 내 확인 버튼 클릭 시 모달 dismiss와 동시에 FeedDetailVC pop을 해야하므로` rx.notification`을 적용했습니다. 
``` swift 
// FeedDetailUnknownUserErrorViewController.swift

rootView.confirmationButton.rx.tap
    .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
    .bind(with: self, onNext: { owner, _ in
        NotificationCenter.default.post(name: owner.popFeedDetailViewControllerNotificationName,
                                                             object: nil)
        owner.dismiss(animated: true)
    })
    .disposed(by: disposeBag)
```
<br/>

#### 📓 `materialize` 오퍼레이터를 활용하여 네트워크 통신 에러 핸들링 구현 
`.materialize`: onNext, onError, onCompleted를 Event로 래핑
기존 subscribe 에 있는 onNext, onError 로 이벤트를 처리했을 때보다 훨씬 명확하게 이벤트 처리를 할 수 있고 가독성이 높아집니다. 
또한, onError 발생 시에는 스트림이 종료되지만 위 오퍼레이터를 사용 시 스트림이 종료되지 않습니다. 

즉, `materialize`는 `Observable` 스트림의 모든 이벤트를 하나의 흐름에서 처리하고 싶을 때 매우 유용하네요!
```swift
input.viewWillAppearEvent
    .flatMapLatest {
        self.getSingleFeed(self.feedId)
            .asObservable()
            .materialize()
    }
    .subscribe(with: self, onNext: { owner, event in
        switch event {
        case .next(let feed):
            owner.feedData.onNext(feed)
            owner.likeButtonState.accept(feed.isLiked)
            owner.likeCount.accept(feed.likeCount)
            owner.feedUserId = feed.userId
            owner.novelId = feed.novelId
            owner.commentCount.accept(feed.commentCount)
            owner.isMyFeed.accept(feed.isMyFeed)
        case .error(let error):
            owner.handleNetworkError(error)
        case .completed:
            break
    }
})
.disposed(by: disposeBag)
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2024-12-30 at 02 54 28](https://github.com/user-attachments/assets/c0abc13b-9b48-4c4b-81ab-6245fbae89ef)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference
[RxSwift) error handling - catch, catchAndReturn, retry, retry(when:), materialize, dematerialize](https://gyuios.tistory.com/271)
<br/>
