### PR TITLE
[Feat] #556 - 피드 상세뷰 내 이미지 첨부 UI 구현 

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -22,40 +22,28 @@
 		39EDFB392D38D9A7009F071A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB382D38D9A7009F071A /* FirebaseAnalytics */; };
 		39EDFB3B2D38D9A7009F071A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB3A2D38D9A7009F071A /* FirebaseMessaging */; };
 		39EF97AC2B53E43800D2148B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 39EF97AB2B53E43800D2148B /* Lottie */; };
-		B9023C182DDF63C100AC18F3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */; };
-		B9DDB08C2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */; };
 		CD3E5A852B54254F00C0A659 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = CD3E5A842B54254F00C0A659 /* RxKeyboard */; };
 		CDE0C0312D23B04D000BC822 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CDE0C0302D23B04D000BC822 /* AmplitudeSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		2CD229182B42E685005400BE /* WSSiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WSSiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		2CD229292B42E687005400BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
-		CD514C8D2CD5D6DB007A27A8 /* WSSiOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WSSiOS.entitlements; sourceTree = "<group>"; };
-		E486AE282CFEB2CC00465AEE /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		E4EC12DF2D06FDB200B961BB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		B9C8AC4D2DDF646800F2076A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Debug.xcconfig,
+				Info.plist,
+				Release.xcconfig,
+			);
+			target = 2CD229172B42E685005400BE /* WSSiOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		B90DFC2A2D8E896200D62D76 /* Home */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Home; sourceTree = "<group>"; };
-		E4E960BE2D7718A50058E6CC /* Feed */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Feed; sourceTree = "<group>"; };
-		E4E9613E2D7718CB0058E6CC /* Network */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Network; sourceTree = "<group>"; };
-		E4E961A42D7718D00058E6CC /* Data */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Data; sourceTree = "<group>"; };
-		E4E961E62D7718D50058E6CC /* FeedDetail */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FeedDetail; sourceTree = "<group>"; };
-		E4E962142D7718E00058E6CC /* NovelReview */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NovelReview; sourceTree = "<group>"; };
-		E4E962412D7718E20058E6CC /* Login */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Login; sourceTree = "<group>"; };
-		E4E962632D7718E40058E6CC /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
-		E4E962992D7718E60058E6CC /* NovelDetail */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NovelDetail; sourceTree = "<group>"; };
-		E4E962CA2D7718E80058E6CC /* FeedEdit */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FeedEdit; sourceTree = "<group>"; };
-		E4E962E92D7718EA0058E6CC /* Library */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Library; sourceTree = "<group>"; };
-		E4E963262D7718EB0058E6CC /* Search */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Search; sourceTree = "<group>"; };
-		E4E963692D7718F30058E6CC /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
-		E4E963AD2D7718F40058E6CC /* Setting */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Setting; sourceTree = "<group>"; };
-		E4E963FB2D7719030058E6CC /* Base */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Base; sourceTree = "<group>"; };
-		E4E964502D77190B0058E6CC /* Resource */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Resource; sourceTree = "<group>"; };
-		E4E964792D77190D0058E6CC /* App */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = App; sourceTree = "<group>"; };
+		B9C8AAA52DDF646800F2076A /* WSSiOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B9C8AC4D2DDF646800F2076A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WSSiOS; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,19 +74,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2CCBF9E92B4C1E2200D787C2 /* MyPage */ = {
-			isa = PBXGroup;
-			children = (
-				E4E963AD2D7718F40058E6CC /* Setting */,
-				E4E963692D7718F30058E6CC /* Profile */,
-			);
-			path = MyPage;
-			sourceTree = "<group>";
-		};
 		2CD2290F2B42E685005400BE = {
 			isa = PBXGroup;
 			children = (
-				2CD2291A2B42E685005400BE /* WSSiOS */,
+				B9C8AAA52DDF646800F2076A /* WSSiOS */,
 				2CD229192B42E685005400BE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -109,51 +88,6 @@
 				2CD229182B42E685005400BE /* WSSiOS.app */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		2CD2291A2B42E685005400BE /* WSSiOS */ = {
-			isa = PBXGroup;
-			children = (
-				B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */,
-				B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */,
-				CD514C8D2CD5D6DB007A27A8 /* WSSiOS.entitlements */,
-				E4E964792D77190D0058E6CC /* App */,
-				E4E964502D77190B0058E6CC /* Resource */,
-				2CD2294F2B42E9AD005400BE /* Source */,
-				E4E9613E2D7718CB0058E6CC /* Network */,
-				2CD229292B42E687005400BE /* Info.plist */,
-				E486AE282CFEB2CC00465AEE /* Debug.xcconfig */,
-				E4EC12DF2D06FDB200B961BB /* Release.xcconfig */,
-			);
-			path = WSSiOS;
-			sourceTree = "<group>";
-		};
-		2CD2294F2B42E9AD005400BE /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				2CD229502B42E9C8005400BE /* Presentation */,
-				E4E961A42D7718D00058E6CC /* Data */,
-			);
-			path = Source;
-			sourceTree = "<group>";
-		};
-		2CD229502B42E9C8005400BE /* Presentation */ = {
-			isa = PBXGroup;
-			children = (
-				E4E962142D7718E00058E6CC /* NovelReview */,
-				E4E962412D7718E20058E6CC /* Login */,
-				E4E962632D7718E40058E6CC /* Onboarding */,
-				E4E962992D7718E60058E6CC /* NovelDetail */,
-				E4E961E62D7718D50058E6CC /* FeedDetail */,
-				E4E962CA2D7718E80058E6CC /* FeedEdit */,
-				E4E960BE2D7718A50058E6CC /* Feed */,
-				E4E962E92D7718EA0058E6CC /* Library */,
-				B90DFC2A2D8E896200D62D76 /* Home */,
-				E4E963262D7718EB0058E6CC /* Search */,
-				2CCBF9E92B4C1E2200D787C2 /* MyPage */,
-				E4E963FB2D7719030058E6CC /* Base */,
-			);
-			path = Presentation;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -172,23 +106,7 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				B90DFC2A2D8E896200D62D76 /* Home */,
-				E4E960BE2D7718A50058E6CC /* Feed */,
-				E4E9613E2D7718CB0058E6CC /* Network */,
-				E4E961A42D7718D00058E6CC /* Data */,
-				E4E961E62D7718D50058E6CC /* FeedDetail */,
-				E4E962142D7718E00058E6CC /* NovelReview */,
-				E4E962412D7718E20058E6CC /* Login */,
-				E4E962632D7718E40058E6CC /* Onboarding */,
-				E4E962992D7718E60058E6CC /* NovelDetail */,
-				E4E962CA2D7718E80058E6CC /* FeedEdit */,
-				E4E962E92D7718EA0058E6CC /* Library */,
-				E4E963262D7718EB0058E6CC /* Search */,
-				E4E963692D7718F30058E6CC /* Profile */,
-				E4E963AD2D7718F40058E6CC /* Setting */,
-				E4E963FB2D7719030058E6CC /* Base */,
-				E4E964502D77190B0058E6CC /* Resource */,
-				E4E964792D77190D0058E6CC /* App */,
+				B9C8AAA52DDF646800F2076A /* WSSiOS */,
 			);
 			name = WSSiOS;
 			packageProductDependencies = (
@@ -265,8 +183,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9023C182DDF63C100AC18F3 /* GoogleService-Info.plist in Resources */,
-				B9DDB08C2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -285,7 +201,8 @@
 /* Begin XCBuildConfiguration section */
 		2CD2292A2B42E687005400BE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E486AE282CFEB2CC00465AEE /* Debug.xcconfig */;
+			baseConfigurationReferenceAnchor = B9C8AAA52DDF646800F2076A /* WSSiOS */;
+			baseConfigurationReferenceRelativePath = Debug.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -350,7 +267,8 @@
 		};
 		2CD2292B2B42E687005400BE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4EC12DF2D06FDB200B961BB /* Release.xcconfig */;
