### PR TITLE
[FIx] #515 - 댓글 작성 중복 요청 방지 로직 추가 

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
@@ -1,0 +1,23 @@
+//
+//  NotificationName.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/4/25.
+//
+
+import Foundation
+
+enum NotificationName {
+    static let novelReviewKeywordSelected = Notification.Name("novelReviewKeywordSelected")
+    static let novelReviewDataSelected = Notification.Name("novelReviewDataSelected")
+    static let novelReviewDateRemoved = Notification.Name("novelReviewDateRemoved")
+    static let feedEdited = Notification.Name("feedEdited")
+    static let novelReviewed = Notification.Name("novelReviewed")
+    static let popFeedDetailViewController = Notification.Name("popFeedDetailViewController")
+    static let feedNovelConnected = Notification.Name("feedNovelConnected")
+    static let blockUser = Notification.Name("blockUser")
+    static let pushToUpdateDetailSearchResult = Notification.Name("pushToUpdateDetailSearchResult")
+    static let pushToDetailSearchResult = Notification.Name("pushToDetailSearchResult")
+    static let changeRepresentativeAvatar = Notification.Name("changeRepresentativeAvatar")
+    static let moveToLibraryTab = Notification.Name("moveToLibraryTab")
+}

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -12,21 +12,6 @@ enum StringLiterals {
         static let deviceIdentifier = "DEVICE_IDENTIFIER"
     }
     
