### PR TITLE
[Fix] #498 - 피드 길이가 길어질 때 마지막 2개의 댓글이 잘리는 이슈 해결 

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyView.swift
@@ -100,7 +100,7 @@ final class FeedDetailReplyView: UIView {
         
         let cellFrameInSuperview = cell.convert(cell.bounds, to: self)
         let numberOfItems = replyCollectionView.numberOfItems(inSection: indexPath.section)
-        let isLastTwoCells = numberOfItems >= 3 && indexPath.item >= numberOfItems - 2
+        let isLastTwoCells = indexPath.item >= numberOfItems - 2
         
         dropdownView.snp.updateConstraints {
             $0.top.equalToSuperview().inset(isLastTwoCells ? cellFrameInSuperview.minY - dropdownView.frame.height : cellFrameInSuperview.minY + 40)


### PR DESCRIPTION
### ⭐️Issue
- close #498 
<br/>

### 🌟Motivation
- 피드 길이가 길어질 때 마지막 2개의 댓글이 잘리는 이슈 해결했습니다. 
<br/>

### 🌟Key Changes
- 기존에는 `let isLastTwoCells = numberOfItems >= 3 && indexPath.item >= numberOfItems - 2` 로 설정하여 cell의 개수가 3개 이상일 때에만 마지막 댓글 2개만 드롭다운이 상단에 위치하도록 했습니다. 
그러나 피드 길이가 길어질 떄에는 댓글 개수가 2개 이하면 드롭다운이 잘리는 현상이 발생하여 **cell 개수에 대한 조건을 제거하였습니다.** 
``` swift
// FeedDetailReplyView.swift 

func updateDropdownViewLayout(indexPath: IndexPath) {
        guard let cell = replyCollectionView.cellForItem(at: indexPath) else { return }
        
        let cellFrameInSuperview = cell.convert(cell.bounds, to: self)
        let numberOfItems = replyCollectionView.numberOfItems(inSection: indexPath.section)
        let isLastTwoCells = indexPath.item >= numberOfItems - 2 // 수정한 부분 
        
        dropdownView.snp.updateConstraints {
            $0.top.equalToSuperview().inset(isLastTwoCells ? cellFrameInSuperview.minY - dropdownView.frame.height : cellFrameInSuperview.minY + 40)
            $0.trailing.equalToSuperview().inset(20)
        }
    }
```
<br/>

### 🌟Simulation
| Before | After | 
| -- |  -- |
| ![Simulator Screenshot - iPhone 13 mini - 2025-03-24 at 00 39 07](https://github.com/user-attachments/assets/a160df03-b9ed-4c89-86c4-7efd669d234a)| ![Simulator Screenshot - iPhone 13 mini - 2025-03-24 at 00 36 45](https://github.com/user-attachments/assets/e4cef15c-754c-4314-9222-ec6f01f53196)|
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
