### PR TITLE
[Hotfix] #476 - 2차 스프린트 1차 QA 사항 수정

### DIFF
--- a/WSSiOS/WSSiOS/Network/Auth/AuthService.swift
+++ b/WSSiOS/WSSiOS/Network/Auth/AuthService.swift
@@ -16,6 +16,7 @@ protocol AuthService {
     func reissueToken() -> Single<ReissueResult>
     func postWithdrawId(reason: String, refreshToken: String) -> Single<Void>
     func postLogout(logoutRequest: LogoutRequest) -> Single<Void>
+    func checkUserisValid() -> Single<Void>
 }
 
 
@@ -122,6 +123,25 @@ final class DefaultAuthService: NSObject, Networking, AuthService {
             NetworkLogger.log(request: request)
 
             return tokenCheckURLSession.rx.data(request: request)
+                .map { _ in }
+                .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
+    
+    /// UserMe API로 탈퇴한 유저인지 확인함
+    func checkUserisValid() -> Single<Void> {
+        do {
+            let request = try makeHTTPRequest(method: .get,
+                                              path: URLs.User.userme,
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+            
+            
+            NetworkLogger.log(request: request)
+            
+            return basicURLSession.rx.data(request: request)
                 .map { _ in }
                 .asSingle()
         } catch {

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/ServiceTermAgreement/ServiceTerm.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/ServiceTermAgreement/ServiceTerm.swift
@@ -41,7 +41,7 @@ enum ServiceTerm: CaseIterable {
         case .serviceAgreement:
             return "서비스 이용약관 동의"
         case .privacyPolicy:
-            return "개인정보 수집 및 이용 안내"
+            return "개인정보 수집 및 이용 동의"
         case .marketingConsent:
             return "마케팅 정보 수신 동의"
         }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #476 
<br/>

### 🌟Motivation
- 404 처리가 잘못되어서, 회원 탈퇴가 아닌 404 에러에도 모두 로그인 화면으로 돌아가는 오류 해결
- 약관 동의 화면 UX 라이팅 변경
<br/>

### 🌟Key Changes
- 404 에러가 오면, 다른 일반 API를 호출하여 실제로 회원 탈퇴를 했는지 확인하도록 했는데, 이때 기존 서비스에 있는 API 를 사용해 호출하였기 때문에 해당 API 도 다시 404 에러가 떠서 또 동일한 API를 호출하는 무한 재귀에 빠지는 오류가 있었습니다. 
- 해당 오류 때문에 QA 때는 일단 404면 다 로그인으로 돌아가도록 했더니, 회원 탈퇴를 한 경우가 아닐 때에도 로그인으로 돌아가는 현상이 생겼습니다.
- 토큰체크URL Session을 사용하지 않는 토큰 리이슈 API를 사용하면 회원 탈퇴 여부를 확인하면서도 무한 재귀에 빠지지 않기 때문에, 일단 401 때와 동일하게 처리하도록 수정했습니다.
<br/>


### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
