### PR TITLE
[Feat] #376 - MyPageEditView 진입 분기처리 및 장르 미선택시 에러 해결

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -372,12 +372,13 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: false)
     }
     
-    func pushToMyPageEditViewController(profile: MyProfileResult) {
+    func pushToMyPageEditViewController(entryType: MyPageEditEntryType,profile: MyProfileResult) {
         let viewController = MyPageEditProfileViewController(
             viewModel: MyPageEditProfileViewModel(
                 userRepository: DefaultUserRepository(
                     userService: DefaultUserService(),
                     blocksService: DefaultBlocksService()),
+                entryType: entryType,
                 profileData: profile))
         
         viewController.hidesBottomBarWhenPushed = true

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -372,7 +372,7 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: false)
     }
     
-    func pushToMyPageEditViewController(entryType: MyPageEditEntryType,profile: MyProfileResult) {
+    func pushToMyPageEditViewController(entryType: MyPageEditEntryType, profile: MyProfileResult?) {
         let viewController = MyPageEditProfileViewController(
             viewModel: MyPageEditProfileViewModel(
                 userRepository: DefaultUserRepository(

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -190,14 +190,10 @@ final class HomeViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.pushToMyPageViewController
+        output.pushToMyPageEditViewController
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
-                if let tabBarController = owner.tabBarController as? WSSTabBarController {
-                    if let myPageIndex = WSSTabBarItem.allCases.firstIndex(of: .myPage) {
-                        tabBarController.selectedIndex = myPageIndex
-                    }
-                }
+                owner.pushToMyPageEditViewController(entryType: .home, profile: nil)
             })
             .disposed(by: disposeBag)
         
@@ -243,6 +239,14 @@ final class HomeViewController: UIViewController {
             .subscribe(with: self, onNext: { owner, buttonType in
                 guard let url = URL(string: StringLiterals.AppMinimumVersion.appStoreURL) else { return }
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            })
+            .disposed(by: disposeBag)
+        
+        //취향장르 정보 수정 Notification
+        NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile"))
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, _ in
+                owner.showToast(.editUserProfile)
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -74,7 +74,7 @@ final class HomeViewModel: ViewModelType {
         var tasteRecommendList: Observable<[TasteRecommendNovel]>
         let tasteRecommendCollectionViewHeight: Driver<CGFloat>
         let updateTasteRecommendView: Observable<(Bool, Bool)>
-        let pushToMyPageViewController: Observable<Void>
+        let pushToMyPageEditViewController: Observable<Void>
         
         let pushToNovelDetailViewController: Observable<Int>
         let pushToAnnouncementViewController: Observable<Void>
@@ -236,7 +236,7 @@ extension HomeViewModel {
                       tasteRecommendList: tasteRecommendList.asObservable(),
                       tasteRecommendCollectionViewHeight: tasteRecommendCollectionViewHeight.asDriver(),
                       updateTasteRecommendView: updateTasteRecommendView.asObservable(),
-                      pushToMyPageViewController: pushToMyPageViewController.asObservable(),
+                      pushToMyPageEditViewController: pushToMyPageViewController.asObservable(),
                       pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
                       pushToAnnouncementViewController: pushToAnnouncementViewController.asObservable(),
                       showInduceLoginModalView: showInduceLoginModalView.asObservable(),

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -191,7 +191,7 @@ final class MyPageViewController: UIViewController {
         output.pushToEditViewController
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, data in
-                owner.pushToMyPageEditViewController(profile: data)
+                owner.pushToMyPageEditViewController(entryType: .myPage, profile: data)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -418,7 +418,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     
     private func getProfileData() -> Observable<MyProfileResult> {
         return userRepository.getMyProfileData()
-            .asObservable()
+            .observe(on: MainScheduler.instance)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -10,9 +10,16 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+enum MyPageEditEntryType {
+    case myPage
+    case home
+}
+
 final class MyPageEditProfileViewModel: ViewModelType {
     
     //MARK: - Properties
+    
+    private var entryType: MyPageEditEntryType
     
     let genreList: [String] = NovelGenre.allCases.map { $0.toKorean }
     
@@ -21,7 +28,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     static let introLimit = 50
     
     private let userRepository: UserRepository
-    private var profileData: MyProfileResult
+    private var profileData: MyProfileResult?
     private var avatarId: Int = -1
     
     private var userNickname = BehaviorRelay<String>(value: "")
@@ -37,9 +44,11 @@ final class MyPageEditProfileViewModel: ViewModelType {
     //MARK: - Life Cycle
     
     init(userRepository: UserRepository,
-         profileData: MyProfileResult) {
+         entryType: MyPageEditEntryType,
+         profileData: MyProfileResult? = nil) {
         
         self.userRepository = userRepository
+        self.entryType = entryType
         self.profileData = profileData
     }
     
@@ -87,13 +96,37 @@ final class MyPageEditProfileViewModel: ViewModelType {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        // 데이터 초기 설정
-        self.userNickname.accept(self.profileData.nickname)
-        self.userIntro.accept(self.profileData.intro)
-        self.userGenre.accept(self.profileData.genrePreferences)
-        self.userImage.accept(self.profileData.avatarImage)
-        
-        output.bindProfileData.accept(self.profileData)
+        // 진입 경로 별 데이터 바인딩 분리
+        if entryType == .myPage {
+            guard let profileData = self.profileData else { fatalError("프로필 데이터가 전달되지 않음") }
+            
+            self.userNickname.accept(profileData.nickname)
+            self.userIntro.accept(profileData.intro)
+            self.userGenre.accept(profileData.genrePreferences)
+            self.userImage.accept(profileData.avatarImage)
+            
+            output.bindProfileData.accept(profileData)
+            
+        } else if entryType == .home {
+            Observable.just(())
+                .flatMapLatest { [weak self] _ -> Observable<MyProfileResult> in
+                    guard let self = self else { return Observable.empty() }
+                    return self.getProfileData()
+                }
+                .subscribe(with: self, onNext: { owner, profileData in
+                    owner.profileData = profileData
+                    owner.userNickname.accept(profileData.nickname)
+                    owner.userIntro.accept(profileData.intro)
+                    owner.userGenre.accept(profileData.genrePreferences)
+                    owner.userImage.accept(profileData.avatarImage)
+                    
+                    output.bindProfileData.accept(profileData)
+                    
+                }, onError: { owner, error in
+                    print(error)
+                })
+                .disposed(by: disposeBag)
+        }
         
         let bindGenreTuple = checkGenreToMakeTuple(self.genreList, self.userGenre.value)
         output.bindGenreCell.accept(bindGenreTuple)
@@ -112,19 +145,19 @@ final class MyPageEditProfileViewModel: ViewModelType {
             .flatMapLatest{ _ -> Observable<Void> in
                 var updatedFields: [String: Any] = [:]
                 
-                if self.userImage.value != self.profileData.avatarImage && self.avatarId != -1  {
+                if self.userImage.value != self.profileData?.avatarImage && self.avatarId != -1  {
                     updatedFields["avatarId"] = self.avatarId
                 }
                 
-                if self.userNickname.value != self.profileData.nickname {
+                if self.userNickname.value != self.profileData?.nickname {
                     updatedFields["nickname"] = self.userNickname.value
                 }
                 
-                if self.userIntro.value != self.profileData.intro {
+                if self.userIntro.value != self.profileData?.intro {
                     updatedFields["intro"] = self.userIntro.value
                 }
                 
-                if self.userGenre.value != self.profileData.genrePreferences {
+                if self.userGenre.value != self.profileData?.genrePreferences {
                     updatedFields["genrePreferences"] = self.userGenre.value.map { $0 }
                 } else {
                     updatedFields["genrePreferences"] = []
@@ -166,7 +199,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
         input.profileViewDidTap
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .subscribe(with: self, onNext: { owner, _ in
-                output.pushToAvatarViewController.accept(owner.profileData.nickname)
+                output.pushToAvatarViewController.accept(owner.profileData?.nickname ?? "")
             })
             .disposed(by: disposeBag)
         
@@ -190,7 +223,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
                 let isNickNameValid = owner.isValidNicknameCharacters(text)
                 output.checkButtonIsAbled.accept(text != owner.userNickname.value && isNickNameValid)
                 
-                if(limitedText == owner.profileData.nickname) {
+                if(limitedText == owner.profileData?.nickname) {
                     owner.checkDuplicatedButton.accept(false)
                 }
             })
@@ -298,7 +331,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     }
     
     private func changeInfoData() {
-        if (self.userNickname.value == profileData.nickname && self.userIntro.value == profileData.intro && self.userGenre.value == profileData.genrePreferences && self.userImage.value == self.profileData.avatarImage) {
+        if (self.userNickname.value == profileData?.nickname && self.userIntro.value == profileData?.intro && self.userGenre.value == profileData?.genrePreferences && self.userImage.value == self.profileData?.avatarImage) {
             self.changeCompleteButtonRelay.accept(self.checkDuplicatedButton.value)
         }
         else {
@@ -381,6 +414,11 @@ final class MyPageEditProfileViewModel: ViewModelType {
                 }
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func getProfileData() -> Observable<MyProfileResult> {
+        return userRepository.getMyProfileData()
+            .asObservable()
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -108,11 +108,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
             output.bindProfileData.accept(profileData)
             
         } else if entryType == .home {
-            Observable.just(())
-                .flatMapLatest { [weak self] _ -> Observable<MyProfileResult> in
-                    guard let self = self else { return Observable.empty() }
-                    return self.getProfileData()
-                }
+            self.getProfileData()
                 .subscribe(with: self, onNext: { owner, profileData in
                     owner.profileData = profileData
                     owner.userNickname.accept(profileData.nickname)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -157,10 +157,10 @@ final class MyPageEditProfileViewModel: ViewModelType {
                     updatedFields["intro"] = self.userIntro.value
                 }
                 
-                if self.userGenre.value != self.profileData?.genrePreferences {
-                    updatedFields["genrePreferences"] = self.userGenre.value.map { $0 }
-                } else {
+                if self.userGenre.value == [] {
                     updatedFields["genrePreferences"] = []
+                } else {
+                    updatedFields["genrePreferences"] = self.userGenre.value.map { $0 }
                 }
                 
                 return self.patchProfile(updatedFields: updatedFields)


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #376 
<br/>

### 🌟Motivation

- EditView 를 진입하는 경로를 2가지로 구분하였습니다 (홈/마이페이지)
- 다른 요소를 선택하고 저장할시 선택했던 장르가 초기화되는 에러를 해결하였습니다.

<br/>

### 🌟Key Changes

<br/>

진입 경로를 ViewController 에서 해야할 지, ViewModel 에서 해야할 지 고민했는데 로직처리라고 생각하여 ViewModel 에서 하기로 하였습니다:)
따라서 myPage 에서 Edit 으로 넘어갔을 때 GET /users/my-profile API 는 호출되지 않습니다.

```swift
enum MyPageEditEntryType {
    case myPage
    case home
}

init(userRepository: UserRepository,
         entryType: MyPageEditEntryType,
         profileData: MyProfileResult? = nil) {
        
        self.userRepository = userRepository
        self.entryType = entryType
        self.profileData = profileData
    }
```
<br/>

### 🌟Simulation
| 홈에서 진입시 | 마이페이지에서 진입시 |
|---|---|
|![Simulator Screen Recording - iPhone 16 - 2025-01-01 at 20 47 13](https://github.com/user-attachments/assets/c814a784-b169-4595-94ae-28164592c530)|![Simulator Screen Recording - iPhone 16 - 2025-01-01 at 20 47 27](https://github.com/user-attachments/assets/aa58fc29-f079-4e6a-ba33-5c1594ab4044)|

<br/>

| 닉네임 수정 후 기존 장르 확인 | 소개 수정 후 기존 장르 확인 |
|---|---|
|![Simulator Screen Recording - iPhone 16 - 2025-01-01 at 20 52 35](https://github.com/user-attachments/assets/daf331cf-7933-4c8f-9c5e-75e622fc83e7)|![Simulator Screen Recording - iPhone 16 - 2025-01-01 at 20 52 47](https://github.com/user-attachments/assets/664ca6a9-77e5-4609-ac89-ff5df5353a17)|


<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
