### PR TITLE
[Fix] #418 - 앱스토어 연결 링크 내 kr 국가코드 추가

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -599,6 +599,6 @@ enum StringLiterals {
         static var appStoreID: String {
             return Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.appStoreID) as? String ?? "Error"
         }
-        static let appStoreURL = "itms-apps://itunes.apple.com/app/\(appStoreID)"
+        static let appStoreURL = "itms-apps://itunes.apple.com/kr/app/\(appStoreID)"
     }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #418 
<br/>

### 🌟Motivation
- 앱스토어 연결 링크 내 국가코드 추가했습니다. 
<br/>

### 🌟Key Changes
- 기존엔 앱스토어 앱 설정국가가 EN으로 되어있었으나, 이후에 KR로 변경되면서 앱스토어 연결이 안되는 이슈가 발생했습니다. 
따라서 링크 내에 국가코드 (kr)을 따로 추가하여 이슈를 해결했습니다. 

- 현재 개발서버의 최소 버전은 1.0.2 로 설정해두었고, 운영서버는 1.0.0으로 설정해두었습니다.
추후 업데이트가 진행되면 서버 post하여 최소버전 설정해두겠습니다!
<br/>

### 🌟Simulation

https://github.com/user-attachments/assets/748b0920-5242-4c0b-86e2-47903c709feb


<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