+			baseConfigurationReferenceAnchor = B9C8AAA52DDF646800F2076A /* WSSiOS */;
+			baseConfigurationReferenceRelativePath = Release.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -409,7 +327,8 @@
 		};
 		2CD2292D2B42E687005400BE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E486AE282CFEB2CC00465AEE /* Debug.xcconfig */;
+			baseConfigurationReferenceAnchor = B9C8AAA52DDF646800F2076A /* WSSiOS */;
+			baseConfigurationReferenceRelativePath = Debug.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -451,7 +370,8 @@
 		};
 		2CD2292E2B42E687005400BE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4EC12DF2D06FDB200B961BB /* Release.xcconfig */;
+			baseConfigurationReferenceAnchor = B9C8AAA52DDF646800F2076A /* WSSiOS */;
+			baseConfigurationReferenceRelativePath = Release.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 71;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -22,28 +22,40 @@
 		39EDFB392D38D9A7009F071A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB382D38D9A7009F071A /* FirebaseAnalytics */; };
 		39EDFB3B2D38D9A7009F071A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB3A2D38D9A7009F071A /* FirebaseMessaging */; };
 		39EF97AC2B53E43800D2148B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 39EF97AB2B53E43800D2148B /* Lottie */; };
+		B9023C182DDF63C100AC18F3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */; };
+		B9DDB08C2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */; };
 		CD3E5A852B54254F00C0A659 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = CD3E5A842B54254F00C0A659 /* RxKeyboard */; };
 		CDE0C0312D23B04D000BC822 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CDE0C0302D23B04D000BC822 /* AmplitudeSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		2CD229182B42E685005400BE /* WSSiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WSSiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2CD229292B42E687005400BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
+		CD514C8D2CD5D6DB007A27A8 /* WSSiOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WSSiOS.entitlements; sourceTree = "<group>"; };
+		E486AE282CFEB2CC00465AEE /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		E4EC12DF2D06FDB200B961BB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		E43969E52DDCB63400572D0D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Debug.xcconfig,
-				Info.plist,
-				Release.xcconfig,
-			);
-			target = 2CD229172B42E685005400BE /* WSSiOS */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		E43968472DDCB63400572D0D /* WSSiOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E43969E52DDCB63400572D0D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WSSiOS; sourceTree = "<group>"; };
+		B90DFC2A2D8E896200D62D76 /* Home */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Home; sourceTree = "<group>"; };
+		E4E960BE2D7718A50058E6CC /* Feed */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Feed; sourceTree = "<group>"; };
+		E4E9613E2D7718CB0058E6CC /* Network */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Network; sourceTree = "<group>"; };
+		E4E961A42D7718D00058E6CC /* Data */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Data; sourceTree = "<group>"; };
+		E4E961E62D7718D50058E6CC /* FeedDetail */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FeedDetail; sourceTree = "<group>"; };
+		E4E962142D7718E00058E6CC /* NovelReview */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NovelReview; sourceTree = "<group>"; };
+		E4E962412D7718E20058E6CC /* Login */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Login; sourceTree = "<group>"; };
+		E4E962632D7718E40058E6CC /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
+		E4E962992D7718E60058E6CC /* NovelDetail */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NovelDetail; sourceTree = "<group>"; };
+		E4E962CA2D7718E80058E6CC /* FeedEdit */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FeedEdit; sourceTree = "<group>"; };
+		E4E962E92D7718EA0058E6CC /* Library */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Library; sourceTree = "<group>"; };
+		E4E963262D7718EB0058E6CC /* Search */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Search; sourceTree = "<group>"; };
+		E4E963692D7718F30058E6CC /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
+		E4E963AD2D7718F40058E6CC /* Setting */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Setting; sourceTree = "<group>"; };
+		E4E963FB2D7719030058E6CC /* Base */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Base; sourceTree = "<group>"; };
+		E4E964502D77190B0058E6CC /* Resource */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Resource; sourceTree = "<group>"; };
+		E4E964792D77190D0058E6CC /* App */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = App; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,10 +86,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2CCBF9E92B4C1E2200D787C2 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				E4E963AD2D7718F40058E6CC /* Setting */,
+				E4E963692D7718F30058E6CC /* Profile */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
 		2CD2290F2B42E685005400BE = {
 			isa = PBXGroup;
 			children = (
-				E43968472DDCB63400572D0D /* WSSiOS */,
+				2CD2291A2B42E685005400BE /* WSSiOS */,
 				2CD229192B42E685005400BE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -88,6 +109,51 @@
 				2CD229182B42E685005400BE /* WSSiOS.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		2CD2291A2B42E685005400BE /* WSSiOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9023C172DDF63C100AC18F3 /* GoogleService-Info.plist */,
+				B9DDB08A2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist */,
+				CD514C8D2CD5D6DB007A27A8 /* WSSiOS.entitlements */,
+				E4E964792D77190D0058E6CC /* App */,
+				E4E964502D77190B0058E6CC /* Resource */,
+				2CD2294F2B42E9AD005400BE /* Source */,
+				E4E9613E2D7718CB0058E6CC /* Network */,
+				2CD229292B42E687005400BE /* Info.plist */,
+				E486AE282CFEB2CC00465AEE /* Debug.xcconfig */,
+				E4EC12DF2D06FDB200B961BB /* Release.xcconfig */,
+			);
+			path = WSSiOS;
+			sourceTree = "<group>";
+		};
+		2CD2294F2B42E9AD005400BE /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				2CD229502B42E9C8005400BE /* Presentation */,
+				E4E961A42D7718D00058E6CC /* Data */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		2CD229502B42E9C8005400BE /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				E4E962142D7718E00058E6CC /* NovelReview */,
+				E4E962412D7718E20058E6CC /* Login */,
+				E4E962632D7718E40058E6CC /* Onboarding */,
+				E4E962992D7718E60058E6CC /* NovelDetail */,
+				E4E961E62D7718D50058E6CC /* FeedDetail */,
+				E4E962CA2D7718E80058E6CC /* FeedEdit */,
+				E4E960BE2D7718A50058E6CC /* Feed */,
+				E4E962E92D7718EA0058E6CC /* Library */,
+				B90DFC2A2D8E896200D62D76 /* Home */,
+				E4E963262D7718EB0058E6CC /* Search */,
+				2CCBF9E92B4C1E2200D787C2 /* MyPage */,
+				E4E963FB2D7719030058E6CC /* Base */,
+			);
+			path = Presentation;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -106,7 +172,23 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				E43968472DDCB63400572D0D /* WSSiOS */,
+				B90DFC2A2D8E896200D62D76 /* Home */,
+				E4E960BE2D7718A50058E6CC /* Feed */,
+				E4E9613E2D7718CB0058E6CC /* Network */,
+				E4E961A42D7718D00058E6CC /* Data */,
+				E4E961E62D7718D50058E6CC /* FeedDetail */,
+				E4E962142D7718E00058E6CC /* NovelReview */,
+				E4E962412D7718E20058E6CC /* Login */,
+				E4E962632D7718E40058E6CC /* Onboarding */,
+				E4E962992D7718E60058E6CC /* NovelDetail */,
+				E4E962CA2D7718E80058E6CC /* FeedEdit */,
+				E4E962E92D7718EA0058E6CC /* Library */,
+				E4E963262D7718EB0058E6CC /* Search */,
+				E4E963692D7718F30058E6CC /* Profile */,
+				E4E963AD2D7718F40058E6CC /* Setting */,
+				E4E963FB2D7719030058E6CC /* Base */,
+				E4E964502D77190B0058E6CC /* Resource */,
+				E4E964792D77190D0058E6CC /* App */,
 			);
 			name = WSSiOS;
 			packageProductDependencies = (
@@ -183,6 +265,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9023C182DDF63C100AC18F3 /* GoogleService-Info.plist in Resources */,
+				B9DDB08C2D70300A00D8D4B3 /* GoogleService-Info-Debug.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,8 +285,7 @@
 /* Begin XCBuildConfiguration section */
 		2CD2292A2B42E687005400BE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = E43968472DDCB63400572D0D /* WSSiOS */;
-			baseConfigurationReferenceRelativePath = Debug.xcconfig;
+			baseConfigurationReference = E486AE282CFEB2CC00465AEE /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -267,8 +350,7 @@
 		};
 		2CD2292B2B42E687005400BE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = E43968472DDCB63400572D0D /* WSSiOS */;
