### PR TITLE
[Fix] #529 - 타인 보관함을 보려고 해도 본인의 서재 탭으로 이동하는 오류 해결

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -204,7 +204,7 @@ enum StringLiterals {
             static let privateLabel = "님의 프로필은\n비공개 상태예요"
             static let unknownAlertButtonTitle = "확인"
             static let myProfileLibrary = "내 통계"
-            static let otherProfileLibrary = "서재"
+            static let otherProfileLibrary = "통계"
             static let myProfileFeed = "내 활동"
             static let otherProfileFeed = "활동"
             static let activityButton = "활동기록 더보기"

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -387,6 +387,14 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
+    func pushToLibraryViewController(userId: Int, pageIndex: Int = 0) {
+        let viewController = LibraryViewController(userId: userId)
+
+        viewController.setPageIndex(target: pageIndex)
+        viewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
     func pushToMyPageFeedDetailViewController(userId: Int, useData: MyProfileEntity) {
         let viewController = MyPageFeedDetailViewController(
             viewModel: MyPageFeedDetailViewModel(

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
@@ -85,7 +85,7 @@ final class WSSTabBarController: UITabBarController {
             self.setTabBarController()
         }
         
-        NotificationCenter.default.rx.notification(Notification.Name("MoveToLibraryTab"))
+        NotificationCenter.default.rx.notification(StringLiterals.NotificationCenter.moveToLibraryTab)
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, notification in
                 if let libraryNavigationVC = owner.viewControllers?[WSSTabBarItem.library.rawValue] as? UINavigationController,

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -18,6 +18,10 @@ final class LibraryViewController: UIViewController {
     
     private var pageIndex: Int = 0
     private let userId: Int
+    private var isMyLibrary: Bool {
+        let myId = UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
+        return self.userId == myId
+    }
     private let disposeBag = DisposeBag()
     private let sortTypeList = StringLiterals.Alignment.self
     private let readStatusList = StringLiterals.LibraryReadStatus.allCases.map { $0.rawValue }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -36,6 +36,7 @@ final class LibraryViewController: UIViewController {
     private let libraryPageViewController = UIPageViewController(transitionStyle: .scroll,
                                                                  navigationOrientation: .horizontal,
                                                                  options: nil)
+    private let backButton = UIButton()
     
     // MARK: - Life Cycle
     
@@ -53,7 +54,7 @@ final class LibraryViewController: UIViewController {
         
         setUI()
         setHierarchy()
-        setLayout()
+        setLayout(isMyLibrary: isMyLibrary)
         
         delegate()
         register()
@@ -64,7 +65,7 @@ final class LibraryViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(true, animated: true)
+        setLibraryViewUI()
         setPageViewControllerToPageIndex()
     }
     
@@ -146,7 +147,18 @@ final class LibraryViewController: UIViewController {
         guard target >= 0, target < self.tabBarList.count else { return }
         self.pageIndex = target
     }
-    
+
+    func setLibraryViewUI() {
+        if isMyLibrary {
+            self.navigationController?.setNavigationBarHidden(true, animated: true)
+        } else {
+            hideTabBar()
+            setWSSNavigationBar(title: StringLiterals.Navigation.Title.library,
+                                left: backButton,
+                                right: nil)
+            self.libraryNavigationView.isHidden = true
+        }
+    }
 }
 
 //MARK: - Set PageController
@@ -194,6 +206,10 @@ extension LibraryViewController {
     
     private func setUI() {
         self.view.backgroundColor = .wssWhite
+        
+        backButton.do {
+            $0.setImage(.icNavigateLeft.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray300), for: .normal)
+        }
     }
     
     private func setHierarchy() {
@@ -204,17 +220,27 @@ extension LibraryViewController {
         libraryPageViewController.didMove(toParent: self)
     }
     
-    private func setLayout() {
-        libraryNavigationView.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(52)
-        }
-        
-        libraryPageBar.snp.makeConstraints() {
-            $0.top.equalTo(libraryNavigationView.snp.bottom)
-            $0.width.equalToSuperview()
-            $0.height.equalTo(54)
+    private func setLayout(isMyLibrary: Bool) {
+        if isMyLibrary {
+            libraryNavigationView.snp.makeConstraints {
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+                $0.leading.trailing.equalToSuperview()
+                $0.height.equalTo(52)
+            }
+            
+            libraryPageBar.snp.makeConstraints() {
+                $0.top.equalTo(libraryNavigationView.snp.bottom)
+                $0.width.equalToSuperview()
+                $0.height.equalTo(54)
+            }
+        } else {
+            libraryNavigationView.isHidden = true
+            
+            libraryPageBar.snp.makeConstraints() {
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+                $0.width.equalToSuperview()
+                $0.height.equalTo(54)
+            }
         }
         
         libraryPageViewController.view.snp.makeConstraints {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryViewController/LibraryViewController.swift
@@ -61,6 +61,7 @@ final class LibraryViewController: UIViewController {
         
         setupPageBar()
         setupPageViewController()
+        bindAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -129,6 +130,14 @@ final class LibraryViewController: UIViewController {
         }
     }
     
+    private func bindAction() {
+        backButton.rx.tap
+            .bind(with: self, onNext: { owner, _ in
+                owner.popToLastViewController()
+            })
+            .disposed(by: disposeBag)
+    }
+    
     //MARK: - Custom Method
     
     private func setPageViewControllerToPageIndex() {
@@ -139,15 +148,15 @@ final class LibraryViewController: UIViewController {
             completion: nil
         )
         libraryPageBar.libraryTabCollectionView.selectItem(at: IndexPath(item: pageIndex, section: 0),
-                                                                 animated: true,
-                                                                 scrollPosition: [])
+                                                           animated: true,
+                                                           scrollPosition: [])
     }
     
     func setPageIndex(target: Int) {
         guard target >= 0, target < self.tabBarList.count else { return }
         self.pageIndex = target
     }
-
+    
     func setLibraryViewUI() {
         if isMyLibrary {
             self.navigationController?.setNavigationBarHidden(true, animated: true)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -332,17 +332,32 @@ final class MyPageViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.pushToLibraryViewController
+            .withLatestFrom(output.isMyPage) {
+                (userId, isMyPage) in (userId, isMyPage)
+            }
             .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, userId in
-                NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: nil)
+            .bind(with: self, onNext: { owner, data in
+                let (userId, isMyPage) = data
+                if isMyPage {
+                    NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: nil)
+                } else {
+                    owner.pushToLibraryViewController(userId: userId)
+                }
             })
             .disposed(by: disposeBag)
         
         output.pushToSpecificLibraryViewController
+            .withLatestFrom(output.isMyPage) {
+                (userData, isMyPage) in  (userData.0, userData.1, isMyPage)
+            }
             .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, userData in
-                let (_, pageIndex) = userData
-                NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: pageIndex)
+            .bind(with: self, onNext: { owner, data in
+                let (userId, pageIndex, isMyPage) = data
+                if isMyPage {
+                    NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: pageIndex)
+                } else {
+                    owner.pushToLibraryViewController(userId: userId)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -339,7 +339,7 @@ final class MyPageViewController: UIViewController {
             .bind(with: self, onNext: { owner, data in
                 let (userId, isMyPage) = data
                 if isMyPage {
-                    NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: nil)
+                    NotificationCenter.default.post(name: StringLiterals.NotificationCenter.moveToLibraryTab, object: nil)
                 } else {
                     owner.pushToLibraryViewController(userId: userId)
                 }
@@ -347,14 +347,14 @@ final class MyPageViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.pushToSpecificLibraryViewController
-            .withLatestFrom(output.isMyPage) {
-                (userData, isMyPage) in  (userData.0, userData.1, isMyPage)
+            .withLatestFrom(output.isMyPage) { (userData, isMyPage) in
+               (userData.0, userData.1, isMyPage)
             }
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, data in
                 let (userId, pageIndex, isMyPage) = data
                 if isMyPage {
-                    NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: pageIndex)
+                    NotificationCenter.default.post(name: StringLiterals.NotificationCenter.moveToLibraryTab, object: pageIndex)
                 } else {
                     owner.pushToLibraryViewController(userId: userId, pageIndex: pageIndex)
                 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -356,7 +356,7 @@ final class MyPageViewController: UIViewController {
                 if isMyPage {
                     NotificationCenter.default.post(name: Notification.Name("MoveToLibraryTab"), object: pageIndex)
                 } else {
-                    owner.pushToLibraryViewController(userId: userId)
+                    owner.pushToLibraryViewController(userId: userId, pageIndex: pageIndex)
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #529 
<br/>

### 🌟Motivation
- 타인 프로필에서의 처리가 누락되어있던 것들을 수정했습니다.
<br/>

### 🌟Key Changes
- 타인 프로필에서의 라이팅 변경
- 타인 프로필에서는 서재 뷰가 네비게이션 방식으로 들어가도록 변경
- 타인 프로필에서 들어간 서재 뷰 UI는 이전과 동일하도록 복구
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 16 Pro - 2025-04-20 at 10 29 16](https://github.com/user-attachments/assets/cba488c2-790b-4c69-9178-eb9b629bcddb)

<br/>

### 🌟To Reviewer
- 아니 다른 Rx객체의 값을 가져올때, 기존 값과 합쳐서 원하는 대로 구성해서 스트림에 전달하는게 되는 거였더라구요..? 매번 map으로 가져오던 나 반성합니다..
```swift
.withLatestFrom(output.isMyPage) {
    (userData, isMyPage) in  (userData.0, userData.1, isMyPage)
}

```
<br/>

### 🌟Reference

<br/>
