### PR TITLE
[Feat] #466 - 피드 관련 공지사항 알림 읽음 처리 API 구현 

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -3058,10 +3058,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = websosoDevelopment;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = websosoDebug;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/WSSiOS/WSSiOS/Network/Notification/NotificationService.swift
+++ b/WSSiOS/WSSiOS/Network/Notification/NotificationService.swift
@@ -13,6 +13,7 @@ protocol NotificationService {
     func getNotifications(lastNotificationId: Int, size: Int) -> Single<NotificationsResult>
     func getNotificationDetail(notificationId: Int) -> Single<NotificationDetailResult>
     func getNotificationUnreadStatus() -> Single<NotificationUnreadStatusResult>
+    func postNotificationRead(notificationId: Int) -> Single<Void>
 }
 
 final class DefaultNoticeService: NSObject, Networking, NotificationService {
@@ -73,6 +74,24 @@ final class DefaultNoticeService: NSObject, Networking, NotificationService {
             return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0, to: NotificationUnreadStatusResult.self) }
                 .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
+    
+    func postNotificationRead(notificationId: Int) -> Single<Void> {
+        do {
+            let request = try makeHTTPRequest(method: .post,
+                                              path: URLs.Notification.postNotificationRead(notificationId: notificationId),
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+            
+            NetworkLogger.log(request: request)
+            
+            return tokenCheckURLSession.rx.data(request: request)
+                .map { _ in }
+                .asSingle()
+            
         } catch {
             return Single.error(error)
         }

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -176,6 +176,9 @@ enum URLs {
             return "/notifications/\(notificationId)"
         }
         static let getNotificationUnreadStatus = "/notifications/unread"
+        static func postNotificationRead(notificationId: Int) -> String {
+            return "/notifications/\(notificationId)/read"
+        }
     }
     
     enum Search {

--- a/WSSiOS/WSSiOS/Source/Data/Repository/NotificationRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/NotificationRepository.swift
@@ -13,6 +13,7 @@ protocol NotificationRepository {
     func getNotifications(lastNotificationId: Int) -> Observable<NotificationsEntity>
     func getNotificationDetail(notificationId: Int) -> Observable<NotificationDetailEntity>
     func getNotificationUnreadStatus() -> Observable<NotificationUnreadStatusResult>
+    func postNotificationRead(notificationId: Int) -> Observable<Void>
 }
 
 struct TestNotificationRepository: NotificationRepository {
@@ -36,6 +37,10 @@ struct TestNotificationRepository: NotificationRepository {
     
     func getNotificationUnreadStatus() -> Observable<NotificationUnreadStatusResult> {
         return Observable.just(NotificationUnreadStatusResult(hasUnreadNotifications: false))
+    }
+    
+    func postNotificationRead(notificationId: Int) -> Observable<Void> {
+        return Observable.just(())
     }
 }
 
@@ -64,6 +69,11 @@ struct DefaultNotificationRepository: NotificationRepository {
     
     func getNotificationUnreadStatus() -> Observable<NotificationUnreadStatusResult> {
         return notificationService.getNotificationUnreadStatus()
+            .asObservable()
+    }
+    
+    func postNotificationRead(notificationId: Int) -> Observable<Void> {
+        return notificationService.postNotificationRead(notificationId: notificationId)
             .asObservable()
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotice/HomeNoticeViewModel/HomeNoticeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotice/HomeNoticeViewModel/HomeNoticeViewModel.swift
@@ -79,16 +79,14 @@ final class HomeNoticeViewModel: ViewModelType {
             }
             .subscribe(with: self, onNext: { owner, notification in
                 let notificationId = notification.notificationId
-                guard let feedId = notification.feedId else { return }
-                
                 if notification.isNotice {
                     owner.pushToNoticeDetailViewController.accept(notificationId)
                 } else if notification.isRead {
-                    owner.pushToFeedDetailViewController.accept(feedId)
+                    owner.pushToFeedDetailViewController.accept(notification.feedId ?? -1)
                 } else {
                     self.postNotificationRead(notificationId: notificationId)
                         .subscribe(onCompleted: {
-                            self.pushToFeedDetailViewController.accept(feedId)
+                            self.pushToFeedDetailViewController.accept(notification.feedId ?? -1)
                         })
                         .disposed(by: self.disposeBag)
                 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotice/HomeNoticeViewModel/HomeNoticeViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotice/HomeNoticeViewModel/HomeNoticeViewModel.swift
@@ -125,4 +125,8 @@ final class HomeNoticeViewModel: ViewModelType {
     private func getNotifications(lastNotificationId: Int) -> Observable<NotificationsEntity> {
         return notificationRepository.getNotifications(lastNotificationId: lastNotificationId)
     }
+    
+    private func postNotificationRead(notificationId: Int) -> Observable<Void> {
+        return notificationRepository.postNotificationRead(notificationId: notificationId)
+    }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #466 
<br/>

### 🌟Motivation
- 피드 관련 공지사항을 클릭했을 때 알림 읽음 처리가 될 수 있도록 하는 POST API 연결 했습니다. 
<br/>

### 🌟Key Changes
각 공지사항의 상태에 따른 분기처리를 `HomeNoticeVM`에서 처리해주었습니다. 
**1. 공지사항일 때 -> 공지사항 상세뷰로 이동**
**2. 이미 읽은 공지사항일 때 -> 별도의 서버 요청 없이 피드 상세뷰로 이동**
ㄴ 이때에 공지사항은 자체적으로 서버에서 읽음 처리를 해주나, 피드 관련 공지사항은 따로 클라에서 post를 해줘야 하기 때문
**3. 이외의 상황일 때 (읽지 않았고 피드 관련 공지사항일 때) -> 읽음 처리 API POST 후 피드 상세뷰로 이동** 

```swift
input.noticeTableViewCellSelected
    .map { indexPath -> NotificationEntity in
        return self.notificationList.value[indexPath.row]
    }
    .subscribe(with: self, onNext: { owner, notification in
        let notificationId = notification.notificationId
        guard let feedId = notification.feedId else { return }
                
        if notification.isNotice {
            owner.pushToNoticeDetailViewController.accept(notificationId)
        } else if notification.isRead {
            owner.pushToFeedDetailViewController.accept(feedId)
        } else {
            self.postNotificationRead(notificationId: notificationId)
                .subscribe(onCompleted: {
                    self.pushToFeedDetailViewController.accept(feedId)
                })
                .disposed(by: self.disposeBag)
        }
    })
    .disposed(by: disposeBag)
```
<br/>


### 🌟Simulation
해당 작업 브랜치로 이동하여 확인 부탁드립니다. 
<br/>

### 🌟To Reviewer
~**PR #449 머지 후 리뷰 부탁드립니다 ( _ _ )**~
리뷰 부탁드립니다~
<br/>

### 🌟Reference

<br/>
