### PR TITLE
[Feat] #451 - 보관함 상태 탭시 특정 위치로 이동 및 에러 수정

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -386,7 +386,7 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func pushToLibraryViewController(userId: Int) {
+    func pushToLibraryViewController(userId: Int, pageIndex: Int = 0) {
         let viewController = LibraryViewController(
             libraryViewModel: LibraryViewModel(
                 userRepository: DefaultUserRepository(
@@ -394,6 +394,7 @@ extension UIViewController {
                     blocksService: DefaultBlocksService()),
                 userId: userId))
         
+        viewController.pageIndex = pageIndex
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -15,12 +15,13 @@ final class LibraryViewController: UIViewController {
     
     //MARK: - Properties
     
+    var pageIndex: Int = 0
+    
     private let libraryViewModel: LibraryViewModel
     private let disposeBag = DisposeBag()
     
     private let sortTypeList = StringLiterals.Alignment.self
     private let readStatusList = StringLiterals.LibraryReadStatus.allCases.map { $0.rawValue }
-    private var currentPageIndex = 0
     private let sendNovelTotalCount = BehaviorRelay<Int>(value: 0)
     
     //UI 관련
@@ -108,7 +109,8 @@ final class LibraryViewController: UIViewController {
                     viewController.view.tag = index
                 }
                 
-                owner.libraryPageViewController.setViewControllers([owner.libraryPages[0]],
+                guard owner.pageIndex < StringLiterals.ReviewerStatus.allCases.count else { return }
+                owner.libraryPageViewController.setViewControllers([owner.libraryPages[owner.pageIndex]],
                                                                    direction: .forward,
                                                                    animated: false,
                                                                    completion: nil)
@@ -142,7 +144,7 @@ final class LibraryViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        libraryPageBar.libraryTabCollectionView.selectItem(at: IndexPath(item: 0, section: 0),
+        libraryPageBar.libraryTabCollectionView.selectItem(at: IndexPath(item: self.pageIndex, section: 0),
                                                            animated: true,
                                                            scrollPosition: [])
     }
@@ -154,7 +156,7 @@ extension LibraryViewController : UIPageViewControllerDelegate {
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if completed, let currentViewController = pageViewController.viewControllers?.first, let index = libraryPages.firstIndex(of: currentViewController as! LibraryChildViewController) {
             libraryPageBar.libraryTabCollectionView.selectItem(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .centeredHorizontally)
-            currentPageIndex = index
+            pageIndex = index
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewModel/LibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewModel/LibraryViewModel.swift
@@ -39,7 +39,7 @@ final class LibraryViewModel: ViewModelType {
     struct Output {
         let setUpPageViewController = BehaviorRelay<Int>(value: 0)
         let bindCell = BehaviorRelay<[String]>(value: [])
-        let moveToTappedTabBar = BehaviorRelay<Int>(value: 0)
+        let moveToTappedTabBar = PublishRelay<Int>()
         let popLastViewController = PublishRelay<Void>()
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -16,12 +16,12 @@ final class MyPageInventoryView: UIView {
     
     //터치영역
     let inventoryView = UIView()
+    let inventoryStackView = UIStackView()
     
     private let titleLabel = UILabel()
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
     private let inventoryDetailView = UIView()
-    let inventoryStackView = UIStackView()
     
     private var interestStackView = UIStackView()
     private let interestCountLabel = UILabel()

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -18,7 +18,8 @@ final class MyPageInventoryView: UIView {
     let inventoryView = UIView()
     
     private let titleLabel = UILabel()
-    private let arrowButton = UIButton()
+    private let arrowView = UIView()
+    private let arrowImageView = UIImageView()
     private let inventoryDetailView = UIView()
     private let stackView = UIStackView()
     
@@ -61,9 +62,9 @@ final class MyPageInventoryView: UIView {
             $0.textColor = .wssBlack
         }
         
-        arrowButton.do {
-            $0.setImage(.icNavigateRight.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray200), for: .normal)
-            $0.isUserInteractionEnabled = true
+        arrowImageView.do {
+            $0.image = .icNavigateRight.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray200)
+            $0.contentMode = .center
         }
         
         inventoryDetailView.do {
@@ -116,9 +117,10 @@ final class MyPageInventoryView: UIView {
     private func setHierarchy() {
         self.addSubview(inventoryView)
         inventoryView.addSubviews(titleLabel,
-                                  arrowButton,
+                                  arrowView,
                                   inventoryDetailView)
         inventoryDetailView.addSubview(stackView)
+        arrowView.addSubview(arrowImageView)
         
         let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
         let interestStack = createVerticalStack(countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0] , addLine: true)
@@ -138,19 +140,23 @@ final class MyPageInventoryView: UIView {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(30)
             
-            arrowButton.snp.makeConstraints {
-                $0.top.equalToSuperview()
-                $0.trailing.equalToSuperview()
+            arrowView.snp.makeConstraints {
+                $0.top.trailing.equalToSuperview()
                 $0.size.equalTo(44)
+                
+                arrowImageView.snp.makeConstraints {
+                    $0.center.equalToSuperview()
+                    $0.size.equalTo(22)
+                }
             }
             
             titleLabel.snp.makeConstraints {
                 $0.leading.equalToSuperview()
-                $0.centerY.equalTo(arrowButton.snp.centerY)
+                $0.centerY.equalTo(arrowView.snp.centerY)
             }
             
             inventoryDetailView.snp.makeConstraints {
-                $0.top.equalTo(arrowButton.snp.bottom)
+                $0.top.equalTo(arrowView.snp.bottom)
                 $0.leading.trailing.bottom.equalToSuperview()
                 $0.height.equalTo(70)
                 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -21,21 +21,20 @@ final class MyPageInventoryView: UIView {
     private let titleLabel = UILabel()
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
-    private let inventoryDetailView = UIView()
     
-    private var interestStackView = UIStackView()
+    private var interestView = UIView()
     private let interestCountLabel = UILabel()
     private let interestLabel = UILabel()
     
-    private var watchingStackView = UIStackView()
+    private var watchingView = UIView()
     private let watchingCountLabel = UILabel()
     private let watchingLabel = UILabel()
     
-    private var watchedStackView = UIStackView()
+    private var watchedView = UIView()
     private let watchedCountLabel = UILabel()
     private let watchedLabel = UILabel()
     
-    private var quitStackView = UIStackView()
+    private var quitView = UIView()
     private let quitCountLabel = UILabel()
     private let quitLabel = UILabel()
     
@@ -71,73 +70,33 @@ final class MyPageInventoryView: UIView {
             $0.contentMode = .center
         }
         
-        inventoryDetailView.do {
+        inventoryStackView.do {
             $0.backgroundColor = .wssGray50
             $0.layer.cornerRadius = 14
-        }
-        
-        inventoryStackView.do {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
             $0.spacing = 2
         }
         
         let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
-        interestStackView = createVerticalStack(tag: 0, countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0],
-                                                addLine: true)
-        watchingStackView = createVerticalStack(tag: 1, countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
-        watchedStackView = createVerticalStack(tag: 2, countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
-        quitStackView = createVerticalStack(tag: 3, countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
-    }
-    
-    private func createVerticalStack(tag: Int, countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIStackView {
-        countLabel.do {
-            $0.applyWSSFont(.title2, with: "0")
-            $0.textAlignment = .center
-        }
-        
-        textLabel.do {
-            $0.applyWSSFont(.body5, with: text)
-            $0.textColor = .wssGray200
-            $0.textAlignment = .center
-        }
-        
-        let verticalStack = UIStackView(arrangedSubviews: [countLabel, textLabel]).then {
-            $0.axis = .vertical
-            $0.alignment = .center
-            $0.spacing = 2
-            $0.tag = tag
-        }
-        
-        if addLine {
-            let dividerView = UIView().then {
-                $0.backgroundColor = .wssGray70
-            }
-            
-            verticalStack.addSubview(dividerView)
-            
-            dividerView.snp.makeConstraints {
-                $0.centerY.trailing.equalToSuperview()
-                $0.height.equalTo(40)
-                $0.width.equalTo(1)
-            }
-        }
-        
-        return verticalStack
+        interestView = createInventorySectionView(tag: 0, countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0],
+                                                  addLine: true)
+        watchingView = createInventorySectionView(tag: 1, countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
+        watchedView = createInventorySectionView(tag: 2, countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
+        quitView = createInventorySectionView(tag: 3, countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
     }
     
     private func setHierarchy() {
         self.addSubview(inventoryView)
         inventoryView.addSubviews(titleLabel,
                                   arrowView,
-                                  inventoryDetailView)
-        inventoryDetailView.addSubview(inventoryStackView)
+                                  inventoryStackView)
         arrowView.addSubview(arrowImageView)
         
-        inventoryStackView.addArrangedSubviews(interestStackView,
-                                      watchingStackView,
-                                      watchedStackView,
-                                      quitStackView)
+        inventoryStackView.addArrangedSubviews(interestView,
+                                               watchingView,
+                                               watchedView,
+                                               quitView)
     }
     
     private func setLayout() {
@@ -161,17 +120,62 @@ final class MyPageInventoryView: UIView {
                 $0.centerY.equalTo(arrowView.snp.centerY)
             }
             
-            inventoryDetailView.snp.makeConstraints {
+            inventoryStackView.snp.makeConstraints {
                 $0.top.equalTo(arrowView.snp.bottom)
                 $0.leading.trailing.bottom.equalToSuperview()
                 $0.height.equalTo(70)
-                
-                inventoryStackView.snp.makeConstraints {
-                    $0.height.equalTo(38.5)
-                    $0.leading.trailing.centerY.equalToSuperview()
-                }
             }
         }
+    }
+    
+    //MARK: - Custom Method
+    
+    private func createInventorySectionView(tag: Int, countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIView {
+        let statusView = UIView()
+        
+        statusView.do {
+            $0.tag = tag
+        }
+        
+        countLabel.do {
+            $0.applyWSSFont(.title2, with: "0")
+            $0.textAlignment = .center
+        }
+        
+        textLabel.do {
+            $0.applyWSSFont(.body5, with: text)
+            $0.textColor = .wssGray200
+            $0.textAlignment = .center
+        }
+        
+        statusView.addSubviews(countLabel,
+                               textLabel)
+        
+        countLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(13.5)
+            $0.centerX.equalToSuperview()
+        }
+        
+        textLabel.snp.makeConstraints {
+            $0.top.equalTo(countLabel.snp.bottom).offset(2)
+            $0.centerX.equalToSuperview()
+        }
+        
+        if addLine {
+            let dividerView = UIView().then {
+                $0.backgroundColor = .wssGray70
+            }
+            
+            statusView.addSubview(dividerView)
+            
+            dividerView.snp.makeConstraints {
+                $0.centerY.trailing.equalToSuperview()
+                $0.height.equalTo(40)
+                $0.width.equalTo(1)
+            }
+        }
+        
+        return statusView
     }
     
     //MARK: - Data

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -17,26 +17,25 @@ final class MyPageInventoryView: UIView {
     //터치영역
     let inventoryView = UIView()
     
-    var interestStackView = UIStackView()
-    var watchingStackView = UIStackView()
-    var watchedStackView = UIStackView()
-    var quitStackView = UIStackView()
-    
     private let titleLabel = UILabel()
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
     private let inventoryDetailView = UIView()
     let inventoryStackView = UIStackView()
     
+    private var interestStackView = UIStackView()
     private let interestCountLabel = UILabel()
     private let interestLabel = UILabel()
     
+    private var watchingStackView = UIStackView()
     private let watchingCountLabel = UILabel()
     private let watchingLabel = UILabel()
     
+    private var watchedStackView = UIStackView()
     private let watchedCountLabel = UILabel()
     private let watchedLabel = UILabel()
     
+    private var quitStackView = UIStackView()
     private let quitCountLabel = UILabel()
     private let quitLabel = UILabel()
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -14,8 +14,10 @@ final class MyPageInventoryView: UIView {
     
     //MARK: - Components
     
+    private let inventoryView = UIView()
+    
     //터치영역
-    let inventoryView = UIView()
+    let inventoryTitleView = UIView()
     let inventoryStackView = UIStackView()
     
     private let titleLabel = UILabel()
@@ -88,9 +90,10 @@ final class MyPageInventoryView: UIView {
     
     private func setHierarchy() {
         self.addSubview(inventoryView)
-        inventoryView.addSubviews(titleLabel,
-                                  arrowView,
+        inventoryView.addSubviews(inventoryTitleView,
                                   inventoryStackView)
+        inventoryTitleView.addSubviews(titleLabel,
+                                       arrowView)
         arrowView.addSubview(arrowImageView)
         
         inventoryStackView.addArrangedSubviews(interestView,
@@ -105,23 +108,27 @@ final class MyPageInventoryView: UIView {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(30)
             
-            arrowView.snp.makeConstraints {
-                $0.top.trailing.equalToSuperview()
-                $0.size.equalTo(44)
+            inventoryTitleView.snp.makeConstraints {
+                $0.top.width.equalToSuperview()
                 
-                arrowImageView.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.size.equalTo(24)
+                arrowView.snp.makeConstraints {
+                    $0.top.trailing.bottom.equalToSuperview()
+                    $0.size.equalTo(44)
+                    
+                    arrowImageView.snp.makeConstraints {
+                        $0.center.equalToSuperview()
+                        $0.size.equalTo(24)
+                    }
+                }
+                
+                titleLabel.snp.makeConstraints {
+                    $0.leading.equalToSuperview()
+                    $0.centerY.equalTo(arrowView.snp.centerY)
                 }
             }
             
-            titleLabel.snp.makeConstraints {
-                $0.leading.equalToSuperview()
-                $0.centerY.equalTo(arrowView.snp.centerY)
-            }
-            
             inventoryStackView.snp.makeConstraints {
-                $0.top.equalTo(arrowView.snp.bottom)
+                $0.top.equalTo(inventoryTitleView.snp.bottom)
                 $0.leading.trailing.bottom.equalToSuperview()
                 $0.height.equalTo(70)
             }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -17,6 +17,11 @@ final class MyPageInventoryView: UIView {
     //터치영역
     let inventoryView = UIView()
     
+    var interestStackView = UIStackView()
+    var watchingStackView = UIStackView()
+    var watchedStackView = UIStackView()
+    var quitStackView = UIStackView()
+    
     private let titleLabel = UILabel()
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
@@ -77,6 +82,12 @@ final class MyPageInventoryView: UIView {
             $0.distribution = .fillEqually
             $0.spacing = 2
         }
+        
+        let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
+        interestStackView = createVerticalStack(countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0] , addLine: true)
+        watchingStackView = createVerticalStack(countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
+        watchedStackView = createVerticalStack(countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
+        quitStackView = createVerticalStack(countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
     }
     
     private func createVerticalStack(countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIStackView {
@@ -122,16 +133,10 @@ final class MyPageInventoryView: UIView {
         inventoryDetailView.addSubview(stackView)
         arrowView.addSubview(arrowImageView)
         
-        let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
-        let interestStack = createVerticalStack(countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0] , addLine: true)
-        let watchingStack = createVerticalStack(countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
-        let watchedStack = createVerticalStack(countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
-        let quitStack = createVerticalStack(countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
-        
-        stackView.addArrangedSubviews(interestStack,
-                                      watchingStack,
-                                      watchedStack,
-                                      quitStack)
+        stackView.addArrangedSubviews(interestStackView,
+                                      watchingStackView,
+                                      watchedStackView,
+                                      quitStackView)
     }
     
     private func setLayout() {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -26,7 +26,7 @@ final class MyPageInventoryView: UIView {
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
     private let inventoryDetailView = UIView()
-    private let stackView = UIStackView()
+    let inventoryStackView = UIStackView()
     
     private let interestCountLabel = UILabel()
     private let interestLabel = UILabel()
@@ -77,20 +77,21 @@ final class MyPageInventoryView: UIView {
             $0.layer.cornerRadius = 14
         }
         
-        stackView.do {
+        inventoryStackView.do {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
             $0.spacing = 2
         }
         
         let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
-        interestStackView = createVerticalStack(countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0] , addLine: true)
-        watchingStackView = createVerticalStack(countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
-        watchedStackView = createVerticalStack(countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
-        quitStackView = createVerticalStack(countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
+        interestStackView = createVerticalStack(tag: 0, countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0],
+                                                addLine: true)
+        watchingStackView = createVerticalStack(tag: 1, countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
+        watchedStackView = createVerticalStack(tag: 2, countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
+        quitStackView = createVerticalStack(tag: 3, countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
     }
     
-    private func createVerticalStack(countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIStackView {
+    private func createVerticalStack(tag: Int, countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIStackView {
         countLabel.do {
             $0.applyWSSFont(.title2, with: "0")
             $0.textAlignment = .center
@@ -106,6 +107,7 @@ final class MyPageInventoryView: UIView {
             $0.axis = .vertical
             $0.alignment = .center
             $0.spacing = 2
+            $0.tag = tag
         }
         
         if addLine {
@@ -130,10 +132,10 @@ final class MyPageInventoryView: UIView {
         inventoryView.addSubviews(titleLabel,
                                   arrowView,
                                   inventoryDetailView)
-        inventoryDetailView.addSubview(stackView)
+        inventoryDetailView.addSubview(inventoryStackView)
         arrowView.addSubview(arrowImageView)
         
-        stackView.addArrangedSubviews(interestStackView,
+        inventoryStackView.addArrangedSubviews(interestStackView,
                                       watchingStackView,
                                       watchedStackView,
                                       quitStackView)
@@ -165,7 +167,7 @@ final class MyPageInventoryView: UIView {
                 $0.leading.trailing.bottom.equalToSuperview()
                 $0.height.equalTo(70)
                 
-                stackView.snp.makeConstraints {
+                inventoryStackView.snp.makeConstraints {
                     $0.height.equalTo(38.5)
                     $0.leading.trailing.centerY.equalToSuperview()
                 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -24,21 +24,12 @@ final class MyPageInventoryView: UIView {
     private let arrowView = UIView()
     private let arrowImageView = UIImageView()
     
-    private var interestView = UIView()
+    var readStatusButtons = [UIButton()]
+    
     private let interestCountLabel = UILabel()
-    private let interestLabel = UILabel()
-    
-    private var watchingView = UIView()
     private let watchingCountLabel = UILabel()
-    private let watchingLabel = UILabel()
-    
-    private var watchedView = UIView()
     private let watchedCountLabel = UILabel()
-    private let watchedLabel = UILabel()
-    
-    private var quitView = UIView()
     private let quitCountLabel = UILabel()
-    private let quitLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -80,12 +71,19 @@ final class MyPageInventoryView: UIView {
             $0.spacing = 2
         }
         
-        let statusList = StringLiterals.ReviewerStatus.allCases.map { $0.rawValue }
-        interestView = createInventorySectionView(tag: 0, countLabel: interestCountLabel, textLabel: interestLabel, text: statusList[0],
-                                                  addLine: true)
-        watchingView = createInventorySectionView(tag: 1, countLabel: watchingCountLabel, textLabel: watchingLabel, text: statusList[1])
-        watchedView = createInventorySectionView(tag: 2, countLabel: watchedCountLabel, textLabel: watchedLabel, text: statusList[2])
-        quitView = createInventorySectionView(tag: 3, countLabel: quitCountLabel, textLabel: quitLabel, text: statusList[3])
+        let countLabels: [UILabel] = [
+            interestCountLabel,
+            watchingCountLabel,
+            watchedCountLabel,
+            quitCountLabel
+        ]
+        
+        readStatusButtons = StringLiterals.ReviewerStatus.allCases.enumerated().map { index, status in
+            createInventorySectionView (
+                countLabel: countLabels[index],
+                text: status.rawValue,
+                addLine: index == 0)
+        }
     }
     
     private func setHierarchy() {
@@ -96,10 +94,9 @@ final class MyPageInventoryView: UIView {
                                        arrowView)
         arrowView.addSubview(arrowImageView)
         
-        inventoryStackView.addArrangedSubviews(interestView,
-                                               watchingView,
-                                               watchedView,
-                                               quitView)
+        readStatusButtons.forEach {
+            inventoryStackView.addArrangedSubviews($0)
+        }
     }
     
     private func setLayout() {
@@ -137,12 +134,9 @@ final class MyPageInventoryView: UIView {
     
     //MARK: - Custom Method
     
-    private func createInventorySectionView(tag: Int, countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIView {
-        let statusView = UIView()
-        
-        statusView.do {
-            $0.tag = tag
-        }
+    private func createInventorySectionView(countLabel: UILabel, text: String, addLine: Bool = false) -> UIButton {
+        let statusButton = UIButton()
+        let textLabel = UILabel()
         
         countLabel.do {
             $0.applyWSSFont(.title2, with: "0")
@@ -155,8 +149,8 @@ final class MyPageInventoryView: UIView {
             $0.textAlignment = .center
         }
         
-        statusView.addSubviews(countLabel,
-                               textLabel)
+        statusButton.addSubviews(countLabel,
+                                 textLabel)
         
         countLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(13.5)
@@ -173,7 +167,7 @@ final class MyPageInventoryView: UIView {
                 $0.backgroundColor = .wssGray70
             }
             
-            statusView.addSubview(dividerView)
+            statusButton.addSubview(dividerView)
             
             dividerView.snp.makeConstraints {
                 $0.centerY.trailing.equalToSuperview()
@@ -182,7 +176,7 @@ final class MyPageInventoryView: UIView {
             }
         }
         
-        return statusView
+        return statusButton
     }
     
     //MARK: - Data

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -151,7 +151,7 @@ final class MyPageInventoryView: UIView {
                 
                 arrowImageView.snp.makeConstraints {
                     $0.center.equalToSuperview()
-                    $0.size.equalTo(22)
+                    $0.size.equalTo(24)
                 }
             }
             

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageInventoryView.swift
@@ -187,6 +187,3 @@ final class MyPageInventoryView: UIView {
         quitCountLabel.applyWSSFont(.title2, with: String(describing: data.quitNovelCount))
     }
 }
-
-
-

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -146,14 +146,8 @@ final class MyPageViewController: UIViewController {
             genrePreferenceButtonDidTap: genrePreferenceButtonDidTap,
             libraryButtonDidTap: libraryButtonDidTap,
             feedButtonDidTap: feedButtonDidTap,
-            inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryView.rx.tapGesture()
+            inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryTitleView.rx.tapGesture()
                 .when(.recognized)
-                .filter { [weak self] tapGesture in
-                    guard let self = self else { return false }
-                    let location = tapGesture.location(in: self.rootView.myPageLibraryView.inventoryView.inventoryStackView)
-                    return !self.rootView.myPageLibraryView.inventoryView.inventoryStackView
-                        .subviews.contains(where: { $0.frame.contains(location) })
-                }
                 .asObservable(),
             inventorySpecificPageViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryStackView.rx.tapGesture()
                 .when(.recognized)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -117,6 +117,12 @@ final class MyPageViewController: UIViewController {
     //MARK: - Bind
     
     private func bindViewModel() {
+        let inventoryStatusButtonDidTap = Observable<Int>.merge(
+            rootView.myPageLibraryView.inventoryView.readStatusButtons.enumerated().map { index, button in
+                button.rx.tap
+                    .map { index }
+            })
+        
         let genrePreferenceButtonDidTap = Observable.merge(
             rootView.myPageLibraryView.genrePrefrerencesView.myPageGenreOpenButton.rx.tap.map { true },
             rootView.myPageLibraryView.genrePrefrerencesView.myPageGenreCloseButton.rx.tap.map { false }
@@ -149,16 +155,7 @@ final class MyPageViewController: UIViewController {
             inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryTitleView.rx.tapGesture()
                 .when(.recognized)
                 .asObservable(),
-            inventorySpecificPageViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryStackView.rx.tapGesture()
-                .when(.recognized)
-                .compactMap { [weak self] tapGesture -> Int? in
-                    guard let self = self else { return nil }
-                    let location = tapGesture.location(in: self.rootView.myPageLibraryView.inventoryView.inventoryStackView)
-                    if let tappedView = self.rootView.myPageLibraryView.inventoryView.inventoryStackView
-                        .subviews.first(where: { $0.frame.contains(location) }) { return tappedView.tag }
-                    return nil
-                }
-                .asObservable(),
+            inventorySpecificPageViewDidTap: inventoryStatusButtonDidTap,
             feedDetailButtonDidTap: rootView.myPageFeedView.myPageFeedDetailButton.rx.tap,
             editProfileNotification: NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile")).asObservable(),
             feedTableViewItemSelected: rootView.myPageFeedView.myPageFeedTableView.feedTableView.rx.itemSelected.asObservable(),

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -148,6 +148,12 @@ final class MyPageViewController: UIViewController {
             feedButtonDidTap: feedButtonDidTap,
             inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryView.rx.tapGesture()
                 .when(.recognized)
+                .filter { [weak self] tapGesture in
+                    guard let self = self else { return false }
+                    let location = tapGesture.location(in: self.rootView.myPageLibraryView.inventoryView.inventoryStackView)
+                    return !self.rootView.myPageLibraryView.inventoryView.inventoryStackView
+                        .subviews.contains(where: { $0.frame.contains(location) })
+                }
                 .asObservable(),
             inventorySpecificPageViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryStackView.rx.tapGesture()
                 .when(.recognized)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -48,6 +48,7 @@ final class MyPageViewModel: ViewModelType {
     private let pushToFeedDetailViewController = PublishRelay<Int>()
     private let pushToNovelDetailViewController = PublishRelay<Int>()
     private let popViewControllerRelay = PublishRelay<Void>()
+    private let pushToSpecificLibraryViewController = PublishSubject<(Int,Int)>()
     
     private let showToastViewRelay = PublishRelay<Void>()
     private let stickyHeaderActionRelay = BehaviorRelay<Bool>(value: true)
@@ -84,6 +85,7 @@ final class MyPageViewModel: ViewModelType {
         let libraryButtonDidTap: Observable<Bool>
         let feedButtonDidTap: Observable<Bool>
         let inventoryViewDidTap: Observable<UITapGestureRecognizer>
+        let inventorySpecificPageViewDidTap: Observable<Int>
         let feedDetailButtonDidTap: ControlEvent<Void>
         
         let editProfileNotification: Observable<Notification>
@@ -125,6 +127,7 @@ final class MyPageViewModel: ViewModelType {
         
         let pushToFeedDetailViewController: Observable<Int>
         let pushToNovelDetailViewController: Observable<Int>
+        let pushToSpecificLibraryViewController: PublishSubject<(Int, Int)>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -278,6 +281,12 @@ final class MyPageViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        input.inventorySpecificPageViewDidTap
+            .bind(with: self, onNext: { owner, pageIndex in
+                self.pushToSpecificLibraryViewController.onNext((owner.profileId, pageIndex))
+            })
+            .disposed(by: disposeBag)
+        
         return Output(
             isMyPage: self.isMyPageRelay,
             isProfilePrivate: self.isProfilePrivateRelay,
@@ -308,7 +317,8 @@ final class MyPageViewModel: ViewModelType {
             stickyHeaderAction: self.stickyHeaderActionRelay,
             updateButtonWithLibraryView: self.updateButtonWithLibraryViewRelay,
             pushToFeedDetailViewController: self.pushToFeedDetailViewController.asObservable(),
-            pushToNovelDetailViewController: self.pushToNovelDetailViewController.asObservable()
+            pushToNovelDetailViewController: self.pushToNovelDetailViewController.asObservable(),
+            pushToSpecificLibraryViewController: pushToSpecificLibraryViewController
         )
     }
     


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #451 
<br/>

### 🌟Motivation

- 영역 별 터치시 해당 상태로 이동하도록 구현
- 화살표 이미지 터치 안되는 에러 해결

<br/>

### 🌟Key Changes

- 보관함 터치 영역을 섹션 별로 부여하였습니다.

<br/>

1. MyPageInventoryView 에서 Section 별 영역을 기존에는 stackView 로 구현하였지만 이를 UIView 로 바꾸었습니다. 
+Section 별 뷰를 구현할 때 tag 값을 부여하여 터치시 이를 가져올 수 있도록 하였습니다.

```swift
private func createInventorySectionView(tag: Int, countLabel: UILabel, textLabel: UILabel, text: String, addLine: Bool = false) -> UIView {
        let statusView = UIView()
        
        statusView.do {
            $0.tag = tag
        }
        
        countLabel.do {
            $0.applyWSSFont(.title2, with: "0")
            $0.textAlignment = .center
        }
        
        textLabel.do {
            $0.applyWSSFont(.body5, with: text)
            $0.textColor = .wssGray200
            $0.textAlignment = .center
        }
        
        statusView.addSubviews(countLabel,
                               textLabel)
        
        countLabel.snp.makeConstraints {
            $0.top.equalToSuperview().inset(13.5)
            $0.centerX.equalToSuperview()
        }
        
        textLabel.snp.makeConstraints {
            $0.top.equalTo(countLabel.snp.bottom).offset(2)
            $0.centerX.equalToSuperview()
        }
        
        if addLine {
            let dividerView = UIView().then {
                $0.backgroundColor = .wssGray70
            }
            
            statusView.addSubview(dividerView)
            
            dividerView.snp.makeConstraints {
                $0.centerY.trailing.equalToSuperview()
                $0.height.equalTo(40)
                $0.width.equalTo(1)
            }
        }
        
        return statusView
    }
```
<br/>

2. MyPageViewModel 에서 기존 inventoryViewDidTap 와 다른 inventorySpecificPageViewDidTap 을 추가하였으며 inventorySpecificPageViewDidTap 은 터치된 tag 값을 전달합니다.

```swift
inventorySpecificPageViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryStackView.rx.tapGesture()
                .when(.recognized)
                .compactMap { [weak self] tapGesture -> Int? in
                    guard let self = self else { return nil }
                    let location = tapGesture.location(in: self.rootView.myPageLibraryView.inventoryView.inventoryStackView)
                    if let tappedView = self.rootView.myPageLibraryView.inventoryView.inventoryStackView
                        .subviews.first(where: { $0.frame.contains(location) }) { return tappedView.tag }
                    return nil
                }
                .asObservable(),
```
<br/>

3.  inventoryViewDidTap 와  inventorySpecificPageViewDidTap 영역이 겹쳐 .filter 값으로 중복 영역 터치를 방지하였습니다.

```swift
inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryView.rx.tapGesture()
                .when(.recognized)
                .filter { [weak self] tapGesture in
                    guard let self = self else { return false }
                    let location = tapGesture.location(in: self.rootView.myPageLibraryView.inventoryView.inventoryStackView)
                    return !self.rootView.myPageLibraryView.inventoryView.inventoryStackView
                        .subviews.contains(where: { $0.frame.contains(location) })
                }
                .asObservable(),
```
<br/>

4. LibraryViewController 와 LibraryViewModel 에서 기존에 0으로 잡았던 초기값들을 변경해주었습니다.

```swift
//VC
var pageIndex: Int = 0
...
guard owner.pageIndex < StringLiterals.ReviewerStatus.allCases.count else { return }
                owner.libraryPageViewController.setViewControllers([owner.libraryPages[owner.pageIndex]],
                                                                   direction: .forward,
                                                                   animated: false,
                                                                   completion: nil)
...
libraryPageBar.libraryTabCollectionView.selectItem(at: IndexPath(item: self.pageIndex, section: 0),
                                                           animated: true,
                                                           scrollPosition: [])

//VM
let moveToTappedTabBar = PublishRelay<Int>()
```
<br/>

### 🌟Simulation

| 디자인 의뢰 영역 | 실제 구현 영역 |
|---|---|
|<img width="800" alt="스크린샷 2025-01-19 오후 10 36 58" src="https://github.com/user-attachments/assets/4f3d256d-10e4-48d9-8ee7-076cb5e51da1" />|<img width="841" alt="스크린샷 2025-01-19 오후 10 34 03" src="https://github.com/user-attachments/assets/827f8279-a16f-42f6-945f-0e51950270f2" />|

<br/>

| 회색박스 제외 터치 | 회색박스 영역별 터치 |
|---|---|
|![RPReplay_Final1737291441](https://github.com/user-attachments/assets/ace2affb-e8a3-441d-9fbb-e8e7e95ffe49)|![RPReplay_Final1737291426](https://github.com/user-attachments/assets/ae51f8d5-34fe-4944-8758-d6a45c70722b)|

<br/>

### 🌟To Reviewer
마이페이지와 라이브러리 코드가 좀 더 더러워졌습니다 ,,,
어서 스프린트끝나고 리팩 합시둥 ,,,
<br/>

### 🌟Reference
제스처 중첩 방지 => 지피티 땡큐
<br/>
