### PR TITLE
[Chore] #541 - 피드작성뷰 내 이미지 추가 버튼 코드 주석 처리

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
@@ -82,7 +82,6 @@ final class FeedEditContentView: UIView {
                          spoilerView)
         feedTextWrapperView.addSubviews(feedTextView,
                                         placeholderLabel,
-                                        photoImageView,
                                         letterCountLabel)
     }
     
@@ -109,12 +108,12 @@ final class FeedEditContentView: UIView {
             $0.top.leading.equalToSuperview().inset(20)
         }
         
-        photoImageView.snp.makeConstraints {
-            $0.size.equalTo(24)
-            $0.leading.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(12)
-        }
-        
+//        photoImageView.snp.makeConstraints {
+//            $0.size.equalTo(24)
+//            $0.leading.equalToSuperview().inset(20)
+//            $0.bottom.equalToSuperview().inset(12)
+//        }
+   
         letterCountLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(12.5)


### PR DESCRIPTION
### ⭐️Issue
- close #542 
<br/>

### 🌟Motivation
- 스프린트 기간에 맞추어 피드 작성 뷰 내 이미지 추가 버튼을 추가하지 않고, 추후 6월말 업데이트에 반영하도록 해당 코드 주석처리 해두었습니다. 
<br/>

### 🌟Key Changes

<br/>


### 🌟Simulation
<img src="https://github.com/user-attachments/assets/3a178a64-d793-4732-9af5-d61889cbdaee" width=200>
<br/>

### 🌟To Reviewer
X
<br/>

### 🌟Reference
X
<br/>