-			baseConfigurationReferenceRelativePath = Release.xcconfig;
+			baseConfigurationReference = E4EC12DF2D06FDB200B961BB /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -327,8 +409,7 @@
 		};
 		2CD2292D2B42E687005400BE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = E43968472DDCB63400572D0D /* WSSiOS */;
-			baseConfigurationReferenceRelativePath = Debug.xcconfig;
+			baseConfigurationReference = E486AE282CFEB2CC00465AEE /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -370,8 +451,7 @@
 		};
 		2CD2292E2B42E687005400BE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = E43968472DDCB63400572D0D /* WSSiOS */;
-			baseConfigurationReferenceRelativePath = Release.xcconfig;
+			baseConfigurationReference = E4EC12DF2D06FDB200B961BB /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -278,16 +278,7 @@ extension UIViewController {
     }
     
     func pushToFeedDetailViewController(feedId: Int) {
-        let viewController = FeedDetailViewController(
-            viewModel: FeedDetailViewModel(
-                feedDetailRepository: DefaultFeedDetailRepository(
-                    feedDetailService: DefaultFeedDetailService()
-                ), userRepository: DefaultUserInfoRepository(
-                    userService: DefaultUserService()
-                ),
-                feedId: feedId
-            )
-        )
+        let viewController = ModuleFactory.shared.makeFeedDetailViewController(feedId: feedId)
         viewController.navigationController?.isNavigationBarHidden = false
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -396,6 +396,12 @@ extension UIViewController {
         self.present(feedDetailUnknownFeedErrorViewController, animated: true)
     }
     
+    func presentToFeedDetailAddImageViewerViewController(imageURLs: [URL?], startIndex: Int) {
+        let viewController = FeedDetailAddImageViewerController(imageURLs: imageURLs, startIndex: startIndex)
+        viewController.modalPresentationStyle = .overFullScreen
+        self.present(viewController, animated: true)
+    }
+    
     func topViewController() -> UIViewController {
         if let presented = self.presentedViewController {
             return presented.topViewController()

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -396,8 +396,8 @@ extension UIViewController {
         self.present(feedDetailUnknownFeedErrorViewController, animated: true)
     }
     
-    func presentToFeedDetailAddImageViewerViewController(imageURLs: [URL?], startIndex: Int) {
-        let viewController = FeedDetailAddImageViewerController(imageURLs: imageURLs, startIndex: startIndex)
+    func presentToFeedDetailAddImageViewerViewController(startIndex: Int, imageURLs: [URL?]) {
+        let viewController = FeedDetailAddImageViewerController(startIndex: startIndex, imageURLs: imageURLs)
         viewController.modalPresentationStyle = .overFullScreen
         self.present(viewController, animated: true)
     }

--- a/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
+++ b/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
@@ -69,8 +69,7 @@ extension ModuleFactory: ServiceTermAgreementModuleFactory {
 
 extension ModuleFactory: FeedDetailModuleFactory {
     func makeFeedDetailViewController(feedId: Int) -> UIViewController {
-        return FeedDetailViewController(viewModel: FeedDetailViewModel(feedDetailRepository:
-                                                                        TestFeedDetailRepository(),
+        return FeedDetailViewController(viewModel: FeedDetailViewModel(feedDetailRepository: TestFeedDetailRepository(),
                                                                        userRepository: DefaultUserInfoRepository(userService: DefaultUserService()),
                                                                        feedId: feedId))
     }

--- a/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
+++ b/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
@@ -17,8 +17,12 @@ protocol NovelDetailModuleFactory {
     func makeNovelDetailViewController(novelId: Int) -> UIViewController
 }
 
-protocol ServiceTermAgreementFactory {
+protocol ServiceTermAgreementModuleFactory {
     func makeServiceTermAgreementViewController() -> UIViewController
+}
+
+protocol FeedDetailModuleFactory {
+    func makeFeedDetailViewController(feedId: Int) -> UIViewController
 }
 
 protocol MyPageModuleFactory {
@@ -57,9 +61,18 @@ extension ModuleFactory: OnboardingModuleFactory {
     }
 }
 
-extension ModuleFactory: ServiceTermAgreementFactory {
+extension ModuleFactory: ServiceTermAgreementModuleFactory {
     func makeServiceTermAgreementViewController() -> UIViewController {
         return ServiceTermAgreementViewController(repository: DefaultUserInfoRepository(userService: DefaultUserService()))
+    }
+}
+
+extension ModuleFactory: FeedDetailModuleFactory {
+    func makeFeedDetailViewController(feedId: Int) -> UIViewController {
+        return FeedDetailViewController(viewModel: FeedDetailViewModel(feedDetailRepository:
+                                                                        TestFeedDetailRepository(),
+                                                                       userRepository: DefaultUserInfoRepository(userService: DefaultUserService()),
+                                                                       feedId: feedId))
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Data/DTO/Feed/FeedResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/Feed/FeedResponse.swift
@@ -31,6 +31,8 @@ struct FeedResponse: Decodable {
     var isModified: Bool
     var isMyFeed: Bool
     var isPublic: Bool
+    
+    var images: [String]
 }
 
 /// 소소피드 댓글 전체 조회
@@ -51,4 +53,85 @@ struct FeedCommentResponse: Decodable {
     var isSpoiler: Bool
     var isBlocked: Bool
     var isHidden: Bool
+}
+
+
+// MARK: - Test Repository를 위한 Dummy Data
+
+extension FeedResponse {
+    static let dummyOneImageData = FeedResponse(userId: 12345,
+                                                nickname: "배고픈하이에나",
+                                                avatarImage: "",
+                                                feedId: 12,
+                                                createdDate: "10월 3일",
+                                                feedContent: "배고플 땐 너구리",
+                                                likeCount: 1,
+                                                isLiked: true,
+                                                commentCount: 2,
+                                                relevantCategories: [],
+                                                isSpoiler: false,
+                                                isModified: false,
+                                                isMyFeed: true,
+                                                isPublic: true,
+                                                images: ["https://i.pinimg.com/736x/d1/16/6f/d1166fe8e8cbd0f513d58f464ec38458.jpg"])
+    
+    static let dummyTwoImagesData = FeedResponse(userId: 12345,
+                                                 nickname: "배고픈 하이에나",
+                                                 avatarImage: "",
+                                                 feedId: 12,
+                                                 createdDate: "10월 3일",
+                                                 feedContent: "배고플 땐 너구리",
+                                                 likeCount: 1,
+                                                 isLiked: true,
+                                                 commentCount: 2,
+                                                 relevantCategories: [],
+                                                 isSpoiler: false,
+                                                 isModified: false,
+                                                 isMyFeed: true,
+                                                 isPublic: true,
+                                                 images: ["https://i.pinimg.com/736x/d1/16/6f/d1166fe8e8cbd0f513d58f464ec38458.jpg",
+                                                         "https://i.pinimg.com/736x/bc/ba/b2/bcbab29a5bd96f4268349694b5a50356.jpg"])
+    
+    static let dummyThreeImagesData = FeedResponse(userId: 12345,
+                                               nickname: "배고픈 하이에나",
+                                               avatarImage: "",
+                                               feedId: 12,
+                                               createdDate: "10월 3일",
+                                               feedContent: "배고플 땐 너구리",
+                                               likeCount: 1,
+                                               isLiked: true,
+                                               commentCount: 2,
+                                               relevantCategories: [],
+                                               isSpoiler: false,
+                                               isModified: false,
+                                               isMyFeed: true,
+                                               isPublic: true,
+                                               images: ["https://i.pinimg.com/736x/d1/16/6f/d1166fe8e8cbd0f513d58f464ec38458.jpg",
+                                                        "https://i.pinimg.com/736x/bc/ba/b2/bcbab29a5bd96f4268349694b5a50356.jpg",
+                                                       "https://i.pinimg.com/736x/d4/d5/c0/d4d5c07c9206aa7b7b351e2ac80458bc.jpg"])
+    
+    static let dummyManyImagesData = FeedResponse(userId: 12345,
+                                                  nickname: "배고픈 하이에나",
+                                                  avatarImage: "",
+                                                  feedId: 12,
+                                                  createdDate: "10월 3일",
+                                                  feedContent: "배고플 땐 너구리",
+                                                  likeCount: 1,
+                                                  isLiked: true,
+                                                  commentCount: 2,
+                                                  novelId: 12,
+                                                  title: "웹소설 제목",
+                                                  novelRatingCount: 10,
+                                                  novelRating: 1.2,
+                                                  relevantCategories: [],
+                                                  isSpoiler: false,
+                                                  isModified: false,
+                                                  isMyFeed: true,
+                                                  isPublic: true,
+                                                  images: ["https://i.pinimg.com/736x/d1/16/6f/d1166fe8e8cbd0f513d58f464ec38458.jpg",
+                                                           "https://i.pinimg.com/736x/8d/95/16/8d9516ee19eeba5f601422bb0143d11c.jpg",
+                                                           "https://i.pinimg.com/736x/bc/ba/b2/bcbab29a5bd96f4268349694b5a50356.jpg",
+                                                           "https://i.pinimg.com/736x/ee/71/9e/ee719e73c2bda47940746d520c3d71e3.jpg",
+                                                          "https://i.pinimg.com/736x/d4/d5/c0/d4d5c07c9206aa7b7b351e2ac80458bc.jpg",
+                                                          "https://i.pinimg.com/736x/90/a8/3b/90a83b82a938a5c6dbe76b247366d428.jpg"])
 }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
@@ -46,7 +46,8 @@ extension FeedResponse {
         let hasLinkedNovel = self.novelId != nil
         let hasImage = self.images.count > 0
         let imageCount = self.images.count
-       // let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeBucketImageURL(path: $0) }
+        // let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeBucketImageURL(path: $0) }
+        // 테스트용 코드 -> 머지 시 삭제 예정
         let imageURLs: [URL?] = self.images.map { URL(string: $0)! }
         
         return FeedEntity(userId: self.userId,

--- a/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
@@ -33,12 +33,21 @@ struct FeedEntity {
     let isModified: Bool
     let isMyFeed: Bool
     let isPublic: Bool
+    
+    // 피드 첨부 이미지 관련
+    let hasImage: Bool
+    let imageCount: Int
+    let imageURLs: [URL?]
 }
 
 extension FeedResponse {
     func toEntity() -> FeedEntity {
         let userProfileImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         let hasLinkedNovel = self.novelId != nil
+        let hasImage = self.images.count > 0
+        let imageCount = self.images.count
+       // let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeBucketImageURL(path: $0) }
+        let imageURLs: [URL?] = self.images.map { URL(string: $0)! }
         
         return FeedEntity(userId: self.userId,
                           userNickname: self.nickname,
@@ -58,6 +67,9 @@ extension FeedResponse {
                           isSpoiler: self.isSpoiler,
                           isModified: self.isModified,
                           isMyFeed: self.isMyFeed,
-                          isPublic: self.isPublic)
+                          isPublic: self.isPublic,
+                          hasImage: hasImage,
+                          imageCount: imageCount,
+                          imageURLs: imageURLs)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
@@ -46,7 +46,7 @@ extension FeedResponse {
         let hasLinkedNovel = self.novelId != nil
         let hasImage = self.images.count > 0
         let imageCount = self.images.count
-        // let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeBucketImageURL(path: $0) }
+        //let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeImageURLString(path: $0) }
         // 테스트용 코드 -> 머지 시 삭제 예정
         let imageURLs: [URL?] = self.images.map { URL(string: $0)! }
         

--- a/WSSiOS/WSSiOS/Source/Data/Repository/FeedDetailRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/FeedDetailRepository.swift
@@ -31,7 +31,7 @@ protocol FeedDetailRepository {
 
 struct TestFeedDetailRepository: FeedDetailRepository {
     func getSingleFeedData(feedId: Int) -> Observable<FeedEntity> {
-        return Observable.just(FeedEntity(userId: 0, userNickname: "굴", userProfileImageURL: nil, feedId: 1, createdDate: "2001년 10월 3일", feedContent: "오호랏", likeCount: 1, isLiked: true, commentCount: 1, genreCategories: [], hasLinkedNovel: false, novelId: 1, novelTitle: "", novelRatingCount: 0, novelRating: 0, isSpoiler: false, isModified: true, isMyFeed: true, isPublic: false))
+        return Observable.just(FeedResponse.dummyOneImageData).map { $0.toEntity() }
     }
     
     func getSingleFeedComments(feedId: Int) -> Observable<FeedCommentsEntity> {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
@@ -1,0 +1,85 @@
+//
+//  FeedDetailAddImageViewerView.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/20/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedDetailAddImageViewerView: UIView {
+    
+    //MARK: - Components
+    
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    private let collectionViewLayout = UICollectionViewFlowLayout()
+    
+    let closeButton = UIButton(type: .system)
+    let pageLabel = UILabel()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - UI
+    
+    private func setUI() {
+        collectionViewLayout.do {
+            $0.scrollDirection = .horizontal
+            $0.minimumLineSpacing = 0
+            collectionView.setCollectionViewLayout($0, animated: true)
+        }
+        
+        collectionView.do {
+            $0.isPagingEnabled = true
+            $0.showsHorizontalScrollIndicator = false
+            $0.backgroundColor = .black
+        }
+        
+        closeButton.do {
+            $0.setImage(.icCancelModal
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssWhite), for: .normal)
+        }
+        
+        pageLabel.do {
+            $0.textColor = .wssWhite
+        }
+    }
+    
+    private func setHierarchy() {
+        self.addSubviews(collectionView,
+                         closeButton,
+                         pageLabel)
+    }
+    
+    private func setLayout() {
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.size.equalTo(44)
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(1)
+            $0.leading.equalToSuperview().offset(6)
+        }
+        
+        pageLabel.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(11)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
@@ -82,4 +82,10 @@ final class FeedDetailAddImageViewerView: UIView {
             $0.centerX.equalToSuperview()
         }
     }
+    
+    //MARK: - Custom Methods
+    
+    func updatePageLabel(for index: Int, imageCount: Int) {
+        pageLabel.applyWSSFont(.title2, with: "\(index + 1) / \(imageCount)")
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAddImageViewerView.swift
@@ -78,7 +78,7 @@ final class FeedDetailAddImageViewerView: UIView {
         }
         
         pageLabel.snp.makeConstraints {
-            $0.top.equalTo(self.safeAreaLayoutGuide).offset(11)
+            $0.centerY.equalTo(closeButton.snp.centerY)
             $0.centerX.equalToSuperview()
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -62,14 +62,14 @@ final class FeedDetailAddImageView: UIView {
         }
     }
     
-    func bindImages(images: [UIImage]) {
+    func bindImages(imageURLs: [URL?]) {
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
-        let imageWidth = calculateImageWidth(for: images.count)
+        let imageWidth = calculateImageWidth(for: imageURLs.count)
         
-        for image in images {
+        for imageURL in imageURLs {
             let imageView = UIImageView().then {
-                $0.image = image
+                $0.kfSetImage(url: imageURL)
                 $0.layer.cornerRadius = 8
                 $0.clipsToBounds = true
                 $0.contentMode = .scaleAspectFill
@@ -78,7 +78,7 @@ final class FeedDetailAddImageView: UIView {
             stackView.addArrangedSubview(imageView)
         }
         
-        scrollView.isScrollEnabled = images.count > 3
+        scrollView.isScrollEnabled = imageURLs.count > 3
         
         stackView.snp.updateConstraints {
             $0.height.equalTo(imageWidth)

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -117,6 +117,7 @@ final class FeedDetailAddImageView: UIView {
         }
     }
     
+    // 이미지 개수에 따른 사이즈 계산 함수
     private func calculateImageWidth(for count: Int) -> CGFloat {
         let horizontalPadding: CGFloat = 40
         let imageSpacing: CGFloat = 7

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -1,0 +1,108 @@
+//
+//  FeedDetailAddImageView.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/19/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedDetailAddImageView: UIView {
+    
+    //MARK: - UI Components
+    
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        scrollView.do {
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        stackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 7
+            $0.alignment = .fill
+            $0.distribution = .fillEqually
+        }
+    }
+    
+    private func setHierarchy() {
+        self.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+    }
+    
+    private func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalTo(0)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalTo(0)
+        }
+    }
+    
+    func bindImages(images: [UIImage]) {
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        let imageWidth = calculateImageWidth(for: images.count)
+        
+        for image in images {
+            let imageView = UIImageView().then {
+                $0.image = image
+                $0.layer.cornerRadius = 8
+                $0.clipsToBounds = true
+                $0.contentMode = .scaleAspectFill
+                $0.snp.makeConstraints { $0.width.equalTo(imageWidth) }
+            }
+            stackView.addArrangedSubview(imageView)
+        }
+        
+        scrollView.isScrollEnabled = images.count > 3
+        
+        stackView.snp.updateConstraints {
+            $0.height.equalTo(imageWidth)
+        }
+        
+        scrollView.snp.updateConstraints {
+            $0.height.equalTo(imageWidth)
+        }
+    }
+    
+    private func calculateImageWidth(for count: Int) -> CGFloat {
+        let horizontalPadding: CGFloat = 40
+        let imageSpacing: CGFloat = 7
+        let totalWidth = UIScreen.main.bounds.width - horizontalPadding
+
+        switch count {
+        case 1:
+            return totalWidth
+        case 2:
+            return (totalWidth - imageSpacing) / 2
+        case 3:
+            return (totalWidth - imageSpacing * 2) / 3
+        default:
+            return 100
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -10,7 +10,17 @@ import UIKit
 import SnapKit
 import Then
 
+protocol FeedDetailAddImageViewDelegate: AnyObject {
+    func addImageDidTap(_ view: FeedDetailAddImageView, didTapImageAt index: Int, imageURLs: [URL?])
+}
+
 final class FeedDetailAddImageView: UIView {
+    
+    //MARK: - Properties
+    
+    weak var delegate: FeedDetailAddImageViewDelegate?
+    
+    private var imageURLs: [URL?] = []
     
     //MARK: - UI Components
     
@@ -35,6 +45,7 @@ final class FeedDetailAddImageView: UIView {
     private func setUI() {
         scrollView.do {
             $0.showsHorizontalScrollIndicator = false
+            $0.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         }
         
         stackView.do {
@@ -62,19 +73,36 @@ final class FeedDetailAddImageView: UIView {
         }
     }
     
+    @objc private func imageTapped(_ sender: UITapGestureRecognizer) {
+        guard let tappedImageView = sender.view as? UIImageView else { return }
+        let index = tappedImageView.tag
+        delegate?.addImageDidTap(self, didTapImageAt: index, imageURLs: imageURLs)
+    }
+    
     func bindImages(imageURLs: [URL?]) {
+        self.imageURLs = imageURLs
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         let imageWidth = calculateImageWidth(for: imageURLs.count)
         
-        for imageURL in imageURLs {
+        for (index, imageURL) in imageURLs.enumerated() {
             let imageView = UIImageView().then {
                 $0.kfSetImage(url: imageURL)
                 $0.layer.cornerRadius = 8
                 $0.clipsToBounds = true
                 $0.contentMode = .scaleAspectFill
-                $0.snp.makeConstraints { $0.width.equalTo(imageWidth) }
+                $0.isUserInteractionEnabled = true
             }
+            
+            imageView.snp.makeConstraints {
+                $0.width.equalTo(imageWidth)
+                $0.height.equalTo(imageWidth)
+            }
+            
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageTapped(_:)))
+            imageView.addGestureRecognizer(tapGesture)
+            imageView.tag = index
+            
             stackView.addArrangedSubview(imageView)
         }
         
@@ -93,7 +121,7 @@ final class FeedDetailAddImageView: UIView {
         let horizontalPadding: CGFloat = 40
         let imageSpacing: CGFloat = 7
         let totalWidth = UIScreen.main.bounds.width - horizontalPadding
-
+        
         switch count {
         case 1:
             return totalWidth

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -9,18 +9,14 @@ import UIKit
 
 import SnapKit
 import Then
-
-protocol FeedDetailAddImageViewDelegate: AnyObject {
-    func addImageDidTap(_ view: FeedDetailAddImageView, didTapImageAt index: Int, imageURLs: [URL?])
-}
+import RxSwift
 
 final class FeedDetailAddImageView: UIView {
     
     //MARK: - Properties
     
-    weak var delegate: FeedDetailAddImageViewDelegate?
-    
-    private var imageURLs: [URL?] = []
+    let imageTapSubject = PublishSubject<(Int)>()
+    private let disposeBag = DisposeBag()
     
     //MARK: - UI Components
     
@@ -72,14 +68,7 @@ final class FeedDetailAddImageView: UIView {
         }
     }
     
-    @objc private func imageTapped(_ sender: UITapGestureRecognizer) {
-        guard let tappedImageView = sender.view as? UIImageView else { return }
-        let index = tappedImageView.tag
-        delegate?.addImageDidTap(self, didTapImageAt: index, imageURLs: imageURLs)
-    }
-    
     func bindImages(imageURLs: [URL?]) {
-        self.imageURLs = imageURLs
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         let imageWidth = calculateImageWidth(for: imageURLs.count)
@@ -97,9 +86,15 @@ final class FeedDetailAddImageView: UIView {
                 $0.size.equalTo(imageWidth)
             }
             
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageTapped(_:)))
-            imageView.addGestureRecognizer(tapGesture)
             imageView.tag = index
+            
+            let tapGesture = UITapGestureRecognizer()
+            imageView.addGestureRecognizer(tapGesture)
+            
+            tapGesture.rx.event
+                .map { _ in (index) }
+                .bind(to: imageTapSubject)
+                .disposed(by: disposeBag)
             
             stackView.addArrangedSubview(imageView)
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailAddImageView.swift
@@ -52,7 +52,6 @@ final class FeedDetailAddImageView: UIView {
             $0.axis = .horizontal
             $0.spacing = 7
             $0.alignment = .fill
-            $0.distribution = .fillEqually
         }
     }
     
@@ -95,8 +94,7 @@ final class FeedDetailAddImageView: UIView {
             }
             
             imageView.snp.makeConstraints {
-                $0.width.equalTo(imageWidth)
-                $0.height.equalTo(imageWidth)
+                $0.size.equalTo(imageWidth)
             }
             
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageTapped(_:)))

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -17,7 +17,7 @@ final class FeedDetailContentView: UIView {
     private let stackView = UIStackView()
     private let contentWrapperView = UIView()
     private let contentLabel = UILabel()
-    private let addImageView = FeedDetailAddImageView()
+    let addImageView = FeedDetailAddImageView()
     private let linkNovelWrapperView = UIView()
     let linkNovelView = FeedNovelView()
     private let reactWrapperView = UIView()

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -15,9 +15,12 @@ final class FeedDetailContentView: UIView {
     //MARK: - UI Components
     
     private let stackView = UIStackView()
+    private let contentWrapperView = UIView()
     private let contentLabel = UILabel()
     private let addImageView = FeedDetailAddImageView()
+    private let linkNovelWrapperView = UIView()
     let linkNovelView = FeedNovelView()
+    private let reactWrapperView = UIView()
     let reactView = FeedReactView()
     private let dividerView = UIView()
     
@@ -55,22 +58,31 @@ final class FeedDetailContentView: UIView {
     private func setHierarchy() {
         self.addSubviews(stackView,
                          dividerView)
-        stackView.addArrangedSubviews(contentLabel,
+        contentWrapperView.addSubview(contentLabel)
+        linkNovelWrapperView.addSubview(linkNovelView)
+        reactWrapperView.addSubview(reactView)
+        stackView.addArrangedSubviews(contentWrapperView,
                                       addImageView,
-                                      linkNovelView,
-                                      reactView)
+                                      linkNovelWrapperView,
+                                      reactWrapperView)
     }
     
     private func setLayout() {
         stackView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.edges.equalToSuperview()
+        }
+
+        [contentLabel, linkNovelView, reactView].forEach {
+            $0.snp.makeConstraints {
+                $0.verticalEdges.equalToSuperview()
+                $0.horizontalEdges.equalToSuperview().inset(20)
+            }
         }
         
         dividerView.snp.makeConstraints {
-            $0.top.equalTo(stackView.snp.bottom).offset(22)
+            $0.top.equalTo(stackView.snp.bottom).offset(16)
             $0.height.equalTo(7)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
     }
     
@@ -83,12 +95,12 @@ final class FeedDetailContentView: UIView {
         }
         
         if data.hasLinkedNovel {
-            stackView.insertArrangedSubview(linkNovelView, at: 2)
+            stackView.insertArrangedSubview(linkNovelWrapperView, at: 2)
             linkNovelView.bindData(title: data.novelTitle ?? "",
                                    rating: data.novelRating ?? 0,
                                    participants: data.novelRatingCount ?? 0)
         } else {
-            linkNovelView.removeFromSuperview()
+            linkNovelWrapperView.removeFromSuperview()
         }
         
         reactView.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -14,7 +14,9 @@ final class FeedDetailContentView: UIView {
     
     //MARK: - UI Components
     
+    private let stackView = UIStackView()
     private let contentLabel = UILabel()
+    private let addImageView = FeedDetailAddImageView()
     let linkNovelView = FeedNovelView()
     let reactView = FeedReactView()
     private let dividerView = UIView()
@@ -35,6 +37,12 @@ final class FeedDetailContentView: UIView {
     }
     
     private func setUI() {
+        stackView.do {
+            $0.axis = .vertical
+            $0.alignment = .fill
+            $0.spacing = 30
+        }
+        
         contentLabel.do {
             $0.textColor = .wssBlack
         }
@@ -45,31 +53,22 @@ final class FeedDetailContentView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubviews(contentLabel,
-                         linkNovelView,
-                         reactView,
+        self.addSubviews(stackView,
                          dividerView)
+        stackView.addArrangedSubviews(contentLabel,
+                                      addImageView,
+                                      linkNovelView,
+                                      reactView)
     }
     
     private func setLayout() {
-        contentLabel.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-        
-        linkNovelView.snp.makeConstraints {
-            $0.top.equalTo(contentLabel.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(48)
-        }
-        
-        reactView.snp.makeConstraints {
-            $0.top.equalTo(linkNovelView.snp.bottom).offset(24)
-            $0.leading.trailing.equalToSuperview().inset(20)
+        stackView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
         dividerView.snp.makeConstraints {
-            $0.top.equalTo(reactView.snp.bottom).offset(22)
+            $0.top.equalTo(stackView.snp.bottom).offset(22)
             $0.height.equalTo(7)
             $0.leading.trailing.bottom.equalToSuperview()
         }
@@ -84,27 +83,26 @@ final class FeedDetailContentView: UIView {
         }
         
         if data.hasLinkedNovel {
-            linkNovelView.isHidden = false
-            linkNovelView.snp.remakeConstraints {
-                $0.top.equalTo(contentLabel.snp.bottom).offset(20)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.height.equalTo(48)
-            }
+            stackView.insertArrangedSubview(linkNovelView, at: 2)
             linkNovelView.bindData(title: data.novelTitle ?? "",
                                    rating: data.novelRating ?? 0,
                                    participants: data.novelRatingCount ?? 0)
         } else {
-            linkNovelView.isHidden = true
-            reactView.snp.remakeConstraints {
-                $0.top.equalTo(contentLabel.snp.bottom).offset(20)
-                $0.leading.trailing.equalToSuperview().inset(20)
-            }
+            linkNovelView.removeFromSuperview()
         }
         
         reactView.do {
             $0.bindData(likeRating: data.likeCount,
                         isLiked: data.isLiked,
                         commentRating: data.commentCount)
+        }
+        
+        if data.hasImage {
+            stackView.insertArrangedSubview(addImageView, at: 1)
+            stackView.setCustomSpacing(data.hasLinkedNovel ? 16 : 30, after: addImageView)
+            addImageView.bindImages(imageURLs: data.imageURLs)
+        } else {
+            addImageView.removeFromSuperview()
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailCell/FeedDetailAddImageViewerCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailCell/FeedDetailAddImageViewerCell.swift
@@ -1,0 +1,72 @@
+//
+//  FeedDetailAddImageViewerCell.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/19/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedDetailAddImageViewerCell: UICollectionViewCell {
+    
+    //MARK: - Components
+    
+    private let scrollView = UIScrollView()
+    private let imageView = UIImageView()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        scrollView.zoomScale = 1.0
+        imageView.image = nil
+    }
+    
+    //MARK: - UI
+    
+    private func setUI() {
+        scrollView.do {
+            $0.minimumZoomScale = 1.0
+            $0.maximumZoomScale = 3.0
+            $0.frame = contentView.bounds
+            $0.delegate = self
+        }
+        
+        imageView.do {
+            $0.frame = contentView.bounds
+            $0.contentMode = .scaleAspectFit
+            $0.clipsToBounds = true
+        }
+    }
+    
+    private func setHierarchy() {
+        contentView.addSubview(scrollView)
+        scrollView.addSubview(imageView)
+    }
+    
+    //MARK: - Bind
+    
+    func bindImage(url: URL?) {
+        imageView.kfSetImage(url: url)
+    }
+}
+
+extension FeedDetailAddImageViewerCell: UIScrollViewDelegate {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return imageView
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
@@ -130,7 +130,7 @@ final class FeedDetailView: UIView {
         }
         
         replyView.snp.makeConstraints {
-            $0.top.equalTo(feedContentView.snp.bottom)
+            $0.top.equalTo(feedContentView.snp.bottom).offset(16)
             $0.leading.trailing.bottom.equalToSuperview()
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
@@ -1,0 +1,108 @@
+//
+//  FeedDetailAddImageViewerController.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 5/19/25.
+//
+
+import UIKit
+
+import RxSwift
+
+final class FeedDetailAddImageViewerController: UIViewController {
+    
+    //MARK: - Properties
+    
+    private let imageURLs: [URL?]
+    private let startIndex: Int
+    
+    private let disposeBag = DisposeBag()
+    
+    private var hasScrolledToInitialIndex = false
+    
+    //MARK: - UI Components
+    
+    private let rootView = FeedDetailAddImageViewerView()
+    
+    //MARK: - Life Cycles
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    init(imageURLs: [URL?], startIndex: Int) {
+        self.imageURLs = imageURLs
+        self.startIndex = startIndex
+        
+        super.init(nibName: nil, bundle: nil)
+        self.modalPresentationStyle = .fullScreen
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupCollectionView()
+        bindAction()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        rootView.pageLabel.applyWSSFont(.title2, with:  "\(startIndex + 1) / \(imageURLs.count)")
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        if !hasScrolledToInitialIndex && startIndex < imageURLs.count {
+            let indexPath = IndexPath(item: startIndex, section: 0)
+            rootView.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+            hasScrolledToInitialIndex = true
+        }
+    }
+    
+    private func setupCollectionView() {
+        rootView.collectionView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+        rootView.collectionView.rx.setDataSource(self)
+            .disposed(by: disposeBag)
+        rootView.collectionView.register(FeedDetailAddImageViewerCell.self,
+                                         forCellWithReuseIdentifier: FeedDetailAddImageViewerCell.cellIdentifier)
+    }
+    
+    private func bindAction() {
+        rootView.closeButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension FeedDetailAddImageViewerController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return imageURLs.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeedDetailAddImageViewerCell.cellIdentifier,
+                                                            for: indexPath) as? FeedDetailAddImageViewerCell else {
+            return UICollectionViewCell()
+        }
+        cell.bindImage(url: imageURLs[indexPath.item])
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return collectionView.frame.size
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let pageIndex = Int(round(scrollView.contentOffset.x / scrollView.frame.width))
+        rootView.pageLabel.applyWSSFont(.title2, with: "\(pageIndex + 1) / \(imageURLs.count)")
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
@@ -95,7 +95,7 @@ extension FeedDetailAddImageViewerController: UICollectionViewDataSource, UIColl
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return collectionView.frame.size
+        return collectionView.bounds.size
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
@@ -13,8 +13,8 @@ final class FeedDetailAddImageViewerController: UIViewController {
     
     //MARK: - Properties
     
-    private let imageURLs: [URL?]
     private let startIndex: Int
+    private let imageURLs: [URL?]
     
     private let disposeBag = DisposeBag()
     
@@ -30,9 +30,9 @@ final class FeedDetailAddImageViewerController: UIViewController {
         self.view = rootView
     }
     
-    init(imageURLs: [URL?], startIndex: Int) {
-        self.imageURLs = imageURLs
+    init(startIndex: Int, imageURLs: [URL?]) {
         self.startIndex = startIndex
+        self.imageURLs = imageURLs
         
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .fullScreen

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
@@ -60,6 +60,8 @@ final class FeedDetailAddImageViewerController: UIViewController {
         }
     }
     
+    //MARK: - Bind
+    
     private func setupCollectionView() {
         rootView.collectionView.rx.setDelegate(self)
             .disposed(by: disposeBag)

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailAddImageViewerController.swift
@@ -49,12 +49,6 @@ final class FeedDetailAddImageViewerController: UIViewController {
         bindAction()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        rootView.pageLabel.applyWSSFont(.title2, with:  "\(startIndex + 1) / \(imageURLs.count)")
-    }
-    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
@@ -62,6 +56,7 @@ final class FeedDetailAddImageViewerController: UIViewController {
             let indexPath = IndexPath(item: startIndex, section: 0)
             rootView.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
             hasScrolledToInitialIndex = true
+            rootView.updatePageLabel(for: startIndex, imageCount: imageURLs.count)
         }
     }
     
@@ -103,6 +98,6 @@ extension FeedDetailAddImageViewerController: UICollectionViewDataSource, UIColl
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let pageIndex = Int(round(scrollView.contentOffset.x / scrollView.frame.width))
-        rootView.pageLabel.applyWSSFont(.title2, with: "\(pageIndex + 1) / \(imageURLs.count)")
+        rootView.updatePageLabel(for: pageIndex, imageCount: imageURLs.count)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -58,6 +58,8 @@ final class FeedDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.rootView.feedContentView.addImageView.delegate = self
+        
         bindViewModel()
         registerCell()
         delegate()
@@ -603,5 +605,11 @@ extension FeedDetailViewController: FeedDetailReplyCollectionDelegate {
     
     func spoilerTextDidTap() {
         self.commentSpoilerTextDidTap.accept(())
+    }
+}
+
+extension FeedDetailViewController: FeedDetailAddImageViewDelegate {
+    func addImageDidTap(_ view: FeedDetailAddImageView, didTapImageAt index: Int, imageURLs: [URL?]) {
+        self.presentToFeedDetailAddImageViewerViewController(imageURLs: imageURLs, startIndex: index)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -85,8 +85,6 @@ final class FeedDetailViewController: UIViewController {
         
         rootView.replyWritingView.replyWritingTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
-        
-        rootView.feedContentView.addImageView.delegate = self
     }
     
     private func bindViewModel() {
@@ -115,6 +113,7 @@ final class FeedDetailViewController: UIViewController {
             replyCollectionViewContentSize: rootView.replyView.replyCollectionView.rx.observe(CGSize.self, "contentSize"),
             likeButtonDidTap: rootView.feedContentView.reactView.likeView.rx.tapGesture().when(.recognized).asObservable(),
             userProfileViewDidTap: rootView.profileView.userProfileImageView.rx.tapGesture().when(.recognized).asObservable(),
+            imageViewDidTap: rootView.feedContentView.addImageView.imageTapSubject.asObservable(),
             linkNovelViewDidTap: rootView.feedContentView.linkNovelView.rx.tapGesture().when(.recognized).asObservable(),
             viewDidTap: viewDidTap,
             commentContentUpdated: rootView.replyWritingView.replyWritingTextView.rx.text.orEmpty.distinctUntilChanged().asObservable(),
@@ -170,6 +169,16 @@ final class FeedDetailViewController: UIViewController {
         output.replyCollectionViewHeight
             .drive(with: self, onNext: { owner, height in
                 owner.rootView.replyView.updateCollectionViewHeight(height: height)
+            })
+            .disposed(by: disposeBag)
+        
+        // 첨부 이미지
+        output.presentFeedDetailAddImageViewerController
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, data in
+                let startIndex = data.0
+                let imageURLs = data.1
+                owner.presentToFeedDetailAddImageViewerViewController(startIndex: startIndex, imageURLs: imageURLs)
             })
             .disposed(by: disposeBag)
         
@@ -605,11 +614,5 @@ extension FeedDetailViewController: FeedDetailReplyCollectionDelegate {
     
     func spoilerTextDidTap() {
         self.commentSpoilerTextDidTap.accept(())
-    }
-}
-
-extension FeedDetailViewController: FeedDetailAddImageViewDelegate {
-    func addImageDidTap(_ view: FeedDetailAddImageView, didTapImageAt index: Int, imageURLs: [URL?]) {
-        self.presentToFeedDetailAddImageViewerViewController(imageURLs: imageURLs, startIndex: index)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -58,8 +58,6 @@ final class FeedDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.rootView.feedContentView.addImageView.delegate = self
-        
         bindViewModel()
         registerCell()
         delegate()
@@ -87,6 +85,8 @@ final class FeedDetailViewController: UIViewController {
         
         rootView.replyWritingView.replyWritingTextView.rx.setDelegate(self)
             .disposed(by: disposeBag)
+        
+        rootView.feedContentView.addImageView.delegate = self
     }
     
     private func bindViewModel() {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -25,13 +25,17 @@ final class FeedDetailViewModel: ViewModelType {
     private let replyCollectionViewHeight = BehaviorRelay<CGFloat>(value: 0)
     private var feedUserId: Int?
     
-    // 작품 연결
-    private var novelId: Int?
-    private let presentNovelDetailViewController = PublishRelay<Int>()
+    // 첨부 이미지
+    private var imageURLs: [URL?] = []
+    private let presentToFeedDetailAddImageViewerViewController = PublishRelay<(Int, [URL?])>()
     
     // 관심 버튼
     private let likeCount = BehaviorRelay<Int>(value: 0)
     private let likeButtonState = BehaviorRelay<Bool>(value: false)
+    
+    // 작품 연결
+    private var novelId: Int?
+    private let presentNovelDetailViewController = PublishRelay<Int>()
     
     // 댓글 작성
     let commentCount = BehaviorRelay<Int>(value: 0)
@@ -93,6 +97,9 @@ final class FeedDetailViewModel: ViewModelType {
         let likeButtonDidTap: Observable<UITapGestureRecognizer>
         let userProfileViewDidTap: Observable<UITapGestureRecognizer>
         
+        // 첨부 이미지
+        let imageViewDidTap: Observable<Int>
+        
         // 작품 연결
         let linkNovelViewDidTap: Observable<UITapGestureRecognizer>
         
@@ -125,6 +132,9 @@ final class FeedDetailViewModel: ViewModelType {
         let myProfileData: Observable<MyProfileEntity>
         let popViewController: Observable<Void>
         let replyCollectionViewHeight: Driver<CGFloat>
+        
+        // 첨부 이미지
+        let presentFeedDetailAddImageViewerController: Observable<(Int, [URL?])>
         
         // 관심 버튼
         let likeCount: Driver<Int>
@@ -184,6 +194,7 @@ final class FeedDetailViewModel: ViewModelType {
                     owner.novelId = feed.novelId
                     owner.commentCount.accept(feed.commentCount)
                     owner.isMyFeed.accept(feed.isMyFeed)
+                    owner.imageURLs = feed.imageURLs
                 case .error(let error):
                     owner.handleNetworkError(error)
                 case .completed:
@@ -252,6 +263,13 @@ final class FeedDetailViewModel: ViewModelType {
                 } else if feedUserId == -1 {
                     owner.showWithdrawalUserToastView.accept(())
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        // 첨부 이미지
+        input.imageViewDidTap
+            .subscribe(with: self, onNext: { owner, index in
+                owner.presentToFeedDetailAddImageViewerViewController.accept((index, owner.imageURLs))
             })
             .disposed(by: disposeBag)
         
@@ -475,6 +493,7 @@ final class FeedDetailViewModel: ViewModelType {
                       myProfileData: myProfileData.asObservable(),
                       popViewController: popViewController.asObservable(),
                       replyCollectionViewHeight: replyCollectionViewContentSize,
+                      presentFeedDetailAddImageViewerController: presentToFeedDetailAddImageViewerViewController.asObservable(),
                       likeCount: likeCount.asDriver(),
                       likeButtonToggle: likeButtonState.asDriver(),
                       presentNovelDetailViewController: presentNovelDetailViewController.asObservable(),


### PR DESCRIPTION
### ⭐️Issue
- close #556 
<br/>

### 🌟Motivation
- 피드 상세뷰 내 이미지 첨부 UI를 구현했습니다. 
#### 피드 상세뷰 내 이미지 첨부 기능 명세
| 1. 이미지 개수 별 UI 분기 | 2. 이미지 클릭 시 이미지 상세보기 뷰어 | 
| -- |  -- |
| <img width="900" alt="image" src="https://github.com/user-attachments/assets/f0fb85a0-cb90-4351-b93c-944da58967d9" />  |  <img width="229" alt="image" src="https://github.com/user-attachments/assets/5df94d9c-0d33-46bf-879c-6aebecb0a677" /> |
| 이미지 4장 이상 부터는 수평 스크롤로 이미지 확인이 가능해야 한다. |  이미지 뷰어에선 최상단에 현재 페이지와 전체 페이지가 명시되어야 한다. 스와이프를 통해 이미지를 크게 확인할 수 있어야 한다. |
<br/>

### 🌟Key Changes
#### **FeedDetailAddImageViewerController** 내 `viewDidLayoutSubviews()` 로직 

```swift 
private var hasScrolledToInitialIndex = false

override func viewDidLayoutSubviews() {
    super.viewDidLayoutSubviews()
        
    if !hasScrolledToInitialIndex && startIndex < imageURLs.count {
        let indexPath = IndexPath(item: startIndex, section: 0)
        rootView.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
        hasScrolledToInitialIndex = true
        rootView.updatePageLabel(for: startIndex, imageCount: imageURLs.count)
    }
}
```
 `hasScrolledToInitialIndex`: 뷰컨트롤러에서 초기 진입 시, 원하는 인덱스로 collectionView를 한 번만 스크롤하도록 제어하는 "플래그 역할"을 하는 변수
`viewDidLayoutSubviews`: 뷰의 레이아웃이 바뀔 때마다 여러 번 호출될 수 있습니다. (뷰가 다시 그려질 때, 레이아웃이 바뀔 때 ..) 
플래그 변수가 없을 때에는 스와이프 시 다음 이미지로 스크롤이 잘 안되는 이슈가 있었습니다. (`scrollToItem` 메소드가 여러 번 호출되어서 버벅임)
따라서 위 플래그 변수를 통해 뷰가 바뀔 때 딱 한번만 함수들이 호출될 수 있도록 보장하게 하였습니다. 
<br/>

#### **FeedDetailContentView** 내 StackView 구조 
```swift
private func setHierarchy() {
        self.addSubviews(stackView,
                         dividerView)
        contentWrapperView.addSubview(contentLabel)
        linkNovelWrapperView.addSubview(linkNovelView)
        reactWrapperView.addSubview(reactView)
        stackView.addArrangedSubviews(contentWrapperView,
                                      addImageView,
                                      linkNovelWrapperView,
                                      reactWrapperView)
    }
    
private func setLayout() {
    stackView.snp.makeConstraints {
        $0.edges.equalToSuperview()
    }

    [contentLabel, linkNovelView, reactView].forEach {
         $0.snp.makeConstraints {
              $0.verticalEdges.equalToSuperview()
              $0.horizontalEdges.equalToSuperview().inset(20)
        }
    }
```
뷰를 나열했던 구조를 UIStackView를 사용하여 레이아웃 수정했습니다. 
근데 이미지가 스크롤이 될 때에는 좌우 여백 20을 잡게 되면 이미지도 여백에 먹히게 되어 UI에 부합하지 않았습니다. 
참고로 `StackView`에서는 **전체 가로 폭을 기준**으로 하기 때문에 다른 뷰들도 동일한 폭으로 정렬되며, 결과적으로 다른 뷰들도 간접적으로 패딩처럼 보이게 됩니다.
따라서 뷰를 감싸는 WrapperView를 만들어 해당 뷰 안에 각 뷰를 배치하고 좌우 여백 20을 부여하도록 했습니다. 
<img width="433" alt="image" src="https://github.com/user-attachments/assets/5bfa194e-3e04-431b-ace5-fa6a0294a280" />


### 🌟Simulation
| 1장 | 2장 | 3장 | 4장 이상 | 
| -- | -- | -- | -- | 
| ![oneimage](https://github.com/user-attachments/assets/7ae54b95-b7fc-4643-a49e-c3dfb84c3df0) | ![twoimage](https://github.com/user-attachments/assets/4b4972ee-1814-4dd6-b15e-d23c15958f2a)  | ![threeimage](https://github.com/user-attachments/assets/75d3a083-900c-4884-a842-fab0e36cfaa0) |  ![many](https://github.com/user-attachments/assets/1ba116d2-7a9c-4a94-a93b-2dda0553349b)|
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
