### PR TITLE
[Fix] #519 - My에서 보관함 -> 서재로 네이밍 변경

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -195,7 +195,7 @@ enum StringLiterals {
         enum Profile {
             static let registerNovel = "등록 작품"
             static let record = "기록"
-            static let inventoryTitle = "보관함"
+            static let inventoryTitle = "서재"
             static let preferenceEmpty = "취향 분석"
             static let preferenceEmptyLabel = "작품 취향을 파악할 수 없어요"
             static let genrePreferenceTitle = "장르 취향"


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #519 
<br/>

### 🌟Motivation
- 서재로 바뀐 UX라이팅이 누락되어서 적용했습니다.
<br/>

### 🌟Key Changes

<br/>

```swift
abc
```
<br/>

### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
