### PR TITLE
[Fix] #481 - 공지사항 무한스크롤 작동되지 않는 이슈 해결

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotification/HomeNotificationViewModel/HomeNotificationViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/HomeNotification/HomeNotificationViewModel/HomeNotificationViewModel.swift
@@ -65,7 +65,9 @@ final class HomeNotificationViewModel: ViewModelType {
             .subscribe(onNext: { data in
                 self.notificationList.accept(data.notifications)
                 self.isLoadable = data.isLoadable
-                self.lastNotificationId = data.notifications.count
+                if let lastNotification = data.notifications.last {
+                    self.lastNotificationId = lastNotification.notificationId
+                }
                 self.showLoadingView.accept(false)
             }, onError: { error in
                 print("Error fetching notifications: \(error)")
@@ -112,7 +114,9 @@ final class HomeNotificationViewModel: ViewModelType {
                 let newData = owner.notificationList.value + data.notifications
                 owner.notificationList.accept(newData)
                 owner.isLoadable = data.isLoadable
-                owner.lastNotificationId += data.notifications.count
+                if let lastNotification = data.notifications.last {
+                    owner.lastNotificationId = lastNotification.notificationId
+                }
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
### ⭐️Issue
- close #481 
<br/>

### 🌟Motivation
- 공지사항 무한스크롤이 안되는 이슈를 해결했습니다. 
<br/>

### 🌟Key Changes
#### AS-IS
lastNotificationId를 단순한 데이터의 개수로 증가시켰습니다. 
```swift
lastNotificationId += data.notifications.count
```

#### TO-BE
이전 방식의 문제점: 모든 알림이 모든 유저에게 다 동일하게 전달되지 않는다.
EX) 이나는 400번 알림을 받고 구리스는 400번 알림을 받지 않음.
따라서 일정한 개수만큼 `lastNotificationId`를 증가시키면 구리스는 400번이 없기 때문에 빈 배열이 전달된다.
**-> 받아온 마지막 데이터의 notificationId를 받아 넣어주도록 수정했습니다.** 
```swift
if let lastNotification = data.notifications.last {
    self.lastNotificationId = lastNotification.notificationId
}
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2025-02-16 at 15 37 23](https://github.com/user-attachments/assets/d994a927-9a9e-42a6-89a3-e86cccdc7dfb)

<br/>

### 🌟To Reviewer
이전의 무한스크롤은 count로 넣어줘서 잘될거라 생각했는데...!
상황 케이스를 잘 생각해서 코드를 짜야 할 것 같네요 ㅜㅜ 반성했습니다..
<br/>

### 🌟Reference
X
<br/>
