### PR TITLE
[Fix] #537 - 일반 탐색 결과 레이아웃 깨지는 문제 해결

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchResultCountView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchResultCountView.swift
@@ -54,7 +54,6 @@ final class NormalSearchResultCountView: UIView {
         mainStackView.do {
             $0.axis = .horizontal
             $0.distribution = .equalSpacing
-            $0.alignment = .center
         }
     }
     


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #537 
<br/>

### 🌟Motivation
작품 문의 버튼 추가 후 일반 탐색 시 레이아웃이 깨지는 문제를 해결했습니다. 
<br/>

### 🌟Key Changes
- 상단 영역(작품 개수 라벨, 작품 문의 버튼) 스택뷰의 alignment를 center로 줘버리는 바람에 height가 최대로 확장되는 문제가 있어 해당 속성을 제거했습니다. 
<br/>

### 🌟Simulation
<img src="https://github.com/user-attachments/assets/7895bf08-e98e-446b-9ee4-ba383e99b1ce" width="40%"/>
<br/>

### 🌟To Reviewer
sorry,,
<br/>

### 🌟Reference
X
<br/>
