### PR TITLE
[Feat] #471 - 수출 규정 No 로 default 값 설정

### DIFF
--- a/WSSiOS/WSSiOS/Info.plist
+++ b/WSSiOS/WSSiOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>AMPLITUDE_API_KEY</key>
 	<string>$(AMPLITUDE_API_KEY)</string>
 	<key>APPSTORE_ID</key>


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #471 
<br/>

### 🌟Motivation

테스트플라이트를 올릴 때마다 AppStoreConnect 에 연결 될때까지 기다리고, 수출 관련 문서를 작성해주는 수고가 있었습니다. 이를 Xcode Plist 를 통해 Default 값을 지정하여 해결하였습니다.
추후 수출 규정을 작성해야 할 시 설정을 지우면 됩니다.

<br/>

### 🌟Simulation

기존 설정해주어야 하는 설정창

<img width="1015" alt="스크린샷 2025-01-31 오후 4 30 17" src="https://github.com/user-attachments/assets/3b61b738-904a-45c5-822c-7cf6b611b4a2" />

<br/>

자동으로 수출규정 관련 문서의 설정이 완료된 것을 볼 수 있음

<img width="346" alt="스크린샷 2025-01-31 오후 4 33 32" src="https://github.com/user-attachments/assets/1345aeb7-cd99-4493-bac0-3e5fe3c66622" />



<br/>
