### PR TITLE
[Fix] #425 - MyPageFeedDetail 에러 수정

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageFeedView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageFeedView.swift
@@ -134,15 +134,13 @@ final class MyPageFeedView: UIView {
     
     
     func isEmptyView(isEmpty: Bool) {
-        if isEmpty {
-            myPageFeedEmptyView.isHidden = false
-            
-            [myPageFeedTableView,
-             showMoreActivityButton,
-             paddingViewAfterButton].forEach { view in
-                view.do {
-                    $0.isHidden = true
-                }
+        myPageFeedEmptyView.isHidden = !isEmpty
+        
+        [myPageFeedTableView,
+         showMoreActivityButton,
+         paddingViewAfterButton].forEach { view in
+            view.do {
+                $0.isHidden = isEmpty
             }
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageFeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageFeedDetailViewController.swift
@@ -68,10 +68,10 @@ final class MyPageFeedDetailViewController: UIViewController, UIScrollViewDelega
     }
     
     private func bindViewModel() {
-        let loadNextPageTrigger = rootView.myPageFeedDetailTableView.rx.didScroll
-            .map { [weak self] in
+        let loadNextPageTrigger = rootView.myPageFeedDetailTableView.rx.contentOffset
+            .map { [weak self] contentOffset in
                 guard let self = self else { return false }
-                let offsetY = self.rootView.myPageFeedDetailTableView.contentOffset.y
+                let offsetY = contentOffset.y
                 let contentHeight = self.rootView.myPageFeedDetailTableView.contentSize.height
                 let frameHeight = self.rootView.myPageFeedDetailTableView.frame.height
                 return offsetY + frameHeight >= contentHeight - 100

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -310,8 +310,8 @@ final class MyPageViewController: UIViewController {
         
         output.isEmptyFeed
             .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, _ in
-                owner.rootView.myPageFeedView.isEmptyView(isEmpty: true)
+            .bind(with: self, onNext: { owner, isEmpty in
+                owner.rootView.myPageFeedView.isEmptyView(isEmpty: isEmpty)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -34,7 +34,7 @@ final class MyPageViewModel: ViewModelType {
     private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
     
     private let bindFeedDataRelay = BehaviorRelay<[FeedCellData]>(value: [])
-    private let isEmptyFeedRelay = PublishRelay<Void>()
+    private let isEmptyFeedRelay = PublishRelay<Bool>()
     private let showFeedDetailButtonRelay = BehaviorSubject<Bool>(value: false)
     
     private let updateButtonWithLibraryViewRelay = BehaviorRelay<Bool>(value: true)
@@ -114,7 +114,7 @@ final class MyPageViewModel: ViewModelType {
         
         let bindFeedData: BehaviorRelay<[FeedCellData]>
         let updateFeedTableViewHeight: PublishRelay<CGFloat>
-        let isEmptyFeed: PublishRelay<Void>
+        let isEmptyFeed: PublishRelay<Bool>
         let showFeedDetailButton: BehaviorSubject<Bool>
         
         let showToastView: PublishRelay<Void>
@@ -431,6 +431,7 @@ final class MyPageViewModel: ViewModelType {
             }
     }
     
+    // 활동 데이터 바인딩
     private func updateMyPageFeedData() -> Observable<Void> {
         return getUserFeed(userId: self.profileId, lastFeedId: 0, size: 6)
             .map { feedResult -> [FeedCellData] in
@@ -446,18 +447,19 @@ final class MyPageViewModel: ViewModelType {
                 guard let self else { return }
                 
                 if feedCellData.isEmpty {
-                    self.isEmptyFeedRelay.accept(())
+                    self.isEmptyFeedRelay.accept(true)
                 } else {
                     
                     //5개까지만 활동뷰에 바인딩
                     //5개를 초과할 경우 더보기 버튼 뜨게 함
+                    self.isEmptyFeedRelay.accept(false)
                     let hasMoreThanFive = feedCellData.count > 5
                     self.showFeedDetailButtonRelay.onNext(hasMoreThanFive)
                     self.bindFeedDataRelay.accept(Array(feedCellData.prefix(5)))
                 }
             })
             .catch { [weak self] error in
-                self?.isEmptyFeedRelay.accept(())
+                self?.isEmptyFeedRelay.accept(true)
                 return .just([])
             }
             .map { _ in Void() }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -35,7 +35,7 @@ final class MyPageViewModel: ViewModelType {
     
     private let bindFeedDataRelay = BehaviorRelay<[FeedCellData]>(value: [])
     private let isEmptyFeedRelay = PublishRelay<Void>()
-    private let showFeedDetailButtonRelay = PublishRelay<Bool>()
+    private let showFeedDetailButtonRelay = BehaviorSubject<Bool>(value: false)
     
     private let updateButtonWithLibraryViewRelay = BehaviorRelay<Bool>(value: true)
     private let updateFeedTableViewHeightRelay = PublishRelay<CGFloat>()
@@ -115,7 +115,7 @@ final class MyPageViewModel: ViewModelType {
         let bindFeedData: BehaviorRelay<[FeedCellData]>
         let updateFeedTableViewHeight: PublishRelay<CGFloat>
         let isEmptyFeed: PublishRelay<Void>
-        let showFeedDetailButton: PublishRelay<Bool>
+        let showFeedDetailButton: BehaviorSubject<Bool>
         
         let showToastView: PublishRelay<Void>
         let stickyHeaderAction: BehaviorRelay<Bool>
@@ -452,7 +452,7 @@ final class MyPageViewModel: ViewModelType {
                     //5개까지만 활동뷰에 바인딩
                     //5개를 초과할 경우 더보기 버튼 뜨게 함
                     let hasMoreThanFive = feedCellData.count > 5
-                    self.showFeedDetailButtonRelay.accept(hasMoreThanFive)
+                    self.showFeedDetailButtonRelay.onNext(hasMoreThanFive)
                     self.bindFeedDataRelay.accept(Array(feedCellData.prefix(5)))
                 }
             })


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #425 
<br/>

### 🌟Motivation
마이페이지 내 활동 디테일 에러를 수정하였습니다.
<br/>

### 🌟Key Changes

- 활동 더보기 버튼 초기값을 False 로 부여하였습니다.
- 활동 상세 뷰를 터치없이도 보여지도록 수정하였습니다.
- 활동에 Cell Data 를 서버에서 전달받고 있는데,  별점이 반올림되지 않고 있어서 서버측에 요청 넣어두었습니다!

### 🌟Simulation

| 활동 더보기 버튼 | 활동 디테일뷰 |
|---|---|
![IMG_6355](https://github.com/user-attachments/assets/2489b11b-3a22-4b32-9434-70f3134cd7e7)|![RPReplay_Final1737117976](https://github.com/user-attachments/assets/33092087-0a01-45e2-b6f4-5e5756cc0201)|

<br/>

### 🌟To Reviewer
더보기버튼이 잘 안뜨는 이슈는 재현하기가 어렵네요!
코드 상으로는 무조건 서버 연결이 되어야지 버튼이 보이는 방식이라 문제 없을 것 같습니다 :)

<br/>
