### PR TITLE
[Fix] #426 - MyPageEditView 텍스트 드래그로 부분 선택 안되는 에러 해결

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -3054,10 +3054,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = websosoDevelopment;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = websosoDebug;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -3053,7 +3053,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3095,7 +3095,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -138,10 +138,8 @@ final class MyPageEditProfileView: UIView {
                 $0.backgroundColor = .wssGray50
                 $0.layer.cornerRadius = 14
                 $0.textContainerInset = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
-                $0.spellCheckingType = .no
-                $0.autocorrectionType = .no
-                $0.autocapitalizationType = .none
                 $0.tintColor = .wssBlack
+                $0.font = .Body2
             }
             
             introTextViewPlaceholder.do {
@@ -384,9 +382,6 @@ extension MyPageEditProfileView {
     
     //닉네임
     func updateNicknameText(text: String) {
-        nicknameTextField.makeAttribute(with: text)
-            .kerning(kerningPixel: -0.6)
-            .applyAttribute()
         nicknameCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     
@@ -469,7 +464,7 @@ extension MyPageEditProfileView {
     }
     
     func updateIntro(text: String) {
-        introTextView.applyWSSFont(.body2, with: text)
+//        introTextView.applyWSSFont(.body2, with: text)
         introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -380,7 +380,7 @@ extension MyPageEditProfileView {
     }
     
     //닉네임
-    func updateNicknameText(text: String) {
+    func updateNicknameCount(text: String) {
         nicknameCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     
@@ -462,8 +462,7 @@ extension MyPageEditProfileView {
         }
     }
     
-    func updateIntro(text: String) {
-        print(introTextView.typingAttributes, "😍")
+    func updateIntroCount(text: String) {
         introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -139,7 +139,6 @@ final class MyPageEditProfileView: UIView {
                 $0.layer.cornerRadius = 14
                 $0.textContainerInset = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
                 $0.tintColor = .wssBlack
-                $0.font = .Body2
             }
             
             introTextViewPlaceholder.do {
@@ -464,14 +463,12 @@ extension MyPageEditProfileView {
     }
     
     func updateIntro(text: String) {
-//        introTextView.applyWSSFont(.body2, with: text)
         introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     
     //MARK: - Data
     
     func bindData(data: MyProfileResult) {
-        
         nicknameTextField.makeAttribute(with: data.nickname)
             .kerning(kerningPixel: -0.6)
             .applyAttribute()

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -463,6 +463,7 @@ extension MyPageEditProfileView {
     }
     
     func updateIntro(text: String) {
+        print(introTextView.typingAttributes, "😍")
         introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
@@ -126,7 +126,7 @@ final class MyPageEditProfileViewController: UIViewController {
         
         output.nicknameText
             .bind(with: self, onNext: { owner, text in
-                owner.rootView.updateNicknameText(text: text)
+                owner.rootView.updateNicknameCount(text: text)
             })
             .disposed(by: disposeBag)
         
@@ -153,7 +153,7 @@ final class MyPageEditProfileViewController: UIViewController {
         
         output.introText
             .bind(with: self, onNext: { owner, text in
-                owner.rootView.updateIntro(text: text)
+                owner.rootView.updateIntroCount(text: text)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #426 
<br/>

### 🌟Motivation

~attributedText 를 사용하니 부분 드래그가 안되는 에러가 발생하여 기본 Font 를 사용하였습니다.~

=> 업데이트 함수 내에 applyWSSFont 를 작성해두니, 업데이트 될때마다 makeAttribute 되어 텍스트 전체를 다시 렌더링하여 커서 위치를 찾을 수 없는 에러를 확인하였습니다.
효원이가 해결한 에러와도 같습니다.

하지만 초기 데이터 바인딩할때 (bindData 함수) font 를 적용해두면, [typingattributes](https://developer.apple.com/documentation/uikit/uitextfield/typingattributes) 속성으로 인해 텍스트가 업데이트 될 때마다 따로 makeAttribute 속성을 호출하지 않아도 폰트가 적용될 수 있음을 알게 되었습니다.

<br/>

### 🌟Key Changes

- TextField 
textField 의 lineHeight 가 잘 적용되지 않아 font 를 지정해주고, (수정 전) 처음 값을 연결시켜주는 bindData 함수 호출 시 makeAttribute 를 사용하였습니다.

```swift
nicknameTextField.do {
                $0.font = .Body2
                $0.textColor = .wssBlack
                $0.tintColor = .wssBlack
                $0.contentVerticalAlignment = .center
            }

/// 수정 전 처음 데이터 연결시켜줄 때 
func bindData(data: MyProfileResult) {
        nicknameTextField.makeAttribute(with: data.nickname)
            .kerning(kerningPixel: -0.6)
            .applyAttribute()
        nicknameCountView.countLabel.text = String(data.nickname.count)
    }

/// 수정 후 텍스트 업데이트 될 때 count 만 반영될 수 있도록
func updateNicknameText(text: String) {
        nicknameCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
    }
```

- TextView
 textField 와 달리 초기에 font 를 부여하지 않고 (수정 전) 처음 값을 연결시켜주는 bindData 시에 appleWSSFont 적용시켰습니다. 추후 수정이 되더라도 appleWSSFont가 잘적용됩니다.
```swift
/// 수정 전 처음 데이터 연결시켜줄 때 
func bindData(data: MyProfileResult) {
        introTextView.applyWSSFont(.body2, with: data.intro)
     ...
    }
/// 수정 후 텍스트 업데이트 될 때 count 만 반영될 수 있도록
func updateIntro(text: String) {
        introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
    }
```
<br/>

### 🌟Simulation
| 닉네임 TextField | 소개 TextView |
|---|---|
|![RPReplay_Final1737632024](https://github.com/user-attachments/assets/8d153e68-8ad3-45ae-b5e6-89d15e5840d4)|![RPReplay_Final1737632044](https://github.com/user-attachments/assets/f377608c-4df5-4154-834f-4f86ffd0e368)|

<br/>

