### PR TITLE
[Fix] #476 - 동일계정 여러기기의 경우, 한 기기에서 회원 탈퇴시 다른 기기에서 발생하는 오류 처리

### DIFF
--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -53,6 +53,7 @@ class TokenCheckURLProtocol: URLProtocol {
                 self.handleUnauthorizedResponse()
             } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {  // 요청의 응답 상태 코드가 404인 경우 탈퇴한 것으로, 무조건 로그인 창으로 이동
                 self.deleteTokenAndMoveToLoginViewController(error: NetworkServiceError.authenticationError)
+                print("404 에러로 로그인 화면으로 돌아갑니다.")
             } else { // 401, 404가 아닌 경우 일반적인 응답 처리
                 self.handleTaskResult(data: data, response: response, error: error)
             }

--- a/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/TokenCheckURLProtocol.swift
@@ -107,7 +107,7 @@ class TokenCheckURLProtocol: URLProtocol {
     private func deleteTokenAndMoveToLoginViewController(error: Error) {
         // 실패 시 토큰을 삭제하고 로그인 VC로 이동
         DispatchQueue.main.async {
-            self.deleteTokens()
+            self.deleteUserInfo()
             self.moveToLoginViewController()
         }
         self.client?.urlProtocol(self, didFailWithError: error)
@@ -127,11 +127,12 @@ extension TokenCheckURLProtocol {
                                        forKey: StringLiterals.UserDefault.refreshToken)
     }
     
-    private func deleteTokens() {
-        UserDefaults.standard.setValue(nil,
-                                       forKey: StringLiterals.UserDefault.accessToken)
-        UserDefaults.standard.setValue(nil,
-                                       forKey: StringLiterals.UserDefault.refreshToken)
+    private func deleteUserInfo() {
+        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefault.userId)
+        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefault.userNickname)
+        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefault.userGender)
+        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefault.accessToken)
+        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefault.refreshToken)
     }
     
     private func moveToLoginViewController() {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #476 
<br/>

### 🌟Motivation
- 동일계정 여러기기의 경우, 한 기기에서 회원 탈퇴시 다른 기기에서 아무런 동작을 할 수 없는 에러를 수정합니다.
<br/>

### 🌟Key Changes
- 404 에러인 경우가 handle되고 있지 않아 생긴 문제로, 401에러와 다르게 404인 경우 무조건 바로 로그인 화면으로 이동하도록 변경했습니다.
- 원래 401, 404 에러의 경우 로그인 창으로 돌아갈 때 토큰만 삭제 했었는데, 이러면 다시 로그인한 경우 마이페이지에서 404 에러가 발생하는 오류가 있었습니다. UserDefault에 저장된 User Data가 남아있어 생긴 오류로, 로그아웃이나 회원 탈퇴시에 삭제하는 UserDate를 동일하게 모두 삭제해주도록 변경하여 해결했습니다.
<br/>

### 🌟Simulation
- 동일한 계정에 로그인된 한 기기에서 탈퇴한 경우, 다른 기기에서는 먹통이 됨.
![Simulator Screen Recording - iPhone 16 Pro - 2025-02-13 at 14 31 17](https://github.com/user-attachments/assets/4fbca614-ef00-4b0a-8ded-760d3986108e)

- 수정 후, 404 에러가 뜨면 로그인 화면으로 이동함.
![Simulator Screen Recording - iPhone 16 Pro - 2025-02-13 at 15 29 52](https://github.com/user-attachments/assets/de13e9a4-be98-451a-a0d8-b70b9382a8ca)


<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
