### PR TITLE
[Feat] #531 - FeedListCell 내 피드 공개 여부 UI 반영 

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -609,6 +609,7 @@ enum StringLiterals {
     enum Feed {
         static let spoilerText = "스포일러가 포함된 글 보기"
         static let modifiedText = "(수정됨)"
+        static let isPrivate = "비공개 기록이에요."
     }
     
     enum FeedDetail {

--- a/WSSiOS/WSSiOS/Source/Data/DTO/MyFeedListResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/MyFeedListResponse.swift
@@ -27,4 +27,5 @@ struct MyFeedResponse: Decodable {
     let novelRating: Float?
     let novelRatingCount: Int?
     let relevantCategories: [String]
+    let isPublic: Bool
 }

--- a/WSSiOS/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
@@ -31,6 +31,7 @@ struct TotalFeedResponse: Decodable {
     let isSpoiler: Bool
     let isModified: Bool
     let isMyFeed: Bool
+    let isPublic: Bool
 }
 
 struct FeedContentRequest: Encodable {

--- a/WSSiOS/WSSiOS/Source/Data/Entity/MyFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/MyFeedListEntity.swift
@@ -33,6 +33,7 @@ struct MyFeedEntity {
     let novelRating: Float
     let novelRatingCount: Int
     let relevantCategories: [String]
+    let isPublic: Bool
 }
 
 extension MyFeedResponse {
@@ -60,7 +61,8 @@ extension MyFeedResponse {
                             title: self.title ?? "",
                             novelRating: makeNovelRating,
                             novelRatingCount: self.novelRatingCount ?? -1,
-                            relevantCategories: translatedGenres)
+                            relevantCategories: translatedGenres,
+                            isPublic: isPublic)
     }
     
     private func formattedDate() -> String {

--- a/WSSiOS/WSSiOS/Source/Data/Entity/TotalFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/TotalFeedListEntity.swift
@@ -39,6 +39,7 @@ struct TotalFeedEntity {
     let isSpoiler: Bool
     let isModified: Bool
     let isMyFeed: Bool
+    let isPublic: Bool
 }
 
 extension TotalFeedResponse {
@@ -68,7 +69,8 @@ extension TotalFeedResponse {
             relevantCategories: categoryText,
             isSpoiler: self.isSpoiler,
             isModified: self.isModified,
-            isMyFeed: self.isMyFeed
+            isMyFeed: self.isMyFeed,
+            isPublic: self.isPublic
         )
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListPrivateView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListPrivateView.swift
@@ -1,0 +1,63 @@
+//
+//  FeedListPrivateView.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/1/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedListPrivateView: UIView {
+    
+    //MARK: - Components
+    
+    private let lockImageView = UIImageView()
+    private let privateFeedLabel = UILabel()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - UI
+    
+    private func setUI() {
+        lockImageView.do {
+            $0.image = .icLock.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray200)
+        }
+        
+        privateFeedLabel.do {
+            $0.applyWSSFont(.body4, with: StringLiterals.Feed.isPrivate)
+            $0.textColor = .wssGray200
+        }
+    }
+    
+    private func setHierarchy() {
+        self.addSubviews(lockImageView,
+                         privateFeedLabel)
+    }
+    
+    private func setLayout() {
+        lockImageView.snp.makeConstraints {
+            $0.size.equalTo(18)
+            $0.leading.centerY.equalToSuperview()
+        }
+        
+        privateFeedLabel.snp.makeConstraints {
+            $0.leading.equalTo(lockImageView.snp.trailing).offset(6)
+            $0.verticalEdges.equalToSuperview().inset(10)
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedCell/FeedPageBarCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedCell/FeedPageBarCollectionViewCell.swift
@@ -46,7 +46,6 @@ final class FeedPageBarCollectionViewCell: UICollectionViewCell {
         }
         
         titleLabel.do {
-            $0.font = .Title3
             $0.textColor = isSelected ? .wssWhite : .wssGray300
         }
     }
@@ -66,10 +65,7 @@ final class FeedPageBarCollectionViewCell: UICollectionViewCell {
     func bindData(text: NewNovelGenre) {
         titleLabel.do {
             $0.text = text.withKorean
-            $0.makeAttribute(with: $0.text)?
-                .lineSpacing(spacingPercentage: 0)
-                .kerning(kerningPixel: -0.6)
-                .applyAttribute()
+            $0.applyWSSFont(.title3, with: $0.text)
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedPageBar.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedPageBar.swift
@@ -54,8 +54,7 @@ final class FeedPageBar: UIView {
     
     private func setLayout() {
         feedPageBarCollectionView.snp.makeConstraints() {
-            $0.top.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedViewController.swift
@@ -246,8 +246,8 @@ extension FeedViewController {
         }
         
         pageBar.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom).offset(6)
-            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(41)
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -16,7 +16,6 @@ final class FeedDetailContentView: UIView {
     
     private let contentLabel = UILabel()
     let linkNovelView = FeedNovelView()
-    private let genreLabel = UILabel()
     let reactView = FeedReactView()
     private let dividerView = UIView()
     
@@ -40,10 +39,6 @@ final class FeedDetailContentView: UIView {
             $0.textColor = .wssBlack
         }
         
-        genreLabel.do {
-            $0.textColor = .wssGray200
-        }
-        
         dividerView.do {
             $0.backgroundColor = .wssGray50
         }
@@ -52,7 +47,6 @@ final class FeedDetailContentView: UIView {
     private func setHierarchy() {
         self.addSubviews(contentLabel,
                          linkNovelView,
-                         genreLabel,
                          reactView,
                          dividerView)
     }
@@ -69,13 +63,8 @@ final class FeedDetailContentView: UIView {
             $0.height.equalTo(48)
         }
         
-        genreLabel.snp.makeConstraints {
-            $0.top.equalTo(linkNovelView.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-        
         reactView.snp.makeConstraints {
-            $0.top.equalTo(genreLabel.snp.bottom).offset(24)
+            $0.top.equalTo(linkNovelView.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         
@@ -106,16 +95,10 @@ final class FeedDetailContentView: UIView {
                                    participants: data.novelRatingCount ?? 0)
         } else {
             linkNovelView.isHidden = true
-            genreLabel.snp.remakeConstraints {
+            reactView.snp.remakeConstraints {
                 $0.top.equalTo(contentLabel.snp.bottom).offset(20)
                 $0.leading.trailing.equalToSuperview().inset(20)
             }
-        }
-
-        genreLabel.do {
-            let genreCategories = data.genreCategories.joined(separator: ",")
-            $0.applyWSSFont(.body2, with: genreCategories)
-            $0.lineBreakMode = .byTruncatingTail
         }
         
         reactView.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
@@ -84,10 +84,11 @@ final class FeedListTableViewCell: UITableViewCell {
     
     private func setLayout() {
         stackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(20)
+            $0.top.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(10)
             
             stackView.do {
-                $0.setCustomSpacing(12, after: feedHeaderView)
+                $0.setCustomSpacing(10, after: feedHeaderView)
                 $0.setCustomSpacing(20, after: feedContentView)
             }
         }
@@ -159,7 +160,7 @@ final class FeedListTableViewCell: UITableViewCell {
             
             self.stackView.insertArrangedSubview(feedConnectedNovelView, at: 2)
             stackView.do {
-                $0.setCustomSpacing(20, after: feedConnectedNovelView)
+                $0.setCustomSpacing(10, after: feedConnectedNovelView)
             }
         } else {
             feedConnectedNovelView.removeFromSuperview()
@@ -199,7 +200,7 @@ final class FeedListTableViewCell: UITableViewCell {
                                             novelRating: feed.feed.novelRating)
             self.stackView.insertArrangedSubview(feedConnectedNovelView, at: 2)
             stackView.do {
-                $0.setCustomSpacing(20, after: feedConnectedNovelView)
+                $0.setCustomSpacing(10, after: feedConnectedNovelView)
             }
         } else {
             feedConnectedNovelView.removeFromSuperview()

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
@@ -35,7 +35,6 @@ final class FeedListTableViewCell: UITableViewCell {
     let feedHeaderView = FeedListHeaderView()
     private let feedContentView = FeedListContentView()
     private let feedConnectedNovelView = FeedListConnectedNovelView()
-    private let feedCategoryView = FeedListCategoryView()
     private let feedReactView = FeedListReactView()
     private let dividerView = UIView()
     
@@ -78,7 +77,6 @@ final class FeedListTableViewCell: UITableViewCell {
         stackView.addArrangedSubviews(feedHeaderView,
                                       feedContentView,
                                       feedConnectedNovelView,
-                                      feedCategoryView,
                                       feedReactView)
     }
     
@@ -89,7 +87,6 @@ final class FeedListTableViewCell: UITableViewCell {
             stackView.do {
                 $0.setCustomSpacing(12, after: feedHeaderView)
                 $0.setCustomSpacing(20, after: feedContentView)
-                $0.setCustomSpacing(24, after: feedCategoryView)
             }
         }
         
@@ -165,7 +162,6 @@ final class FeedListTableViewCell: UITableViewCell {
         } else {
             feedConnectedNovelView.removeFromSuperview()
         }
-        feedCategoryView.bindData(relevantCategories: feed.relevantCategories)
         feedReactView.bindData(isLiked: feed.isLiked,
                                likeCount: feed.likeCount,
                                commentCount: feed.commentCount)
@@ -179,7 +175,6 @@ final class FeedListTableViewCell: UITableViewCell {
                                 isModified: feed.feed.isModified)
         feedContentView.bindData(feedContent: feed.feed.feedContent,
                                  isSpoiler: feed.feed.isSpoiler)
-        feedCategoryView.temporaryBindData(relevantCategories: feed.feed.relevantCategories)
         feedReactView.bindData(isLiked: feed.feed.isLiked,
                                likeCount: feed.feed.likeCount,
                                commentCount: feed.feed.commentCount)

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailView/NovelDetailFeedView/NovelDetailFeedCell/FeedListTableViewCell.swift
@@ -36,6 +36,7 @@ final class FeedListTableViewCell: UITableViewCell {
     private let feedContentView = FeedListContentView()
     private let feedConnectedNovelView = FeedListConnectedNovelView()
     private let feedReactView = FeedListReactView()
+    private let feedPrivateView = FeedListPrivateView()
     private let dividerView = UIView()
     
     //MARK: - Life Cycle
@@ -77,7 +78,8 @@ final class FeedListTableViewCell: UITableViewCell {
         stackView.addArrangedSubviews(feedHeaderView,
                                       feedContentView,
                                       feedConnectedNovelView,
-                                      feedReactView)
+                                      feedReactView,
+                                      feedPrivateView)
     }
     
     private func setLayout() {
@@ -162,9 +164,17 @@ final class FeedListTableViewCell: UITableViewCell {
         } else {
             feedConnectedNovelView.removeFromSuperview()
         }
-        feedReactView.bindData(isLiked: feed.isLiked,
-                               likeCount: feed.likeCount,
-                               commentCount: feed.commentCount)
+        
+        if feed.isPublic {
+            feedReactView.bindData(isLiked: feed.isLiked,
+                                   likeCount: feed.likeCount,
+                                   commentCount: feed.commentCount)
+            feedPrivateView.removeFromSuperview()
+            self.stackView.addArrangedSubview(feedReactView)
+        } else {
+            feedReactView.removeFromSuperview()
+            self.stackView.addArrangedSubview(feedPrivateView)
+        }
     }
     
     func bindProfileFeedData(feed: MyFeedListItem) {
@@ -179,7 +189,7 @@ final class FeedListTableViewCell: UITableViewCell {
                                likeCount: feed.feed.likeCount,
                                commentCount: feed.feed.commentCount)
         
-        //연결된 소설 유무에 따라 UI 조정
+        //연결된 소설 유무에 따른 UI 조정
         if feed.feed.novelId != -1,
            !feed.feed.title.isEmpty,
            feed.feed.novelRatingCount != -1,
@@ -193,6 +203,15 @@ final class FeedListTableViewCell: UITableViewCell {
             }
         } else {
             feedConnectedNovelView.removeFromSuperview()
+        }
+        
+        // 피드 공개 여부에 따른 UI 조정
+        if feed.feed.isPublic {
+            feedPrivateView.removeFromSuperview()
+            self.stackView.addArrangedSubview(feedReactView)
+        } else {
+            feedReactView.removeFromSuperview()
+            self.stackView.addArrangedSubview(feedPrivateView)
         }
     }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #531 
<br/>

### 🌟Motivation
- 공용 컴포넌트인 FeedListTableViewCell 내 피드 공개 여부 UI를 반영했습니다. 
- 따라서, 전체 피드, 작품 상세 내 피드, 마이페이지 내 피드 총 3곳에 적용되었습니다. 
<br/>

### 🌟Key Changes

<br/>

### 🌟Simulation
| 전체 피드 | 작품 상세 내 피드 | 마이페이지 내 피드 | 
| -- | -- | -- | 
| ![Simulator Screenshot - iPhone 13 mini - 2025-05-01 at 16 33 34](https://github.com/user-attachments/assets/d2227b76-8398-4aa8-9a9e-896a5eb514b3)  | ![Simulator Screenshot - iPhone 13 mini - 2025-05-01 at 16 34 18](https://github.com/user-attachments/assets/5eb5d563-6e6b-4248-bb63-6db3f2eb2c79) | ![Simulator Screenshot - iPhone 13 mini - 2025-05-01 at 16 33 51](https://github.com/user-attachments/assets/35d9b748-f01d-4ad4-8129-28ca1bf48ff0)  |
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
