### PR TITLE
[Fix] #411 - FeedEditView 이모지 깨지는 문제 해결

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
@@ -142,7 +142,6 @@ final class FeedEditContentView: UIView {
     //MARK: - Data
     
     func bindData(feedContent: String) {
-        // 현재 커서 위치 (UTF-16 인덱스를 String.Index로 변환)
         if let selectedRange = self.feedTextView.selectedTextRange {
             // 시작 위치와 끝 위치를 저장
             let cursorStartPosition = self.feedTextView.offset(from: self.feedTextView.beginningOfDocument, to: selectedRange.start)

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
@@ -142,16 +142,34 @@ final class FeedEditContentView: UIView {
     //MARK: - Data
     
     func bindData(feedContent: String) {
-        // 현재 커서 위치
-        let selectedRange = self.feedTextView.selectedRange
-        
-        self.feedTextView.do {
-            $0.applyWSSFont(.body2, with: feedContent)
+        // 현재 커서 위치 (UTF-16 인덱스를 String.Index로 변환)
+        if let selectedRange = self.feedTextView.selectedTextRange {
+            // 시작 위치와 끝 위치를 저장
+            let cursorStartPosition = self.feedTextView.offset(from: self.feedTextView.beginningOfDocument, to: selectedRange.start)
+            let cursorEndPosition = self.feedTextView.offset(from: self.feedTextView.beginningOfDocument, to: selectedRange.end)
+            
+            if self.feedTextView.text != feedContent {
+                self.feedTextView.do {
+                    $0.applyWSSFont(.body2, with: feedContent)
+                }
+            }
+            
+            // 새로운 텍스트에서 위치 복원
+            if let newStartPosition = self.feedTextView.position(from: self.feedTextView.beginningOfDocument, offset: cursorStartPosition),
+               let newEndPosition = self.feedTextView.position(from: self.feedTextView.beginningOfDocument, offset: cursorEndPosition) {
+                let newSelectedRange = self.feedTextView.textRange(from: newStartPosition, to: newEndPosition)
+                self.feedTextView.selectedTextRange = newSelectedRange
+            }
+
+            // 커서가 가시 영역 아래에 있는 경우 스크롤
+            let caretRect = self.feedTextView.caretRect(for: selectedRange.start)
+            let caretBottom = caretRect.origin.y + caretRect.size.height
+            let visibleAreaBottom = self.feedTextView.contentOffset.y + self.feedTextView.bounds.size.height - self.feedTextView.textContainerInset.bottom
+
+            if caretBottom > visibleAreaBottom {
+                self.feedTextView.setContentOffset(CGPoint(x: 0, y: self.feedTextView.contentOffset.y + (caretBottom - visibleAreaBottom)), animated: true)
+            }
         }
-        
-        // 커서 위치 복원
-        let cursorPosition = min(selectedRange.location, feedContent.count)
-        self.feedTextView.selectedRange = NSRange(location: cursorPosition, length: 0)
         
         self.letterCountLabel.do {
             $0.applyWSSFont(.body2, with: "(\(feedContent.count)/2000)")


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #411 
<br/>

### 🌟Motivation
FeedEditView 이모지 깨지는 문제 해결
<br/>

### 🌟Key Changes

**원인**
- 기존에 커서 위치를 복원하기 위해 selectedRange.location 과 feedContent.count 를 사용함.
(#400 참고.)
- 커서 위치를 복원할 때 사용하는 `selectedRange.location` 은 **UTF-16 인덱스**를 기반으로 커서 위치를 반환.
- `feedContent.count` 는 Swift String의 Character 개수(**유니코드 스칼라**)를 반환.
- UTF-16과 유니코드 스칼라 간의 차이로 인해 커서 위치가 정상적으로 복원되지 않으면서 조합문자인 이모지가 분리되는 현상 발생.

**해결**
- 커서 복원 작업을 UITextView의 UITextPosition 및 offset(from:to:) 메서드를 활용하여 UTF-16 인덱스를 기준으로 작업하도록 변경.
<br/>

### 🌟Simulation
<img src="https://github.com/user-attachments/assets/a47a1181-9345-4764-9f6c-b2e5790bb92d" width="40%"/>➡️<img src="https://github.com/user-attachments/assets/327d2922-b386-4423-bc10-aff6a6250719" width="40%"/>

<br/>

### 🌟To Reviewer
행간/자간 적용을 위해 AttributedString를 사용하면서 이런 문제들이 많이 발생하네요..
AttributedString 안 쓰고 행간/자간 적용하는 방법은 없나?
<br/>

### 🌟Reference

<br/>