-    enum NotificationCenter {
-        static let novelReviewKeywordSelected = Notification.Name("novelReviewKeywordSelected")
-        static let novelReviewDataSelected = Notification.Name("novelReviewDataSelected")
-        static let novelReviewDateRemoved = Notification.Name("novelReviewDateRemoved")
-        static let feedEdited = Notification.Name("feedEdited")
-        static let novelReviewed = Notification.Name("novelReviewed")
-        static let popFeedDetailViewController = Notification.Name("popFeedDetailViewController")
-        static let feedNovelConnected = Notification.Name("feedNovelConnected")
-        static let blockUser = Notification.Name("blockUser")
-        static let pushToUpdateDetailSearchResult = Notification.Name("pushToUpdateDetailSearchResult")
-        static let pushToDetailSearchResult = Notification.Name("pushToDetailSearchResult")
-        static let changeRepresentativeAvatar = Notification.Name("changeRepresentativeAvatar")
-        static let moveToLibraryTab = Notification.Name("moveToLibraryTab")
-    }
-    
     enum UserDefault {
         static let accessToken = "ACCESS_TOKEN"
         static let refreshToken = "REFRESH_TOKEN"

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
@@ -85,7 +85,7 @@ final class WSSTabBarController: UITabBarController {
             self.setTabBarController()
         }
         
-        NotificationCenter.default.rx.notification(StringLiterals.NotificationCenter.moveToLibraryTab)
+        NotificationCenter.default.rx.notification(NotificationName.moveToLibraryTab)
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, notification in
                 if let libraryNavigationVC = owner.viewControllers?[WSSTabBarItem.library.rawValue] as? UINavigationController,

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownFeedErrorViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailUnknownFeedErrorViewController.swift
@@ -14,8 +14,7 @@ final class FeedDetailUnknownFeedErrorViewController: UIViewController {
     //MARK: - Properties
     
     private let disposeBag = DisposeBag()
-    private let popFeedDetailViewControllerNotificationName = Notification.Name("PopFeedDetailViewControllerNotificationName")
-    
+   
     //MARK: - UI Components
     
     private let rootView = FeedDetailUnknownFeedErrorView()
@@ -34,7 +33,7 @@ final class FeedDetailUnknownFeedErrorViewController: UIViewController {
         rootView.confirmationButton.rx.tap
             .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
-                NotificationCenter.default.post(name: owner.popFeedDetailViewControllerNotificationName,
+                NotificationCenter.default.post(name: NotificationName.popFeedDetailViewController,
                                                 object: nil)
                 owner.dismiss(animated: true)
             })

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -130,7 +130,7 @@ final class FeedDetailViewController: UIViewController {
             commentdotsButtonDidTap: commentDotsButtonDidTap.asObservable(),
             commentDropdownDidTap: commentDropdownButtonDidTap,
             reloadComments: reloadComments.asObservable(),
-            popFeedDetailViewControllerNotification: NotificationCenter.default.rx.notification(Notification.Name("PopFeedDetailViewControllerNotificationName")).asObservable()
+            popFeedDetailViewControllerNotification: NotificationCenter.default.rx.notification(NotificationName.popFeedDetailViewController).asObservable()
         )
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -43,6 +43,7 @@ final class FeedDetailViewModel: ViewModelType {
     private let showPlaceholder = BehaviorRelay<Bool>(value: true)
     private let sendButtonEnabled = BehaviorRelay<Bool>(value: false)
     private let textViewEmpty = BehaviorRelay<Bool>(value: true)
+    private var isProcessing: Bool = false
     
     // 피드 드롭다운
     private let showDropdownView = BehaviorRelay<Bool>(value: false)
@@ -305,55 +306,59 @@ final class FeedDetailViewModel: ViewModelType {
         
         input.sendButtonDidTap
             .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
-            .do(onNext: {
+            .flatMapLatest { [weak self] _ -> Observable<Void> in
+                guard let self = self else { return .empty() }
+
+                if self.isProcessing { return .empty() }
+                self.isProcessing = true
+
                 AmplitudeManager.shared.track(AmplitudeEvent.Feed.writeComment)
-            })
-            .flatMapLatest { () -> Observable<Void> in
+
+                let finishSendingComment: () -> Void = {
+                    self.isProcessing = false
+                    self.textViewResignFirstResponder.accept(())
+                    self.updatedCommentContent = ""
+                    self.textViewEmpty.accept(true)
+                    self.showPlaceholder.accept(true)
+                    self.showLoadingView.accept(false)
+                }
+
                 if self.isCommentEditing {
                     return self.putComment(self.feedId,
                                            self.selectedCommentId,
                                            self.updatedCommentContent)
-                    .flatMapLatest { _ in
-                        self.getSingleFeedComments(self.feedId)
-                            .do(onNext: { _ in
-                                self.showLoadingView.accept(true)
-                            })
-                            .do(onNext: { newComments in
-                                self.commentsData.accept(newComments.comments)
-                            })
-                            .map { _ in () }
-                    }
-                    .do(onNext: {
-                        self.textViewResignFirstResponder.accept(())
-                        self.updatedCommentContent = ""
-                        self.textViewEmpty.accept(true)
-                        self.showPlaceholder.accept(true)
-                        self.isCommentEditing = false
-                        self.selectedCommentId = 0
-                        self.showLoadingView.accept(false)
-                    })
-                } else {
-                    return self.postComment(self.feedId, self.updatedCommentContent)
                         .flatMapLatest { _ in
                             self.getSingleFeedComments(self.feedId)
-                                .do(onNext: { _ in
-                                    self.showLoadingView.accept(true)
-                                })
                                 .do(onNext: { newComments in
                                     self.commentsData.accept(newComments.comments)
+                                    self.showLoadingView.accept(true)
                                 })
                                 .map { _ in () }
                         }
                         .do(onNext: {
-                            self.textViewResignFirstResponder.accept(())
-                            self.updatedCommentContent = ""
-                            self.textViewEmpty.accept(true)
-                            self.showPlaceholder.accept(true)
+                            finishSendingComment()
+                            self.isCommentEditing = false
                             self.selectedCommentId = 0
-                            self.showLoadingView.accept(false)
-                            
-                            let newCommentCount = self.commentCount.value + 1
-                            self.commentCount.accept(newCommentCount)
+                        }, onError: { _ in
+                            self.isProcessing = false
+                        })
+                } else {
+                    return self.postComment(self.feedId,
+                                            self.updatedCommentContent)
+                        .flatMapLatest { _ in
+                            self.getSingleFeedComments(self.feedId)
+                                .do(onNext: { newComments in
+                                    self.commentsData.accept(newComments.comments)
+                                    self.showLoadingView.accept(true)
+                                })
+                                .map { _ in () }
+                        }
+                        .do(onNext: {
+                            finishSendingComment()
+                            self.selectedCommentId = 0
+                            self.commentCount.accept(self.commentCount.value + 1)
+                        }, onError: { _ in
+                            self.isProcessing = false
                         })
                 }
             }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -339,7 +339,7 @@ final class MyPageViewController: UIViewController {
             .bind(with: self, onNext: { owner, data in
                 let (userId, isMyPage) = data
                 if isMyPage {
-                    NotificationCenter.default.post(name: StringLiterals.NotificationCenter.moveToLibraryTab, object: nil)
+                    NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: nil)
                 } else {
                     owner.pushToLibraryViewController(userId: userId)
                 }
@@ -354,7 +354,7 @@ final class MyPageViewController: UIViewController {
             .bind(with: self, onNext: { owner, data in
                 let (userId, pageIndex, isMyPage) = data
                 if isMyPage {
-                    NotificationCenter.default.post(name: StringLiterals.NotificationCenter.moveToLibraryTab, object: pageIndex)
+                    NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: pageIndex)
                 } else {
                     owner.pushToLibraryViewController(userId: userId, pageIndex: pageIndex)
                 }


### PR DESCRIPTION
### ⭐️Issue
- close #515 
<br/>

### 🌟Motivation
- 댓글 작성 버튼 클릭 시 중복 요청되는 이슈 수정했습니다. 
<br/>

### 🌟Key Changes
- flag 변수 (`isProcessing: Bool`)을 추가하여 로직 수정했습니다. 

댓글 버튼을 클릭했을 때, `isProcessing = true`이면 `empty()`를 반환하여 아무 작업을 하지 않고 스트림 종료하도록 했습니다. 
```swift
if self.isProcessing { return .empty() }
self.isProcessing = true
```

- 기존에 `StringLiterals` 파일에 있던 `NotificationCenter` 이름들을 `NotificationName`이라는 enum으로 분리하였습니다.
이유: `StringLiterals.Notification.~` 형태로 접근하는 방식은 가독성이 떨어진다고 판단하였고, StringLiterals에는 순수 문자열 값만 존재하는 것이 더 적절하다고 생각했습니다. 따라서 Notification 관련 상수는 별도의 파일로 분리하여 코드의 가독성과 유지보수성을 높이고자 했습니다!

<br/>


### 🌟Simulation

<br/>

### 🌟To Reviewer
-  댓글 작성 해보고 잘 반영되는지 테스트 부탁드립니닷!
<br/>

### 🌟Reference

<br/>
