### PR TITLE
[Feat] #562 - 마이페이지와 타유저페이지 일 때 파일 분리

### DIFF
--- a/WSSiOS/WSSiOS/GoogleService-Info-Debug.plist
+++ b/WSSiOS/WSSiOS/GoogleService-Info-Debug.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyB27TzRSysLIgDVp-NrHVE4IbGzG9_riyk</string>
+	<key>GCM_SENDER_ID</key>
+	<string>613052207578</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>kr.websoso.debug</string>
+	<key>PROJECT_ID</key>
+	<string>websoso-e3a8a</string>
+	<key>STORAGE_BUCKET</key>
+	<string>websoso-e3a8a.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:613052207578:ios:517da4567ebf6c0c5f30e3</string>
+</dict>
+</plist>

--- a/WSSiOS/WSSiOS/GoogleService-Info.plist
+++ b/WSSiOS/WSSiOS/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyB27TzRSysLIgDVp-NrHVE4IbGzG9_riyk</string>
+	<key>GCM_SENDER_ID</key>
+	<string>613052207578</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>kr.websoso</string>
+	<key>PROJECT_ID</key>
+	<string>websoso-e3a8a</string>
+	<key>STORAGE_BUCKET</key>
+	<string>websoso-e3a8a.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:613052207578:ios:f82e924bbca4b6c55f30e3</string>
+</dict>
+</plist>

--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -18,7 +18,7 @@ protocol UserService {
     func getUserProfileVisibility() -> Single<UserProfileVisibilityResponse>
     func patchUserProfileVisibility(isProfilePublic: UserProfileVisibilityRequest) -> Single<Void>
     func getMyProfile() -> Single<MyProfileResponse>
-    func getOtherProfile(userId: Int) -> Single<OtherProfileResponse>
+    func getOtherProfile(userId: Int) -> Single<UserProfileResponse>
     func getUserNovelPreferences(userId: Int) -> Single<UserNovelPreferencesResponse>
     func getUserGenrePreferences(userId: Int) -> Single<UserGenrePreferencesListResponse>
     func patchUserProfile(updatedFields: [String: Any]) -> Single<Void>
@@ -198,7 +198,7 @@ extension DefaultUserService: UserService {
         }
     }
     
-    func getOtherProfile(userId: Int) -> Single<OtherProfileResponse> {
+    func getOtherProfile(userId: Int) -> Single<UserProfileResponse> {
         do {
             let request = try makeHTTPRequest(method: .get,
                                               path: URLs.User.otherProfile(userId: userId),
@@ -209,7 +209,7 @@ extension DefaultUserService: UserService {
             
             return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
-                                       to: OtherProfileResponse.self) }
+                                       to: UserProfileResponse.self) }
                 .asSingle()
             
         } catch {

--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -23,7 +23,7 @@ protocol UserService {
     func getUserGenrePreferences(userId: Int) -> Single<UserGenrePreferencesListResponse>
     func patchUserProfile(updatedFields: [String: Any]) -> Single<Void>
     func getNicknameisValid(nickname: String) -> Single<OnboardingResponse>
-    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Single<MyFeedListResponse>
+    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Single<UserFeedListResponse>
     func getUserNovelList(userId: Int,
                           readStatus: String,
                           lastUserNovelId: Int,
@@ -318,7 +318,7 @@ extension DefaultUserService: UserService {
         }
     }
     
-    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Single<MyFeedListResponse> {
+    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Single<UserFeedListResponse> {
         let feedQueryItems: [URLQueryItem] = [
             URLQueryItem(name: "lastFeedId", value: String(describing: lastFeedId)),
             URLQueryItem(name: "size", value: String(describing: size))
@@ -334,7 +334,7 @@ extension DefaultUserService: UserService {
             
             return tokenCheckURLSession.rx.data(request: request)
                 .map { try self.decode(data: $0,
-                                       to: MyFeedListResponse.self) }
+                                       to: UserFeedListResponse.self) }
                 .asSingle()
         } catch {
             return Single.error(error)

--- a/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
@@ -15,7 +15,7 @@ enum NotificationName {
     static let novelReviewed = Notification.Name("novelReviewed")
     static let popFeedDetailViewController = Notification.Name("popFeedDetailViewController")
     static let feedNovelConnected = Notification.Name("feedNovelConnected")
-    static let blockUser = Notification.Name("blockUser")
+    static let blockUser = Notification.Name("BlockUser")
     static let pushToUpdateDetailSearchResult = Notification.Name("pushToUpdateDetailSearchResult")
     static let pushToDetailSearchResult = Notification.Name("pushToDetailSearchResult")
     static let changeRepresentativeAvatar = Notification.Name("changeRepresentativeAvatar")

--- a/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
@@ -20,4 +20,5 @@ enum NotificationName {
     static let pushToDetailSearchResult = Notification.Name("pushToDetailSearchResult")
     static let changeRepresentativeAvatar = Notification.Name("changeRepresentativeAvatar")
     static let moveToLibraryTab = Notification.Name("moveToLibraryTab")
+    static let editProfile = Notification.Name("EditProfile")
 }

--- a/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/NotificationCenter/NotificationName.swift
@@ -20,5 +20,5 @@ enum NotificationName {
     static let pushToDetailSearchResult = Notification.Name("pushToDetailSearchResult")
     static let changeRepresentativeAvatar = Notification.Name("changeRepresentativeAvatar")
     static let moveToLibraryTab = Notification.Name("moveToLibraryTab")
-    static let editProfile = Notification.Name("EditProfile")
+    static let editProfile = Notification.Name("editProfile")
 }

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -301,41 +301,19 @@ extension UIViewController {
     }
     
     func pushToMyPageViewController() {
-        let viewController = MyPageViewController(
-            viewModel: MyPageViewModel(
-                userRepository: DefaultUserRepository(
-                    userInfoRepository: DefaultUserInfoRepository(
-                        userService: DefaultUserService()),
-                    userBlockRepository: DefaultUserBlockRepository(
-                        blocksService: DefaultBlocksService()))))
-        
+        let viewController = ModuleFactory.shared.makeMyPageViewController()
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
     func pushToUserPageViewController(userId: Int) {
-        let viewController = UserPageViewController(
-            viewModel: UserPageViewModel(
-                userRepository: DefaultUserRepository(
-                    userInfoRepository: DefaultUserInfoRepository(
-                        userService: DefaultUserService()),
-                    userBlockRepository: DefaultUserBlockRepository(
-                        blocksService: DefaultBlocksService())),
-                profileId: userId))
-        
+        let viewController = ModuleFactory.shared.makeUserPageViewController(profileId: userId)
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
     func pushToMyPageEditViewController(entryType: MyPageEditEntryType, profile: MyProfileEntity?) {
-        let viewController = MyPageEditProfileViewController(
-            viewModel: MyPageEditProfileViewModel(
-                userRepository: DefaultUserInfoRepository(
-                    userService: DefaultUserService()
-                ),
-                entryType: entryType,
-                profileData: profile))
-        
+        let viewController = ModuleFactory.shared.makeMyPageEditViewController(entryType: entryType, profile: profile)
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)
     }

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -409,7 +409,7 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func pushToUserPageFeedDetailViewController(userId: Int, userData: OtherProfileEntity) {
+    func pushToUserPageFeedDetailViewController(userId: Int, userData: UserProfileEntity) {
         let viewController = UserPageFeedDetailViewController(
             viewModel: UserPageFeedDetailViewModel(
                 userRepository: DefaultUserInfoRepository(

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -314,6 +314,20 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
+    func pushToUserPageViewController(userId: Int) {
+        let viewController = UserPageViewController(
+            viewModel: UserPageViewModel(
+                userRepository: DefaultUserRepository(
+                    userInfoRepository: DefaultUserInfoRepository(
+                        userService: DefaultUserService()),
+                    userBlockRepository: DefaultUserBlockRepository(
+                        blocksService: DefaultBlocksService())),
+                profileId: userId))
+        
+        viewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
     func pushToMyPageEditViewController(entryType: MyPageEditEntryType, profile: MyProfileEntity?) {
         let viewController = MyPageEditProfileViewController(
             viewModel: MyPageEditProfileViewModel(
@@ -395,14 +409,14 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func pushToMyPageFeedDetailViewController(userId: Int, useData: MyProfileEntity) {
-        let viewController = MyPageFeedDetailViewController(
-            viewModel: MyPageFeedDetailViewModel(
+    func pushToUserPageFeedDetailViewController(userId: Int, userData: OtherProfileEntity) {
+        let viewController = UserPageFeedDetailViewController(
+            viewModel: UserPageFeedDetailViewModel(
                 userRepository: DefaultUserInfoRepository(
                     userService: DefaultUserService()
                 ),
                 profileId: userId,
-                profileData: useData))
+                profileData: userData))
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -300,15 +300,14 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func pushToMyPageViewController(userId: Int) {
+    func pushToMyPageViewController() {
         let viewController = MyPageViewController(
             viewModel: MyPageViewModel(
                 userRepository: DefaultUserRepository(
                     userInfoRepository: DefaultUserInfoRepository(
                         userService: DefaultUserService()),
                     userBlockRepository: DefaultUserBlockRepository(
-                        blocksService: DefaultBlocksService())),
-                profileId: userId))
+                        blocksService: DefaultBlocksService()))))
         
         viewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(viewController, animated: true)

--- a/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
+++ b/WSSiOS/WSSiOS/Resource/Helper/ModuleFactory.swift
@@ -21,6 +21,12 @@ protocol ServiceTermAgreementFactory {
     func makeServiceTermAgreementViewController() -> UIViewController
 }
 
+protocol MyPageModuleFactory {
+    func makeMyPageViewController() -> UIViewController
+    func makeUserPageViewController(profileId: Int) -> UIViewController
+    func makeMyPageEditViewController(entryType: MyPageEditEntryType, profile: MyProfileEntity?) -> UIViewController
+}
+
 final class ModuleFactory {
     static let shared = ModuleFactory()
     private init() {}
@@ -54,5 +60,31 @@ extension ModuleFactory: OnboardingModuleFactory {
 extension ModuleFactory: ServiceTermAgreementFactory {
     func makeServiceTermAgreementViewController() -> UIViewController {
         return ServiceTermAgreementViewController(repository: DefaultUserInfoRepository(userService: DefaultUserService()))
+    }
+}
+
+extension ModuleFactory: MyPageModuleFactory {
+    func makeMyPageViewController() -> UIViewController {
+        return MyPageViewController(viewModel: MyPageViewModel(
+            userRepository: DefaultUserRepository(
+                userInfoRepository: DefaultUserInfoRepository(userService: DefaultUserService()),
+                userBlockRepository: DefaultUserBlockRepository(blocksService: DefaultBlocksService()))))
+    }
+    
+    func makeUserPageViewController(profileId: Int) -> UIViewController {
+        return UserPageViewController(
+            viewModel: UserPageViewModel(
+                userRepository: DefaultUserRepository(
+                    userInfoRepository: DefaultUserInfoRepository(userService: DefaultUserService()),
+                    userBlockRepository: DefaultUserBlockRepository(blocksService: DefaultBlocksService())),
+                profileId: profileId))
+    }
+    
+    func makeMyPageEditViewController(entryType: MyPageEditEntryType, profile: MyProfileEntity?) -> UIViewController {
+        return MyPageEditProfileViewController(
+            viewModel: MyPageEditProfileViewModel(
+                userRepository: DefaultUserInfoRepository(userService: DefaultUserService()),
+                entryType: entryType,
+                profileData: profile))
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/DTO/MyProfileResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/MyProfileResponse.swift
@@ -12,7 +12,7 @@ struct MyProfileResponse: Decodable {
     let genrePreferences: [String]
 }
 
-struct OtherProfileResponse: Decodable {
+struct UserProfileResponse: Decodable {
     let nickname, intro, avatarImage: String
     let genrePreferences: [String]
     let isProfilePublic: Bool

--- a/WSSiOS/WSSiOS/Source/Data/DTO/UserFeedListResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/UserFeedListResponse.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct MyFeedListResponse: Decodable {
+struct UserFeedListResponse: Decodable {
     let isLoadable: Bool
-    let feeds: [MyFeedResponse]
+    let feeds: [UserFeedResponse]
 }
 
-struct MyFeedResponse: Decodable {
+struct UserFeedResponse: Decodable {
     let feedId: Int
     let feedContent: String
     let createdDate: String

--- a/WSSiOS/WSSiOS/Source/Data/Entity/AvatarEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/AvatarEntity.swift
@@ -5,6 +5,8 @@
 //  Created by 신지원 on 3/19/25.
 //
 
+import Foundation
+
 struct AvatarListEntity {
     let avatars: [AvatarEntity]
 }
@@ -19,16 +21,17 @@ struct AvatarEntity {
     let avatarId: Int
     let avatarName: String
     let avatarLine: String
-    let avatarImage: String
+    let avatarImageURL: URL?
     let isRepresentative: Bool
 }
 
 extension AvatarResponse {
     func toEntity() -> AvatarEntity {
+        let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         return AvatarEntity(avatarId: self.avatarId,
                             avatarName: self.avatarName,
                             avatarLine: self.avatarLine,
-                            avatarImage: self.avatarImage,
+                            avatarImageURL: avatarImageURL,
                             isRepresentative: self.isRepresentative)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
@@ -23,17 +23,17 @@ extension MyProfileResponse {
     }
 }
 
-struct OtherProfileEntity {
+struct UserProfileEntity {
     let nickname, intro: String
     let genrePreferences: [String]
     let isProfilePublic: Bool
     let avatarImageURL: URL?
 }
 
-extension OtherProfileResponse {
-    func toEntity() -> OtherProfileEntity {
+extension UserProfileResponse {
+    func toEntity() -> UserProfileEntity {
         let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
-        return OtherProfileEntity(nickname: self.nickname,
+        return UserProfileEntity(nickname: self.nickname,
                                   intro: self.intro,
                                   genrePreferences: self.genrePreferences,
                                   isProfilePublic: self.isProfilePublic,

--- a/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
@@ -22,18 +22,20 @@ extension MyProfileResponse {
 }
 
 struct OtherProfileEntity {
-    let nickname, intro, avatarImage: String
+    let nickname, intro: String
     let genrePreferences: [String]
     let isProfilePublic: Bool
+    let avatarImageURL: URL?
 }
 
 extension OtherProfileResponse {
     func toEntity() -> OtherProfileEntity {
+        let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         return OtherProfileEntity(nickname: self.nickname,
                                   intro: self.intro,
-                                  avatarImage: self.avatarImage,
                                   genrePreferences: self.genrePreferences,
-                                  isProfilePublic: self.isProfilePublic)
+                                  isProfilePublic: self.isProfilePublic,
+                                  avatarImageURL: avatarImageURL)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
@@ -8,16 +8,18 @@
 import Foundation
 
 struct MyProfileEntity {
-    let nickname, intro, avatarImage: String
+    let nickname, intro: String
     let genrePreferences: [String]
+    let avatarImageURL: URL?
 }
 
 extension MyProfileResponse {
     func toEntity() -> MyProfileEntity {
+        let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         return MyProfileEntity(nickname: self.nickname,
                                intro: self.intro,
-                               avatarImage: self.avatarImage,
-                               genrePreferences: self.genrePreferences)
+                               genrePreferences: self.genrePreferences,
+                               avatarImageURL: avatarImageURL)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/ProfileEntity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MyProfileEntity {
-    let nickname, intro: String
+    let nickname, introdution: String
     let genrePreferences: [String]
     let avatarImageURL: URL?
 }
@@ -17,7 +17,7 @@ extension MyProfileResponse {
     func toEntity() -> MyProfileEntity {
         let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         return MyProfileEntity(nickname: self.nickname,
-                               intro: self.intro,
+                               introdution: self.intro,
                                genrePreferences: self.genrePreferences,
                                avatarImageURL: avatarImageURL)
     }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/TotalFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/TotalFeedListEntity.swift
@@ -25,7 +25,7 @@ struct TotalFeedEntity {
     let feedId: Int
     let userId: Int
     let nickname: String
-    let avatarImage: String
+    let avatarImage: URL?
     let createdDate: String
     let feedContent: String
     let likeCount: Int
@@ -48,6 +48,7 @@ struct TotalFeedEntity {
 
 extension TotalFeedResponse {
     func toEntity() -> TotalFeedEntity {
+        let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         let categoryText = self.relevantCategories.joined(separator: ", ")
         let makeNovelRating: Float
         if let novelRating = self.novelRating {
@@ -60,7 +61,7 @@ extension TotalFeedResponse {
             feedId: self.feedId,
             userId: self.userId,
             nickname: self.nickname,
-            avatarImage: self.avatarImage,
+            avatarImage: avatarImageURL,
             createdDate: self.createdDate,
             feedContent: self.feedContent,
             likeCount: self.likeCount,
@@ -91,7 +92,7 @@ extension TotalFeedListEntity {
                                                     TotalFeedEntity(feedId: 10003,
                                                                     userId: 31313131,
                                                                     nickname: "최고다이순신",
-                                                                    avatarImage: "",
+                                                                    avatarImage: nil,
                                                                     createdDate: "10월 4일",
                                                                     feedContent: "안녕 테스트 레포지토리야",
                                                                     likeCount: 12,
@@ -112,7 +113,7 @@ extension TotalFeedListEntity {
                                                     TotalFeedEntity(feedId: 123123,
                                                                     userId: 31313131,
                                                                     nickname: "구리",
-                                                                    avatarImage: "",
+                                                                    avatarImage: nil,
                                                                     createdDate: "10월 3일",
                                                                     feedContent: "이번엔 소설이 없고 이미지가 있어요",
                                                                     likeCount: 12,
@@ -133,7 +134,7 @@ extension TotalFeedListEntity {
                                                     TotalFeedEntity(feedId: 123123,
                                                                     userId: 31313131,
                                                                     nickname: "구림",
-                                                                    avatarImage: "",
+                                                                    avatarImage: nil,
                                                                     createdDate: "10월 3일",
                                                                     feedContent: "이번엔 이미지 없음",
                                                                     likeCount: 12,
@@ -154,7 +155,7 @@ extension TotalFeedListEntity {
                                                     TotalFeedEntity(feedId: 123123,
                                                                     userId: 31313131,
                                                                     nickname: "구리",
-                                                                    avatarImage: "",
+                                                                    avatarImage: nil,
                                                                     createdDate: "10월 3일",
                                                                     feedContent: "이번엔 소설이 없군",
                                                                     likeCount: 12,

--- a/WSSiOS/WSSiOS/Source/Data/Entity/User/UserPreferenceEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/User/UserPreferenceEntity.swift
@@ -9,15 +9,16 @@ import Foundation
 
 struct UserNovelPreferencesEntity {
     let attractivePoints: [String]
-    let keywords: [KeywordResponse]
+    let keywords: [KeywordEntity]
     var hasAttractivePoints: Bool { !attractivePoints.isEmpty }
     var hasKeywords: Bool { !keywords.isEmpty }
 }
 
 extension UserNovelPreferencesResponse {
     func toEntity() -> UserNovelPreferencesEntity {
+        let makeKeywordEntity = self.keywords.map{ $0.toEntity() }
         return UserNovelPreferencesEntity(attractivePoints: self.attractivePoints,
-                                          keywords: self.keywords)
+                                          keywords: makeKeywordEntity)
     }
 }
 

--- a/WSSiOS/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
@@ -7,19 +7,19 @@
 
 import Foundation
 
-struct MyFeedListEntity {
+struct UserFeedListEntity {
     let isLoadable: Bool
-    let feeds: [MyFeedEntity]
+    let feeds: [UserFeedEntity]
 }
 
-extension MyFeedListResponse {
-    func toEntity() -> MyFeedListEntity {
-        return MyFeedListEntity(isLoadable: self.isLoadable,
+extension UserFeedListResponse {
+    func toEntity() -> UserFeedListEntity {
+        return UserFeedListEntity(isLoadable: self.isLoadable,
                                 feeds: self.feeds.map { $0.toEntity()} )
     }
 }
 
-struct MyFeedEntity {
+struct UserFeedEntity {
     let feedId: Int
     let feedContent: String
     let createdDate: String
@@ -40,8 +40,8 @@ struct MyFeedEntity {
     let imageCount: Int
 }
 
-extension MyFeedResponse {
-    func toEntity() -> MyFeedEntity {
+extension UserFeedResponse {
+    func toEntity() -> UserFeedEntity {
         let makeNovelRating: Float
         if let novelRating = self.novelRating {
             makeNovelRating = round(novelRating * 10) / 10
@@ -53,7 +53,7 @@ extension MyFeedResponse {
             NewNovelGenre(rawValue: $0)?.withKorean
         }
         
-        return MyFeedEntity(feedId: self.feedId,
+        return UserFeedEntity(feedId: self.feedId,
                             feedContent: self.feedContent,
                             createdDate: self.formattedDate(),
                             isSpoiler: self.isSpoiler,
@@ -88,8 +88,8 @@ extension MyFeedResponse {
     }
 }
 
-struct MyFeedListItem {
-    let feed: MyFeedEntity
-    let avatarImage: String
+struct UserFeedListItem {
+    let feed: UserFeedEntity
+    let avatarImage: URL?
     let nickname: String
 }

--- a/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository/UserInfoRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository/UserInfoRepository.swift
@@ -12,7 +12,7 @@ import RxSwift
 protocol UserInfoRepository {
     func getUserMeData() -> Observable<UserMeEntity>
     func getMyProfileData() -> Observable<MyProfileEntity>
-    func getOtherProfile(userId: Int) -> Observable<OtherProfileEntity>
+    func getOtherProfile(userId: Int) -> Observable<UserProfileEntity>
     func getUserInfo() -> Observable<UserInfoEntity>
     func putUserInfo(userData: ChangeUserInfoEntity) -> Observable<Void>
     func patchUserName(userNickName: String) -> Observable<Void>
@@ -54,7 +54,7 @@ struct DefaultUserInfoRepository: UserInfoRepository {
             .asObservable()
     }
     
-    func getOtherProfile(userId: Int) -> Observable<OtherProfileEntity> {
+    func getOtherProfile(userId: Int) -> Observable<UserProfileEntity> {
         return userService.getOtherProfile(userId: userId)
             .map{ $0.toEntity() }
             .asObservable()

--- a/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository/UserInfoRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/UserRepository/UserInfoRepository.swift
@@ -23,7 +23,7 @@ protocol UserInfoRepository {
     func getUserGenrePreferences(userId: Int) -> Observable<UserGenrePreferencesListEntity>
     func patchUserProfile(updatedFields: [String: Any]) -> Observable<Void>
     func getNicknameisValid(nickname: String) -> Single<OnboardingResponse>
-    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<MyFeedListEntity>
+    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<UserFeedListEntity>
     func getUserNovelList(userId: Int,
                           readStatus: String,
                           lastUserNovelId: Int,
@@ -114,7 +114,7 @@ struct DefaultUserInfoRepository: UserInfoRepository {
         return userService.getNicknameisValid(nickname: nickname)
     }
     
-    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<MyFeedListEntity> {
+    func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<UserFeedListEntity> {
         return userService.getUserFeed(userId: userId, lastFeedId: lastFeedId, size: size)
             .map { $0.toEntity() }
             .asObservable()

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListHeaderView.swift
@@ -126,8 +126,8 @@ final class FeedListHeaderView: UIView {
     
     //MARK: - Data
     
-    func bindData(avatarImage: String, nickname: String, createdDate: String, isModified: Bool) {
-        userImageView.kfSetImage(url: makeBucketImageURLString(path: avatarImage))
+    func bindData(avatarImageURL: URL?, nickname: String, createdDate: String, isModified: Bool) {
+        userImageView.kfSetImage(url: avatarImageURL)
         userNicknameLabel.applyWSSFont(.title2, with: nickname)
         createdDateLabel.applyWSSFont(.body5, with: createdDate)
         isModifiedLabel.isHidden = !isModified

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListTableViewCell.swift
@@ -148,7 +148,7 @@ final class FeedListTableViewCell: UITableViewCell {
     func bindFeedData(feed: TotalFeedEntity) {
         self.feed.accept(feed)
         
-        feedHeaderView.bindData(avatarImage: feed.avatarImage,
+        feedHeaderView.bindData(avatarImageURL: feed.avatarImage,
                                 nickname: feed.nickname,
                                 createdDate: feed.createdDate,
                                 isModified: feed.isModified)
@@ -192,9 +192,9 @@ final class FeedListTableViewCell: UITableViewCell {
         }
     }
     
-    func bindProfileFeedData(feed: MyFeedListItem) {
+    func bindProfileFeedData(feed: UserFeedListItem) {
         feedHeaderView.dropdownButtonView.isHidden = true
-        feedHeaderView.bindData(avatarImage: feed.avatarImage,
+        feedHeaderView.bindData(avatarImageURL: feed.avatarImage,
                                 nickname: feed.nickname,
                                 createdDate: feed.feed.createdDate,
                                 isModified: feed.feed.isModified)

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
@@ -81,15 +81,13 @@ enum WSSTabBarItem: Int, CaseIterable {
             return LibraryViewController(userId: UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId))
             
         case .myPage:
-            let userId = UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
             let myPageVC = MyPageViewController(
                 viewModel: MyPageViewModel(
                     userRepository: DefaultUserRepository(
                         userInfoRepository: DefaultUserInfoRepository(
                             userService: DefaultUserService()),
                         userBlockRepository: DefaultUserBlockRepository(
-                            blocksService: DefaultBlocksService())),
-                    profileId: userId))
+                            blocksService: DefaultBlocksService()))))
             return myPageVC
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
@@ -90,7 +90,6 @@ enum WSSTabBarItem: Int, CaseIterable {
                         userBlockRepository: DefaultUserBlockRepository(
                             blocksService: DefaultBlocksService())),
                     profileId: userId))
-            myPageVC.entryType = .tabBar
             return myPageVC
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedAssistantView/FeedUserView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedView/FeedAssistantView/FeedUserView.swift
@@ -113,9 +113,9 @@ final class FeedUserView: UIView {
     
     //MARK: - Data
     
-    func bindData(imageURL: String, nickname: String, createdDate: String, isModified: Bool) {
+    func bindData(imageURL: URL?, nickname: String, createdDate: String, isModified: Bool) {
         userImageView.do {
-            $0.kfSetImage(url: makeBucketImageURLString(path: imageURL))
+            $0.kfSetImage(url: imageURL)
             $0.layer.cornerRadius = 12
             $0.layer.masksToBounds = true
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedGenreViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/FeedViewController/FeedGenreViewController.swift
@@ -112,7 +112,7 @@ final class FeedGenreViewController: UIViewController {
         output.pushToUserViewController
             .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .subscribe(with: self, onNext: { owner, userId in
-                owner.pushToMyPageViewController(userId: userId)
+                owner.pushToUserPageViewController(userId: userId)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
@@ -170,6 +170,6 @@ final class FeedDetailReplyWritingView: UIView {
     }
     
     func bindUserProfile(_ data: MyProfileEntity) {
-        userProfileImageView.kfSetImage(url: makeBucketImageURLString(path: data.avatarImage))
+        userProfileImageView.kfSetImage(url: data.avatarImageURL)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -503,7 +503,7 @@ final class FeedDetailViewController: UIViewController {
         
         output.pushToUserPageViewController
             .subscribe(with: self, onNext: { owner, userId in
-                owner.pushToMyPageViewController(userId: userId)
+                owner.pushToUserPageViewController(userId: userId)
             })
             .disposed(by: disposeBag)
 

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -244,7 +244,7 @@ final class HomeViewController: UIViewController {
             .disposed(by: disposeBag)
         
         // 취향장르 정보 수정 Notification
-        NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile"))
+        NotificationCenter.default.rx.notification(NotificationName.editProfile)
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 owner.showToast(.editUserProfile)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import Kingfisher
 import SnapKit
 import Then
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -474,8 +474,8 @@ extension MyPageEditProfileView {
             .applyAttribute()
         nicknameCountView.bindData(text: data.nickname)
         
-        introTextView.applyWSSFont(.body2, with: data.intro)
-        if !data.intro.isEmpty {
+        introTextView.applyWSSFont(.body2, with: data.introdution)
+        if !data.introdution.isEmpty {
             introTextViewPlaceholder.isHidden = true
         } else {
             introCountView.isHidden = false

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -374,9 +374,9 @@ extension MyPageEditProfileView {
     }
     
     //프로필
-    func updateProfileImage(image: String) {
+    func updateProfileImage(image: URL?) {
         userImageView.do {
-            $0.kfSetImage(url: makeBucketImageURLString(path: image))
+            $0.kfSetImage(url: image)
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -12,12 +12,16 @@ import Then
 
 final class MyPageEditProfileView: UIView {
     
+    //MARK: - Properties
+    
+    private let profileImageSize: CGFloat = 94
+    private let profileChangeImageSize: CGFloat = 25
+    
     //MARK: - Components
     
     private let myPageProfileView = UIView()
-    private var userImageView = CircularImageView()
-    let userImageChangeInnerButton: UIButton = CircularButton()
-    private let userImageChangeInnerButtonView = UIImageView()
+    private var userImageView = UIImageView()
+    let userImageChangeImageView = UIImageView()
     
     private let nicknameView = UIView()
     private let nicknameLabel = UILabel()
@@ -70,19 +74,20 @@ final class MyPageEditProfileView: UIView {
         myPageProfileView.do {
             $0.backgroundColor = .wssWhite
             
-            userImageChangeInnerButton.do {
-                var configuration = UIButton.Configuration.filled()
-                configuration.baseBackgroundColor = .wssWhite
-                
-                $0.configuration = configuration
-                $0.imageView?.contentMode = .scaleAspectFit
-                
+            userImageView.do {
+                $0.layer.cornerRadius = profileImageSize / 2
+                $0.clipsToBounds = true
+            }
+            
+            userImageChangeImageView.do {
+                $0.image = .icPlus
+                $0.contentMode = .center
+                $0.clipsToBounds = true
+                $0.layer.cornerRadius = profileChangeImageSize / 2
+                $0.isUserInteractionEnabled = true
+                $0.backgroundColor = .wssWhite
                 $0.layer.borderWidth = 1.04
                 $0.layer.borderColor = UIColor.wssGray70.cgColor
-                
-                userImageChangeInnerButtonView.do {
-                    $0.image = .icPlus
-                }
             }
         }
         
@@ -196,8 +201,7 @@ final class MyPageEditProfileView: UIView {
                          introView,
                          genreView)
         myPageProfileView.addSubviews(userImageView,
-                                      userImageChangeInnerButton)
-        userImageChangeInnerButton.addSubview(userImageChangeInnerButtonView)
+                                      userImageChangeImageView)
         nicknameView.addSubviews(nicknameLabel,
                                  textFieldBackgroundView,
                                  nicknameDuplicatedButton,
@@ -224,21 +228,16 @@ final class MyPageEditProfileView: UIView {
                 $0.top.equalTo(safeAreaLayoutGuide.snp.top).inset(38)
             }
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(94)
+            $0.size.equalTo(profileImageSize)
             
             userImageView.snp.makeConstraints {
                 $0.edges.equalToSuperview()
             }
             
-            userImageChangeInnerButton.snp.makeConstraints {
+            userImageChangeImageView.snp.makeConstraints {
                 $0.trailing.equalTo(userImageView.snp.trailing)
                 $0.bottom.equalTo(userImageView.snp.bottom)
-                $0.size.equalTo(25)
-                
-                userImageChangeInnerButtonView.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.size.equalTo(20)
-                }
+                $0.size.equalTo(profileChangeImageSize)
             }
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -482,8 +482,10 @@ extension MyPageEditProfileView {
             introCountView.isHidden = false
         }
         
-        userImageView.do {
-            $0.kfSetImage(url: makeBucketImageURLString(path: data.avatarImage))
+        if data.avatarImageURL == nil {
+            userImageView.image = .imgProfile
+        } else {
+            userImageView.kfSetImage(url: data.avatarImageURL)
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageEditProfileView.swift
@@ -26,7 +26,7 @@ final class MyPageEditProfileView: UIView {
     lazy var nicknameClearButton = UIButton()
     lazy var nicknameDuplicatedButton = UIButton()
     private let nicknameWarningLabel = UILabel()
-    private var nicknameCountView = MyPageCountView(maxLimit: 10)
+    private var nicknameCountView = UserPageCountView(maxLimit: 10)
     
     private let divide1View = UIView()
     
@@ -34,7 +34,7 @@ final class MyPageEditProfileView: UIView {
     private let introLabel = UILabel()
     lazy var introTextView = UITextView()
     private let introTextViewPlaceholder = UILabel()
-    private var introCountView = MyPageCountView(maxLimit: 50)
+    private var introCountView = UserPageCountView(maxLimit: 50)
     
     private let divide2View = UIView()
     
@@ -381,7 +381,7 @@ extension MyPageEditProfileView {
     
     //닉네임
     func updateNicknameCount(text: String) {
-        nicknameCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
+        nicknameCountView.bindData(text: text)
     }
     
     func updateNicknameTextField(isEditing: Bool, availablity: NicknameAvailablity) {
@@ -463,7 +463,7 @@ extension MyPageEditProfileView {
     }
     
     func updateIntroCount(text: String) {
-        introCountView.countLabel.applyWSSFont(.body4, with: String(text.count))
+        introCountView.bindData(text: text)
     }
     
     //MARK: - Data
@@ -472,7 +472,7 @@ extension MyPageEditProfileView {
         nicknameTextField.makeAttribute(with: data.nickname)
             .kerning(kerningPixel: -0.6)
             .applyAttribute()
-        nicknameCountView.countLabel.text = String(data.nickname.count)
+        nicknameCountView.bindData(text: data.nickname)
         
         introTextView.applyWSSFont(.body2, with: data.intro)
         if !data.intro.isEmpty {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageView.swift
@@ -2,7 +2,7 @@
 //  MyPageView.swift
 //  WSSiOS
 //
-//  Created by 신지원 on 1/8/24.
+//  Created by 신지원 on 5/21/25.
 //
 
 import UIKit
@@ -17,17 +17,11 @@ final class MyPageView: UIView {
     
     let scrollView = UIScrollView()
     let contentView = UIView()
-    
     let headerView = MyPageProfileHeaderView()
-    let mainStickyHeaderView = MyPageStickyHeaderView()
-    let scrolledStickyHeaderView = MyPageStickyHeaderView()
-    
-    let myPageLibraryView = MyPageLibraryView()
-    let myPageFeedView = MyPageFeedView()
+    let myPageLibraryView = UserPageLibraryView()
     
     //In VC
     let settingButton = UIButton()
-    let backButton = UIButton()
     
     // MARK: - Life Cycle
     
@@ -54,70 +48,35 @@ final class MyPageView: UIView {
             $0.showsVerticalScrollIndicator = false
         }
         
-        scrolledStickyHeaderView.do {
-            $0.isHidden = true
-        }
-        
-        myPageFeedView.isHidden = true
-        
         settingButton.do {
             $0.setImage(UIImage(resource: .icSetting), for: .normal)
-        }
-        
-        backButton.do {
-            $0.setImage(.icNavigateLeft.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray300), for: .normal)
         }
     }
     
     private func setHierarchy() {
-        addSubviews(scrollView,
-                    scrolledStickyHeaderView)
-        
+        addSubview(scrollView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(headerView,
-                                mainStickyHeaderView,
-                                myPageLibraryView,
-                                myPageFeedView)
+                                myPageLibraryView)
     }
     
     private func setLayout() {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
-            $0.left.right.bottom.equalToSuperview()
+            $0.horizontalEdges.bottom.equalToSuperview()
         }
         
         contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.edges.width.equalToSuperview()
         }
         
         headerView.snp.makeConstraints {
             $0.top.width.equalToSuperview()
         }
         
-        mainStickyHeaderView.snp.makeConstraints {
+        myPageLibraryView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
-            $0.width.equalToSuperview()
-            $0.height.equalTo(47)
+            $0.width.bottom.equalToSuperview()
         }
-        
-        scrolledStickyHeaderView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
-            $0.width.equalToSuperview()
-            $0.height.equalTo(47)
-        }
-        
-        [myPageLibraryView, myPageFeedView].forEach { view in
-            view.snp.makeConstraints {
-                $0.top.equalTo(headerView.snp.bottom).offset(47)
-                $0.width.equalToSuperview()
-            }
-        }
-    }
-    
-    //MARK: - Data
-    
-    func showContentView(showLibraryView: Bool) {
-        myPageLibraryView.isHidden = !showLibraryView
-        myPageFeedView.isHidden = showLibraryView
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/MyPageView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import Kingfisher
 import SnapKit
 import Then
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
@@ -12,11 +12,15 @@ import Then
 
 final class MyPageProfileHeaderView: UIView {
     
+    //MARK: - Properties
+    
+    private let profileImageSize: CGFloat = 94
+    private let profileChangeImageSize: CGFloat = 25
+    
     //MARK: - Components
     
-    lazy var userImageChangeButton = CircularButton()
-    private let userImageView = CircularImageView()
-    private let userImageChangeButtonView = UIImageView()
+    private let userImageView = UIImageView()
+    let userImageChangeImageView = UIImageView()
     
     private let userNicknameLabel = UILabel()
     private let userIntroLabel = UILabel()
@@ -40,17 +44,18 @@ final class MyPageProfileHeaderView: UIView {
     private func setUI() {
         self.backgroundColor = .wssPrimary20
         
-        userImageChangeButtonView.do {
-            $0.image = .icPencil
+        userImageView.do {
+            $0.layer.cornerRadius = profileImageSize / 2
+            $0.clipsToBounds = true
         }
         
-        userImageChangeButton.do {
-            var configuration = UIButton.Configuration.filled()
-            configuration.baseBackgroundColor = .wssWhite
-            
-            $0.configuration = configuration
-            $0.imageView?.contentMode = .scaleAspectFit
-            
+        userImageChangeImageView.do {
+            $0.image = .icPencil
+            $0.contentMode = .center
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = profileChangeImageSize / 2
+            $0.isUserInteractionEnabled = true
+            $0.backgroundColor = .wssWhite
             $0.layer.borderWidth = 1.04
             $0.layer.borderColor = UIColor.wssGray70.cgColor
         }
@@ -69,32 +74,26 @@ final class MyPageProfileHeaderView: UIView {
     
     private func setHierarchy() {
         addSubviews(userImageView,
-                    userImageChangeButton,
+                    userImageChangeImageView,
                     userNicknameLabel,
                     userIntroLabel)
-        userImageChangeButton.addSubview(userImageChangeButtonView)
     }
     
     private func setLayout() {
         userImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(25)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(94)
+            $0.size.equalTo(profileImageSize)
         }
         
-        userImageChangeButtonView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.size.equalTo(20)
-        }
-        
-        userImageChangeButton.snp.makeConstraints {
+        userImageChangeImageView.snp.makeConstraints {
             $0.trailing.equalTo(userImageView.snp.trailing)
             $0.bottom.equalTo(userImageView.snp.bottom)
-            $0.size.equalTo(25)
+            $0.size.equalTo(profileChangeImageSize)
         }
         
         userNicknameLabel.snp.makeConstraints {
-            $0.top.equalTo(userImageChangeButton.snp.bottom).offset(20)
+            $0.top.equalTo(userImageView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
@@ -116,7 +116,7 @@ final class MyPageProfileHeaderView: UIView {
         }
         userNicknameLabel.applyWSSFont(.headline1, with: data.nickname)
         userIntroLabel.do {
-            $0.applyWSSFont(.body2, with: data.intro)
+            $0.applyWSSFont(.body2, with: data.introdution)
             $0.textAlignment = .center
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/MyPageProfileHeaderView.swift
@@ -109,10 +109,10 @@ final class MyPageProfileHeaderView: UIView {
     //MARK: - Data
     
     func bindData(data: MyProfileEntity) {
-        if data.avatarImage == "" {
+        if data.avatarImageURL == nil {
             userImageView.image = .imgProfile
         } else {
-            userImageView.kfSetImage(url: makeBucketImageURLString(path: data.avatarImage))
+            userImageView.kfSetImage(url: data.avatarImageURL)
         }
         userNicknameLabel.applyWSSFont(.headline1, with: data.nickname)
         userIntroLabel.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageCountView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageCountView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageCountView: UIView {
+final class UserPageCountView: UIView {
     
     //MARK: - Properties
     
@@ -18,7 +18,7 @@ final class MyPageCountView: UIView {
     
     //MARK: - Components
     
-    var countLabel = UILabel()
+    private var countLabel = UILabel()
     private let countLimitLabel = UILabel()
     
     // MARK: - Life Cycle
@@ -66,5 +66,9 @@ final class MyPageCountView: UIView {
             $0.top.leading.bottom.equalToSuperview()
             $0.trailing.equalTo(countLimitLabel.snp.leading)
         }
+    }
+    
+    func bindData(text: String) {
+        countLabel.applyWSSFont(.body4, with: String(text.count))
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageFeedEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageFeedEmptyView.swift
@@ -16,7 +16,7 @@ final class UserPageFeedEmptyView: UIView {
     //MARK: - Components
     
     private let isEmptyImageView = UIImageView()
-    let isEmptyDescriptionLabel = UILabel()
+    private let isEmptyDescriptionLabel = UILabel()
     
     // MARK: - Life Cycle
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageFeedEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageFeedEmptyView.swift
@@ -1,8 +1,8 @@
 //
-//  MyPagePrivateView.swift
+//  MyPageFeedEmptyView.swift
 //  WSSiOS
 //
-//  Created by 신지원 on 11/29/24.
+//  Created by 신지원 on 12/1/24.
 //
 
 import UIKit
@@ -10,12 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPagePrivateView: UIView {
+
+final class UserPageFeedEmptyView: UIView {
     
     //MARK: - Components
     
-    private let isPrivateImageView = UIImageView()
-    let isPrivateDescriptionLabel = UILabel()
+    private let isEmptyImageView = UIImageView()
+    let isEmptyDescriptionLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -36,34 +37,36 @@ final class MyPagePrivateView: UIView {
     private func setUI() {
         self.backgroundColor = .wssWhite
         
-        isPrivateImageView.do {
-            $0.image = .imgEmptyCatLocked
+        isEmptyImageView.do {
+            $0.image = .imgFeedEmptyCat
             $0.contentMode = .scaleAspectFit
         }
         
-        isPrivateDescriptionLabel.do {
+        isEmptyDescriptionLabel.do {
+            $0.applyWSSFont(.body2, with: StringLiterals.MyPage.Profile.emptyFeed)
+            $0.numberOfLines = 1
             $0.textColor = .wssGray200
-            $0.numberOfLines = 2
         }
     }
     
     private func setHierarchy() {
-        self.addSubviews(isPrivateImageView,
-                         isPrivateDescriptionLabel)
+        self.addSubviews(isEmptyImageView,
+                         isEmptyDescriptionLabel)
     }
     
     private func setLayout() {
-        isPrivateImageView.snp.makeConstraints {
+        isEmptyImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(58)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(166)
             $0.height.equalTo(160)
         }
         
-        isPrivateDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(isPrivateImageView.snp.bottom).offset(20)
+        isEmptyDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(isEmptyImageView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview().inset(70)
         }
     }
 }
+

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesOtherView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesOtherView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageGenrePreferencesOtherView.swift
+//  UserPageGenrePreferencesOtherView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageGenrePreferencesOtherView: UIView {
+final class UserPageGenrePreferencesOtherView: UIView {
 
     //MARK: - Components
 
@@ -54,7 +54,3 @@ final class MyPageGenrePreferencesOtherView: UIView {
         }
     }
 }
-
-
-
-

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesTopView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesTopView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageGenrePreferencesTopView.swift
+//  UserPageGenrePreferencesTopView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,14 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageGenrePreferencesTopView: UIView {
+final class UserPageGenrePreferencesTopView: UIView {
     
     //MARK: - Components
     
-    let topGenreImageView = UIImageView()
-    let topGenreTitleLabel = UILabel()
-    let topGenreCountLabel = UILabel()
-    
+    private let topGenreImageView = UIImageView()
+    private let topGenreTitleLabel = UILabel()
+    private let topGenreCountLabel = UILabel()
     
     // MARK: - Life Cycle
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageGenrePreferencesView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageGenrePreferencesView.swift
+//  UserPageGenrePreferencesView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageGenrePreferencesView: UIView {
+final class UserPageGenrePreferencesView: UIView {
     
     //MARK: - Components
     
@@ -18,13 +18,13 @@ final class MyPageGenrePreferencesView: UIView {
     private let titleLabel = UILabel()
     
     private let topView = UIView()
-    private let firstTopGenreView = MyPageGenrePreferencesTopView()
-    private let secondTopGenreView = MyPageGenrePreferencesTopView()
-    private let thirdTopGenreView = MyPageGenrePreferencesTopView()
+    private let firstTopGenreView = UserPageGenrePreferencesTopView()
+    private let secondTopGenreView = UserPageGenrePreferencesTopView()
+    private let thirdTopGenreView = UserPageGenrePreferencesTopView()
     
-    let myPageGenreOpenButton = UIButton()
-    let otherGenreView = MyPageGenrePreferencesOtherView()
-    let myPageGenreCloseButton = UIButton()
+    let userPageGenreOpenButton = UIButton()
+    let userPageOtherGenreView = UserPageGenrePreferencesOtherView()
+    let userPageGenreCloseButton = UIButton()
     
     // MARK: - Life Cycle
     
@@ -57,14 +57,14 @@ final class MyPageGenrePreferencesView: UIView {
             $0.distribution = .fill
         }
         
-        myPageGenreOpenButton.do {
+        userPageGenreOpenButton.do {
             $0.backgroundColor = .wssWhite
             $0.setImage(.icChevronDown, for: .normal)
         }
         
-        otherGenreView.isHidden = true
+        userPageOtherGenreView.isHidden = true
         
-        myPageGenreCloseButton.do {
+        userPageGenreCloseButton.do {
             $0.backgroundColor = .wssWhite
             $0.setImage(.icChevronUp, for: .normal)
         }
@@ -74,9 +74,9 @@ final class MyPageGenrePreferencesView: UIView {
         self.addSubviews(titleLabel,
                          genreStackView)
         genreStackView.addArrangedSubviews(topView,
-                                           myPageGenreOpenButton,
-                                           otherGenreView,
-                                           myPageGenreCloseButton)
+                                           userPageGenreOpenButton,
+                                           userPageOtherGenreView,
+                                           userPageGenreCloseButton)
         topView.addSubviews(firstTopGenreView,
                             secondTopGenreView,
                             thirdTopGenreView)
@@ -119,36 +119,36 @@ final class MyPageGenrePreferencesView: UIView {
             $0.width.equalTo((UIScreen.main.bounds.width-42)/3)
         }
         
-        myPageGenreOpenButton.snp.makeConstraints {
+        userPageGenreOpenButton.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
-        otherGenreView.snp.makeConstraints {
+        userPageOtherGenreView.snp.makeConstraints {
             $0.height.equalTo(0)
         }
         
-        myPageGenreOpenButton.snp.makeConstraints {
+        userPageGenreOpenButton.snp.makeConstraints {
             $0.height.equalTo(0)
         }
     }
     
     func updateView(showOtherGenreView: Bool) {
-        myPageGenreOpenButton.isHidden = showOtherGenreView
-        otherGenreView.isHidden = !showOtherGenreView
-        myPageGenreCloseButton.isHidden = !showOtherGenreView
+        userPageGenreOpenButton.isHidden = showOtherGenreView
+        userPageOtherGenreView.isHidden = !showOtherGenreView
+        userPageGenreCloseButton.isHidden = !showOtherGenreView
         
         genreStackView.setCustomSpacing(showOtherGenreView ? 32 : 0, after: topView)
-        genreStackView.setCustomSpacing(showOtherGenreView ? 20 : 0, after: otherGenreView)
+        genreStackView.setCustomSpacing(showOtherGenreView ? 20 : 0, after: userPageOtherGenreView)
         
-        myPageGenreOpenButton.snp.updateConstraints {
+        userPageGenreOpenButton.snp.updateConstraints {
             $0.height.equalTo(showOtherGenreView ? 0 : 44)
         }
         
-        otherGenreView.snp.updateConstraints {
+        userPageOtherGenreView.snp.updateConstraints {
             $0.height.equalTo(showOtherGenreView ? 250 : 0)
         }
         
-        myPageGenreCloseButton.snp.updateConstraints {
+        userPageGenreCloseButton.snp.updateConstraints {
             $0.height.equalTo(showOtherGenreView ? 44 : 0)
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageInventoryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageInventoryView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageInventoryView.swift
+//  UserPageInventoryView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageInventoryView: UIView {
+final class UserPageInventoryView: UIView {
     
     //MARK: - Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageNovelPreferencesView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageNovelPreferencesView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageNovelPreferencesView.swift
+//  UserPageNovelPreferencesView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageNovelPreferencesView: UIView {
+final class UserPageNovelPreferencesView: UIView {
     
     //MARK: - Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPagePreferencesEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPagePreferencesEmptyView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPagePreferencesEmptyView.swift
+//  UserPagePreferencesEmptyView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPagePreferencesEmptyView: UIView {
+final class UserPagePreferencesEmptyView: UIView {
 
     //MARK: - Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPagePrivateView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPagePrivateView.swift
@@ -1,8 +1,8 @@
 //
-//  MyPageFeedEmptyView.swift
+//  MyPagePrivateView.swift
 //  WSSiOS
 //
-//  Created by 신지원 on 12/1/24.
+//  Created by 신지원 on 11/29/24.
 //
 
 import UIKit
@@ -10,13 +10,12 @@ import UIKit
 import SnapKit
 import Then
 
-
-final class MyPageFeedEmptyView: UIView {
+final class UserPagePrivateView: UIView {
     
     //MARK: - Components
     
-    private let isEmptyImageView = UIImageView()
-    let isEmptyDescriptionLabel = UILabel()
+    private let isPrivateImageView = UIImageView()
+    private var isPrivateDescriptionLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -37,36 +36,41 @@ final class MyPageFeedEmptyView: UIView {
     private func setUI() {
         self.backgroundColor = .wssWhite
         
-        isEmptyImageView.do {
-            $0.image = .imgFeedEmptyCat
+        isPrivateImageView.do {
+            $0.image = .imgEmptyCatLocked
             $0.contentMode = .scaleAspectFit
         }
         
-        isEmptyDescriptionLabel.do {
-            $0.applyWSSFont(.body2, with: StringLiterals.MyPage.Profile.emptyFeed)
-            $0.numberOfLines = 1
+        isPrivateDescriptionLabel.do {
             $0.textColor = .wssGray200
+            $0.textAlignment = .center
+            $0.numberOfLines = 2
         }
     }
     
     private func setHierarchy() {
-        self.addSubviews(isEmptyImageView,
-                         isEmptyDescriptionLabel)
+        self.addSubviews(isPrivateImageView,
+                         isPrivateDescriptionLabel)
     }
     
     private func setLayout() {
-        isEmptyImageView.snp.makeConstraints {
+        isPrivateImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(58)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(166)
             $0.height.equalTo(160)
         }
         
-        isEmptyDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(isEmptyImageView.snp.bottom).offset(20)
+        isPrivateDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(isPrivateImageView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview().inset(70)
         }
     }
+    
+    func bindData(nickname: String) {
+        isPrivateDescriptionLabel.do {
+            $0.applyWSSFont(.body2, with: nickname)
+        }
+    }
 }
-

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
@@ -10,27 +10,15 @@ import UIKit
 import SnapKit
 import Then
 
-class CircularImageView: UIImageView {
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        self.layer.cornerRadius = self.bounds.width / 2
-        self.clipsToBounds = true
-    }
-}
-
-class CircularButton: UIButton {
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        self.layer.cornerRadius = self.bounds.width / 2
-        self.clipsToBounds = true
-    }
-}
-
 final class UserPageProfileHeaderView: UIView {
+    
+    //MARK: - Properties
+    
+    private let profileImageSize: CGFloat = 94
     
     //MARK: - Components
     
-    private let userImageView = CircularImageView()
+    private let userImageView = UIImageView()
     private let userNicknameLabel = UILabel()
     private let userIntroLabel = UILabel()
     
@@ -52,6 +40,11 @@ final class UserPageProfileHeaderView: UIView {
     
     private func setUI() {
         self.backgroundColor = .wssPrimary20
+        
+        userImageView.do {
+            $0.layer.cornerRadius = profileImageSize / 2
+            $0.clipsToBounds = true
+        }
         
         userNicknameLabel.do {
             $0.textColor = .wssBlack
@@ -75,7 +68,7 @@ final class UserPageProfileHeaderView: UIView {
         userImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(25)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(94)
+            $0.size.equalTo(profileImageSize)
         }
         
         userNicknameLabel.snp.makeConstraints {
@@ -94,7 +87,11 @@ final class UserPageProfileHeaderView: UIView {
     //MARK: - Data
     
     func bindData(data: UserProfileEntity) {
-        userImageView.kfSetImage(url: data.avatarImageURL)
+        if data.avatarImageURL == nil {
+            userImageView.image = .imgProfile
+        } else {
+            userImageView.kfSetImage(url: data.avatarImageURL)
+        }
         userNicknameLabel.applyWSSFont(.headline1, with: data.nickname)
         userIntroLabel.do {
             $0.applyWSSFont(.body2, with: data.intro)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
@@ -1,8 +1,8 @@
 //
-//  MyPageProfileHeaderView.swift
+//  UserPageProfileHeaderView.swift
 //  WSSiOS
 //
-//  Created by 신지원 on 5/29/24.
+//  Created by 신지원 on 5/20/25.
 //
 
 import UIKit
@@ -10,14 +10,27 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageProfileHeaderView: UIView {
+class CircularImageView: UIImageView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.bounds.width / 2
+        self.clipsToBounds = true
+    }
+}
+
+class CircularButton: UIButton {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.bounds.width / 2
+        self.clipsToBounds = true
+    }
+}
+
+final class UserPageProfileHeaderView: UIView {
     
     //MARK: - Components
     
-    lazy var userImageChangeButton = CircularButton()
     private let userImageView = CircularImageView()
-    private let userImageChangeButtonView = UIImageView()
-    
     private let userNicknameLabel = UILabel()
     private let userIntroLabel = UILabel()
     
@@ -40,21 +53,6 @@ final class MyPageProfileHeaderView: UIView {
     private func setUI() {
         self.backgroundColor = .wssPrimary20
         
-        userImageChangeButtonView.do {
-            $0.image = .icPencil
-        }
-        
-        userImageChangeButton.do {
-            var configuration = UIButton.Configuration.filled()
-            configuration.baseBackgroundColor = .wssWhite
-            
-            $0.configuration = configuration
-            $0.imageView?.contentMode = .scaleAspectFit
-            
-            $0.layer.borderWidth = 1.04
-            $0.layer.borderColor = UIColor.wssGray70.cgColor
-        }
-        
         userNicknameLabel.do {
             $0.textColor = .wssBlack
             $0.numberOfLines = 1
@@ -69,10 +67,8 @@ final class MyPageProfileHeaderView: UIView {
     
     private func setHierarchy() {
         addSubviews(userImageView,
-                    userImageChangeButton,
                     userNicknameLabel,
                     userIntroLabel)
-        userImageChangeButton.addSubview(userImageChangeButtonView)
     }
     
     private func setLayout() {
@@ -82,19 +78,8 @@ final class MyPageProfileHeaderView: UIView {
             $0.size.equalTo(94)
         }
         
-        userImageChangeButtonView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.size.equalTo(20)
-        }
-        
-        userImageChangeButton.snp.makeConstraints {
-            $0.trailing.equalTo(userImageView.snp.trailing)
-            $0.bottom.equalTo(userImageView.snp.bottom)
-            $0.size.equalTo(25)
-        }
-        
         userNicknameLabel.snp.makeConstraints {
-            $0.top.equalTo(userImageChangeButton.snp.bottom).offset(20)
+            $0.top.equalTo(userImageView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
         }
         
@@ -108,12 +93,8 @@ final class MyPageProfileHeaderView: UIView {
     
     //MARK: - Data
     
-    func bindData(data: MyProfileEntity) {
-        if data.avatarImage == "" {
-            userImageView.image = .imgProfile
-        } else {
-            userImageView.kfSetImage(url: makeBucketImageURLString(path: data.avatarImage))
-        }
+    func bindData(data: OtherProfileEntity) {
+        userImageView.kfSetImage(url: data.avatarImageURL)
         userNicknameLabel.applyWSSFont(.headline1, with: data.nickname)
         userIntroLabel.do {
             $0.applyWSSFont(.body2, with: data.intro)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileAssistantView/UserPageProfileHeaderView.swift
@@ -93,7 +93,7 @@ final class UserPageProfileHeaderView: UIView {
     
     //MARK: - Data
     
-    func bindData(data: OtherProfileEntity) {
+    func bindData(data: UserProfileEntity) {
         userImageView.kfSetImage(url: data.avatarImageURL)
         userNicknameLabel.applyWSSFont(.headline1, with: data.nickname)
         userIntroLabel.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/MyPageEditAvatarCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/MyPageEditAvatarCollectionViewCell.swift
@@ -50,9 +50,13 @@ final class MyPageEditAvatarCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Data
     
-    func bindData(avatarImage: String, isRepresentative: Bool) {
+    func bindData(avatarImageURL: URL?, isRepresentative: Bool) {
         avatarImageView.do {
-            $0.kfSetImage(url: makeBucketImageURLString(path: avatarImage))
+            if avatarImageURL == nil {
+                $0.image = .imgProfile
+            } else {
+                $0.kfSetImage(url: avatarImageURL)
+            }
             
             if (isRepresentative) {
                 $0.layer.borderColor = UIColor.wssPrimary100.cgColor

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageGenrePreferencesOtherTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageGenrePreferencesOtherTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageGenrePreferencesOtherTableViewCell.swift
+//  UserPageGenrePreferencesOtherTableViewCell.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageGenrePreferencesOtherTableViewCell: UITableViewCell {
+final class UserPageGenrePreferencesOtherTableViewCell: UITableViewCell {
 
     //MARK: - Components
     
@@ -36,7 +36,6 @@ final class MyPageGenrePreferencesOtherTableViewCell: UITableViewCell {
     
     private func setUI() {
         genreLabel.textColor = .wssBlack
-        
         countLabel.textColor = .wssGray200
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageNovelPreferencesCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageNovelPreferencesCollectionViewCell.swift
@@ -43,7 +43,7 @@ final class UserPageNovelPreferencesCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func bindData(data: KeywordResponse) {
+    func bindData(data: KeywordEntity) {
         keywordLabel.setText("\(data.keywordName) \(data.keywordCount)")
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageNovelPreferencesCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/ProfileCell/UserPageNovelPreferencesCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageNovelPreferencesCollectionViewCell.swift
+//  UserPageNovelPreferencesCollectionViewCell.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageNovelPreferencesCollectionViewCell: UICollectionViewCell {
+final class UserPageNovelPreferencesCollectionViewCell: UICollectionViewCell {
     
     //MARK: - UI Components
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageFeedDetailView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageFeedDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageFeedDetailView.swift
+//  UserPageFeedDetailView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 12/3/24.
@@ -10,11 +10,11 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageFeedDetailView: UIView {
+final class UserPageFeedDetailView: UIView {
     
     //MARK: - Components
     
-    let myPageFeedDetailTableView = UITableView(frame: .zero, style: .plain)
+    let userPageFeedDetailTableView = UITableView(frame: .zero, style: .plain)
     
     //In VC
     let backButton = UIButton()
@@ -36,7 +36,7 @@ final class MyPageFeedDetailView: UIView {
     //MARK: - UI
     
     private func setUI() {
-        myPageFeedDetailTableView.do {
+        userPageFeedDetailTableView.do {
             $0.separatorStyle = .none
         }
         
@@ -46,11 +46,11 @@ final class MyPageFeedDetailView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubview(myPageFeedDetailTableView)
+        self.addSubview(userPageFeedDetailTableView)
     }
     
     private func setLayout() {
-        myPageFeedDetailTableView.snp.makeConstraints() {
+        userPageFeedDetailTableView.snp.makeConstraints() {
             $0.edges.equalToSuperview()
         }
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageFeedView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageFeedView.swift
@@ -10,23 +10,21 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageFeedView: UIView {
-    
-    // MARK: - Properties
-    
+final class UserPageFeedView: UIView {
+
     // MARK: - Components
     
-    let stackView = UIStackView()
+    private let stackView = UIStackView()
     
-    let myPageFeedTableView = FeedListView()
+    let userPageFeedTableView = FeedListView()
     
     private let showMoreActivityButtonView = UIView()
-    let myPageFeedDetailButton = UIButton()
-    let myPageFeedDetailButtonLabel = UILabel()
+    let userPageFeedDetailButton = UIButton()
+    private let userPageFeedDetailButtonLabel = UILabel()
     private let paddingViewAfterButton = UIView()
     
-    private let myPagePrivateView = MyPagePrivateView()
-    private let myPageFeedEmptyView = MyPageFeedEmptyView()
+    private let userPagePrivateView = UserPagePrivateView()
+    private let userPageFeedEmptyView = UserPageFeedEmptyView()
     
     // MARK: - Life Cycle
     
@@ -49,12 +47,12 @@ final class MyPageFeedView: UIView {
             $0.axis = .vertical
         }
         
-        myPageFeedDetailButton.do {
+        userPageFeedDetailButton.do {
             $0.layer.cornerRadius = 8
             $0.layer.borderColor = UIColor.wssPrimary100.cgColor
             $0.layer.borderWidth = 1
             
-            myPageFeedDetailButtonLabel.do {
+            userPageFeedDetailButtonLabel.do {
                 $0.applyWSSFont(.title2, with: StringLiterals.MyPage.Profile.activityButton)
                 $0.textColor = .wssPrimary100
             }
@@ -64,19 +62,19 @@ final class MyPageFeedView: UIView {
             $0.backgroundColor = .wssWhite
         }
         
-        myPagePrivateView.isHidden = true
-        myPageFeedEmptyView.isHidden = true
+        userPagePrivateView.isHidden = true
+        userPageFeedEmptyView.isHidden = true
     }
     
     private func setHierarchy() {
         self.addSubview(stackView)
-        stackView.addArrangedSubviews(myPageFeedTableView,
+        stackView.addArrangedSubviews(userPageFeedTableView,
                                       showMoreActivityButtonView,
                                       paddingViewAfterButton,
-                                      myPagePrivateView,
-                                      myPageFeedEmptyView)
-        showMoreActivityButtonView.addSubview(myPageFeedDetailButton)
-        myPageFeedDetailButton.addSubview(myPageFeedDetailButtonLabel)
+                                      userPagePrivateView,
+                                      userPageFeedEmptyView)
+        showMoreActivityButtonView.addSubview(userPageFeedDetailButton)
+        userPageFeedDetailButton.addSubview(userPageFeedDetailButtonLabel)
     }
     
     private func setLayout() {
@@ -84,14 +82,14 @@ final class MyPageFeedView: UIView {
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
         
-        myPageFeedDetailButton.snp.makeConstraints {
+        userPageFeedDetailButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(28)
             $0.bottom.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(48)
         }
         
-        myPageFeedDetailButtonLabel.snp.makeConstraints {
+        userPageFeedDetailButtonLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
         
@@ -100,11 +98,11 @@ final class MyPageFeedView: UIView {
             $0.height.equalTo(40)
         }
         
-        myPagePrivateView.snp.makeConstraints {
+        userPagePrivateView.snp.makeConstraints {
             $0.height.equalTo(450)
         }
         
-        myPageFeedEmptyView.snp.makeConstraints {
+        userPageFeedEmptyView.snp.makeConstraints {
             $0.height.equalTo(450)
         }
     }
@@ -113,31 +111,27 @@ final class MyPageFeedView: UIView {
     
     func isPrivateUserView(isPrivate: Bool, nickname: String) {
         if isPrivate {
-            myPagePrivateView.isHidden = false
+            userPagePrivateView.isHidden = false
             
-            [myPageFeedTableView,
+            [userPageFeedTableView,
              showMoreActivityButtonView,
              paddingViewAfterButton,
-             myPageFeedEmptyView].forEach { view in
+             userPageFeedEmptyView].forEach { view in
                 view.do {
                     $0.isHidden = true
                 }
             }
             
             let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-            myPagePrivateView.isPrivateDescriptionLabel.do {
-                $0.applyWSSFont(.body2, with: text)
-                $0.textAlignment = .center
-            }
-            
+            userPagePrivateView.bindData(nickname: text)
         }
     }
     
     
     func isEmptyView(isEmpty: Bool) {
-        myPageFeedEmptyView.isHidden = !isEmpty
+        userPageFeedEmptyView.isHidden = !isEmpty
         
-        [myPageFeedTableView,
+        [userPageFeedTableView,
          showMoreActivityButtonView,
          paddingViewAfterButton].forEach { view in
             view.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageLibraryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageLibraryView.swift
@@ -125,16 +125,14 @@ final class UserPageLibraryView: UIView {
     }
     
     func updatePreferencesEmptyView(isEmpty: Bool) {
-        if isEmpty {
-            [genrePrefrerencesView,
-             secondDividerView,
-             novelPrefrerencesView] .forEach { view in
-                view.do {
-                    $0.isHidden = true
-                }
+        [genrePrefrerencesView,
+         secondDividerView,
+         novelPrefrerencesView] .forEach { view in
+            view.do {
+                $0.isHidden = isEmpty
             }
             
-            preferencesEmptyView.isHidden  = false
+            preferencesEmptyView.isHidden = !isEmpty
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageLibraryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageLibraryView.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageLibraryView.swift
+//  UserPageLibraryView.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 11/16/24.
@@ -10,18 +10,17 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageLibraryView: UIView {
-    
+final class UserPageLibraryView: UIView {
     
     // MARK: - Components
     
     let stackView = UIStackView()
-    let inventoryView = MyPageInventoryView()
-    let genrePrefrerencesView = MyPageGenrePreferencesView()
-    let novelPrefrerencesView = MyPageNovelPreferencesView()
+    let inventoryView = UserPageInventoryView()
+    let genrePrefrerencesView = UserPageGenrePreferencesView()
+    let novelPrefrerencesView = UserPageNovelPreferencesView()
     
-    private let preferencesEmptyView = MyPagePreferencesEmptyView()
-    private let myPagePrivateView = MyPagePrivateView()
+    private let preferencesEmptyView = UserPagePreferencesEmptyView()
+    private let userPagePrivateView = UserPagePrivateView()
     
     private let firstDividerView = UIView()
     private let secondDividerView = UIView()
@@ -53,7 +52,7 @@ final class MyPageLibraryView: UIView {
             $0.backgroundColor = .wssGray50
         }
         
-        myPagePrivateView.isHidden = true
+        userPagePrivateView.isHidden = true
         preferencesEmptyView.isHidden = true
     }
     
@@ -64,7 +63,7 @@ final class MyPageLibraryView: UIView {
                                       genrePrefrerencesView,
                                       secondDividerView,
                                       novelPrefrerencesView,
-                                      myPagePrivateView,
+                                      userPagePrivateView,
                                       preferencesEmptyView)
     }
     
@@ -88,7 +87,7 @@ final class MyPageLibraryView: UIView {
             }
         }
         
-        myPagePrivateView.snp.makeConstraints {
+        userPagePrivateView.snp.makeConstraints {
             $0.height.equalTo(450)
         }
         
@@ -118,13 +117,10 @@ final class MyPageLibraryView: UIView {
                 }
             }
             
-            myPagePrivateView.isHidden = false
+            userPagePrivateView.isHidden = false
             
             let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-            myPagePrivateView.isPrivateDescriptionLabel.do {
-                $0.applyWSSFont(.body2, with: text)
-                $0.textAlignment = .center
-            }
+            userPagePrivateView.bindData(nickname: text)
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageStickyHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageStickyHeaderView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyPageStickyHeaderView: UIView {
+final class UserPageStickyHeaderView: UIView {
     
     // MARK: - Components
     
@@ -49,6 +49,7 @@ final class MyPageStickyHeaderView: UIView {
             
             libraryButtonLabel.do {
                 $0.textColor = .wssBlack
+                $0.applyWSSFont(.body2, with: StringLiterals.MyPage.Profile.otherProfileLibrary)
             }
         }
         
@@ -56,7 +57,10 @@ final class MyPageStickyHeaderView: UIView {
             $0.backgroundColor = .wssWhite
             $0.isSelected = false
             
-            feedButtonLabel.textColor = .wssBlack
+            feedButtonLabel.do {
+                $0.textColor = .wssBlack
+                $0.applyWSSFont(.body2, with: StringLiterals.MyPage.Profile.otherProfileFeed)
+            }
         }
         
         libraryUnderView.do {
@@ -127,10 +131,5 @@ final class MyPageStickyHeaderView: UIView {
         
         libraryUnderView.isHidden = !isLibrarySelected
         feedUnderView.isHidden = isLibrarySelected
-    }
-    
-    func buttonLabelText(isMyPage: Bool) {
-        libraryButtonLabel.applyWSSFont(.body2, with: isMyPage ? StringLiterals.MyPage.Profile.myProfileLibrary : StringLiterals.MyPage.Profile.otherProfileLibrary)
-        feedButtonLabel.applyWSSFont(.body2, with: isMyPage ? StringLiterals.MyPage.Profile.myProfileFeed : StringLiterals.MyPage.Profile.otherProfileFeed)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import Kingfisher
 import SnapKit
 import Then
 

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileView/UserPageView.swift
@@ -1,0 +1,118 @@
+//
+//  UserPageView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/8/24.
+//
+
+import UIKit
+
+import Kingfisher
+import SnapKit
+import Then
+
+final class UserPageView: UIView {
+    
+    //MARK: - Components
+    
+    let scrollView = UIScrollView()
+    let contentView = UIView()
+    
+    let headerView = UserPageProfileHeaderView()
+    let mainStickyHeaderView = UserPageStickyHeaderView()
+    let scrolledStickyHeaderView = UserPageStickyHeaderView()
+    
+    let userPageLibraryView = UserPageLibraryView()
+    let userPageFeedView = UserPageFeedView()
+    
+    //In VC
+    let backButton = UIButton()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - UI
+    
+    private func setUI() {
+        self.backgroundColor = .wssPrimary20
+        
+        scrollView.do {
+            $0.backgroundColor = .wssWhite
+            $0.contentInsetAdjustmentBehavior = .never
+            $0.showsVerticalScrollIndicator = false
+        }
+        
+        scrolledStickyHeaderView.do {
+            $0.isHidden = true
+        }
+        
+        userPageFeedView.isHidden = true
+        
+        backButton.do {
+            $0.setImage(.icNavigateLeft.withRenderingMode(.alwaysOriginal).withTintColor(.wssGray300), for: .normal)
+        }
+    }
+    
+    private func setHierarchy() {
+        addSubviews(scrollView,
+                    scrolledStickyHeaderView)
+        
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(headerView,
+                                mainStickyHeaderView,
+                                userPageLibraryView,
+                                userPageFeedView)
+    }
+    
+    private func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.left.right.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        headerView.snp.makeConstraints {
+            $0.top.width.equalToSuperview()
+        }
+        
+        mainStickyHeaderView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom)
+            $0.width.equalToSuperview()
+            $0.height.equalTo(47)
+        }
+        
+        scrolledStickyHeaderView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.width.equalToSuperview()
+            $0.height.equalTo(47)
+        }
+        
+        [userPageLibraryView, userPageFeedView].forEach { view in
+            view.snp.makeConstraints {
+                $0.top.equalTo(headerView.snp.bottom).offset(47)
+                $0.width.equalToSuperview()
+            }
+        }
+    }
+    
+    //MARK: - Data
+    
+    func showContentView(showLibraryView: Bool) {
+        userPageLibraryView.isHidden = !showLibraryView
+        userPageFeedView.isHidden = showLibraryView
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditAvatarViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditAvatarViewController.swift
@@ -63,7 +63,7 @@ final class MyPageEditAvatarViewController: UIViewController {
                 cellIdentifier: MyPageEditAvatarCollectionViewCell.cellIdentifier,
                 cellType: MyPageEditAvatarCollectionViewCell.self)) { (row, data, cell) in
                     let (avatarImage, isRepresentive) = data
-                    cell.bindData(avatarImage: avatarImage, isRepresentative: isRepresentive)
+                    cell.bindData(avatarImageURL: avatarImage, isRepresentative: isRepresentive)
                 }
                 .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditAvatarViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditAvatarViewController.swift
@@ -43,14 +43,12 @@ final class MyPageEditAvatarViewController: UIViewController {
         bindViewModel()
     }
     
-    //MARK: - Delegate
+    //MARK: - Bind
     
     private func register() {
         self.rootView.avatarImageCollectionView
             .register(MyPageEditAvatarCollectionViewCell.self, forCellWithReuseIdentifier: MyPageEditAvatarCollectionViewCell.cellIdentifier)
     }
-    
-    //MARK: - Bind
     
     private func bindViewModel() {
         let input = MyPageEditAvatarViewModel.Input(

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
@@ -76,7 +76,7 @@ final class MyPageEditProfileViewController: UIViewController {
             backButtonDidTap: rootView.backButton.rx.tap,
             completeButtonDidTap: rootView.completeButton.rx.tap,
             profileViewDidTap: rootView.userImageChangeImageView.rx.tapGesture().when(.recognized).asObservable(),
-            avatarImageNotification: NotificationCenter.default.rx.notification(Notification.Name("ChangRepresentativeAvatar")).asObservable(),
+            avatarImageNotification: NotificationCenter.default.rx.notification(NotificationName.changeRepresentativeAvatar).asObservable(),
             updateNicknameText: rootView.nicknameTextField.rx.text.orEmpty.distinctUntilChanged(),
             textFieldBeginEditing: rootView.nicknameTextField.rx.controlEvent(.editingDidBegin),
             clearButtonDidTap: rootView.nicknameClearButton.rx.tap,

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
@@ -75,7 +75,7 @@ final class MyPageEditProfileViewController: UIViewController {
         let input = MyPageEditProfileViewModel.Input(
             backButtonDidTap: rootView.backButton.rx.tap,
             completeButtonDidTap: rootView.completeButton.rx.tap,
-            profileViewDidTap: rootView.userImageChangeInnerButton.rx.tap,
+            profileViewDidTap: rootView.userImageChangeImageView.rx.tapGesture().when(.recognized).asObservable(),
             avatarImageNotification: NotificationCenter.default.rx.notification(Notification.Name("ChangRepresentativeAvatar")).asObservable(),
             updateNicknameText: rootView.nicknameTextField.rx.text.orEmpty.distinctUntilChanged(),
             textFieldBeginEditing: rootView.nicknameTextField.rx.controlEvent(.editingDidBegin),

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageEditProfileViewController.swift
@@ -51,8 +51,8 @@ final class MyPageEditProfileViewController: UIViewController {
         hideTabBar()
         swipeBackGesture()
         setWSSNavigationBar(title: StringLiterals.Navigation.Title.editProfile,
-                         left: self.rootView.backButton,
-                         right: self.rootView.completeButton)
+                            left: self.rootView.backButton,
+                            right: self.rootView.completeButton)
     }
     
     //MARK: - Delegate

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -113,7 +113,7 @@ final class MyPageViewController: UIViewController {
                 .when(.recognized)
                 .asObservable(),
             inventorySpecificPageViewDidTap: inventoryStatusButtonDidTap,
-            editProfileNotification: NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile")).asObservable())
+            editProfileNotification: NotificationCenter.default.rx.notification(NotificationName.editProfile).asObservable())
         
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -107,7 +107,7 @@ final class MyPageViewController: UIViewController {
             resizeKeywordCollectionViewHeight: rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.observe(CGSize.self, "contentSize"),
             scrollOffset: rootView.scrollView.rx.contentOffset.asDriver(),
             settingButtonDidTap: rootView.settingButton.rx.tap,
-            editButtonDidTap: rootView.headerView.userImageChangeButton.rx.tap,
+            editButtonDidTap: rootView.headerView.userImageChangeImageView.rx.tapGesture().when(.recognized).asObservable(),
             genrePreferenceButtonDidTap: genrePreferenceButtonDidTap,
             inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryTitleView.rx.tapGesture()
                 .when(.recognized)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -65,6 +65,8 @@ final class MyPageViewController: UIViewController {
         headerViewHeightRelay.accept(rootView.headerView.layer.frame.height)
     }
     
+    //MARK: - Bind
+    
     private func register() {
         rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.register(
             UserPageNovelPreferencesCollectionViewCell.self,
@@ -86,8 +88,6 @@ final class MyPageViewController: UIViewController {
         
         rootView.myPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView.delegate = self
     }
-    
-    //MARK: - Bind
     
     private func bindViewModel() {
         let inventoryStatusButtonDidTap = Observable<Int>.merge(
@@ -228,6 +228,8 @@ final class MyPageViewController: UIViewController {
         self.rootView.scrollView.setContentOffset(CGPoint(x: 0, y: -self.rootView.scrollView.contentInset.top), animated: true)
     }
 }
+
+//MARK: - UIScroll 관련 Delegate
 
 extension MyPageViewController: UICollectionViewDelegateFlowLayout, UIScrollViewDelegate, UITableViewDelegate {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -51,9 +51,12 @@ final class MyPageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
         self.viewWillAppearEvent.onNext(())
-        decideNavigation()
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        setWSSNavigationBar(title: StringLiterals.Navigation.Title.myPage,
+                            left: nil,
+                            right: rootView.settingButton,
+                            isVisibleBeforeScroll: false)
     }
     
     override func viewDidLayoutSubviews() {
@@ -244,18 +247,5 @@ extension MyPageViewController: UICollectionViewDelegateFlowLayout, UIScrollView
         if scrollView.contentOffset.y < 0 {
             scrollView.contentOffset.y = 0
         }
-    }
-}
-
-extension MyPageViewController {
-    
-    //MARK: - UI
-    
-    private func decideNavigation() {
-        setWSSNavigationBar(title: "마이페이지",
-                            left: nil,
-                            right: rootView.settingButton,
-                            isVisibleBeforeScroll: false)
-        
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -163,9 +163,7 @@ final class MyPageViewController: UIViewController {
         output.isExistPreferneces
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, isExist in
-                if !isExist {
-                    owner.rootView.myPageLibraryView.updatePreferencesEmptyView(isEmpty: !isExist)
-                }
+                owner.rootView.myPageLibraryView.updatePreferencesEmptyView(isEmpty: !isExist)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -196,6 +196,7 @@ final class MyPageViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: nil)
+                print("😼 서재 탭\n")
             })
             .disposed(by: disposeBag)
         
@@ -203,7 +204,7 @@ final class MyPageViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, pageIndex in
                 NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: pageIndex)
-                
+                print("😼😼특별 서재 탭\n")
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -10,26 +10,14 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-enum EntryType {
-    case tabBar
-    case otherVC
-}
-
 final class MyPageViewController: UIViewController {
     
     //MARK: - Properties
     
     private let disposeBag = DisposeBag()
     private let viewModel: MyPageViewModel
-    var entryType: EntryType = .otherVC
-    
-    private var navigationTitle: String = ""
-    
-    private let isEntryTabbarRelay = BehaviorRelay<Bool>(value: false)
-    private var dropDownCellTap = PublishSubject<String>()
-    private let headerViewHeightRelay = BehaviorRelay<Double>(value: 0)
     private let viewWillAppearEvent = PublishSubject<Void>()
-    private let feedConnectedNovelViewDidTap = PublishRelay<Int>()
+    private let headerViewHeightRelay = BehaviorRelay<Double>(value: 0)
     
     //MARK: - UI Components
     
@@ -56,22 +44,8 @@ final class MyPageViewController: UIViewController {
         
         delegate()
         register()
-        
         bindViewModel()
-        
-        switch entryType {
-        case .tabBar:
-            print("탭바에서 진입")
-            AmplitudeManager.shared.track(AmplitudeEvent.MyPage.mypage)
-            isEntryTabbarRelay.accept(true)
-            
-        case .otherVC:
-            print("다른 VC에서 진입")
-            AmplitudeManager.shared.track(AmplitudeEvent.MyPage.otherMypage)
-            isEntryTabbarRelay.accept(false)
-            hideTabBar()
-            swipeBackGesture()
-        }
+        AmplitudeManager.shared.track(AmplitudeEvent.MyPage.mypage)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -79,8 +53,7 @@ final class MyPageViewController: UIViewController {
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
         self.viewWillAppearEvent.onNext(())
-        decideNavigation(myPage: entryType == .tabBar, navigationTitle: navigationTitle)
-        swipeBackGesture()
+        decideNavigation()
     }
     
     override func viewDidLayoutSubviews() {
@@ -91,12 +64,12 @@ final class MyPageViewController: UIViewController {
     
     private func register() {
         rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.register(
-            MyPageNovelPreferencesCollectionViewCell.self,
-            forCellWithReuseIdentifier: MyPageNovelPreferencesCollectionViewCell.cellIdentifier)
+            UserPageNovelPreferencesCollectionViewCell.self,
+            forCellWithReuseIdentifier: UserPageNovelPreferencesCollectionViewCell.cellIdentifier)
         
-        rootView.myPageLibraryView.genrePrefrerencesView.otherGenreView.genreTableView.register(MyPageGenrePreferencesOtherTableViewCell.self, forCellReuseIdentifier: MyPageGenrePreferencesOtherTableViewCell.cellIdentifier)
-        
-        rootView.myPageFeedView.myPageFeedTableView.feedTableView.register(FeedListTableViewCell.self, forCellReuseIdentifier: FeedListTableViewCell.cellIdentifier)
+        rootView.myPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView
+            .register(UserPageGenrePreferencesOtherTableViewCell.self,
+                      forCellReuseIdentifier: UserPageGenrePreferencesOtherTableViewCell.cellIdentifier)
     }
     
     private func delegate() {
@@ -108,11 +81,7 @@ final class MyPageViewController: UIViewController {
             .setDelegate(self)
             .disposed(by: disposeBag)
         
-        rootView.myPageLibraryView.genrePrefrerencesView.otherGenreView.genreTableView.delegate = self
-        
-        rootView.myPageFeedView.myPageFeedTableView.feedTableView.rx
-            .setDelegate(self)
-            .disposed(by: disposeBag)
+        rootView.myPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView.delegate = self
     }
     
     //MARK: - Bind
@@ -125,76 +94,30 @@ final class MyPageViewController: UIViewController {
             })
         
         let genrePreferenceButtonDidTap = Observable.merge(
-            rootView.myPageLibraryView.genrePrefrerencesView.myPageGenreOpenButton.rx.tap.map { true },
-            rootView.myPageLibraryView.genrePrefrerencesView.myPageGenreCloseButton.rx.tap.map { false }
-        )
-        
-        let libraryButtonDidTap = Observable.merge(
-            rootView.mainStickyHeaderView.libraryButton.rx.tap.map { true },
-            rootView.scrolledStickyHeaderView.libraryButton.rx.tap.map { true }
-        )
-        
-        let feedButtonDidTap = Observable.merge(
-            rootView.mainStickyHeaderView.feedButton.rx.tap.map { true },
-            rootView.scrolledStickyHeaderView.feedButton.rx.tap.map { true }
+            rootView.myPageLibraryView.genrePrefrerencesView.userPageGenreOpenButton.rx.tap.map { true },
+            rootView.myPageLibraryView.genrePrefrerencesView.userPageGenreCloseButton.rx.tap.map { false }
         )
         
         let input = MyPageViewModel.Input(
-            isEntryTabbar: isEntryTabbarRelay.asObservable(),
             viewWillAppearEvent: self.viewWillAppearEvent,
             headerViewHeight: headerViewHeightRelay.asDriver(),
-            resizefeedTableViewHeight: rootView.myPageFeedView.myPageFeedTableView.feedTableView.rx.observe(CGSize.self, "contentSize"),
             resizeKeywordCollectionViewHeight: rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.observe(CGSize.self, "contentSize"),
             scrollOffset: rootView.scrollView.rx.contentOffset.asDriver(),
             settingButtonDidTap: rootView.settingButton.rx.tap,
-            dropdownButtonDidTap: dropDownCellTap,
             editButtonDidTap: rootView.headerView.userImageChangeButton.rx.tap,
-            backButtonDidTap: rootView.backButton.rx.tap,
             genrePreferenceButtonDidTap: genrePreferenceButtonDidTap,
-            libraryButtonDidTap: libraryButtonDidTap,
-            feedButtonDidTap: feedButtonDidTap,
             inventoryViewDidTap: rootView.myPageLibraryView.inventoryView.inventoryTitleView.rx.tapGesture()
                 .when(.recognized)
                 .asObservable(),
             inventorySpecificPageViewDidTap: inventoryStatusButtonDidTap,
-            feedDetailButtonDidTap: rootView.myPageFeedView.myPageFeedDetailButton.rx.tap,
-            editProfileNotification: NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile")).asObservable(),
-            feedTableViewItemSelected: rootView.myPageFeedView.myPageFeedTableView.feedTableView.rx.itemSelected.asObservable(),
-            feedConnectedNovelViewDidTap: feedConnectedNovelViewDidTap.asObservable())
+            editProfileNotification: NotificationCenter.default.rx.notification(NSNotification.Name("EditProfile")).asObservable())
         
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
-        
-        output.isMyPage
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, isMyPage in
-                owner.decideNavigation(myPage: isMyPage, navigationTitle: "")
-                owner.rootView.mainStickyHeaderView.buttonLabelText(isMyPage: isMyPage)
-                owner.rootView.scrolledStickyHeaderView.buttonLabelText(isMyPage: isMyPage)
-            })
-            .disposed(by: disposeBag)
         
         output.profileData
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, data in
                 owner.rootView.headerView.bindData(data: data)
-            })
-            .disposed(by: disposeBag)
-        
-        output.updateNavigationBar
-            .asDriver()
-            .drive(with: self, onNext: { owner, data in
-                let (update, navigationTitle) = data
-                owner.navigationTitle = navigationTitle
-                owner.navigationItem.title = update ? navigationTitle : ""
-            })
-            .disposed(by: disposeBag)
-        
-        output.updateStickyHeader
-            .asDriver()
-            .drive(with: self, onNext: { owner, update in
-                owner.rootView.scrolledStickyHeaderView.isHidden = !update
-                owner.rootView.mainStickyHeaderView.isHidden = update
-                owner.rootView.headerView.isHidden = update
             })
             .disposed(by: disposeBag)
         
@@ -212,35 +135,19 @@ final class MyPageViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.popViewController
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, data in
-                owner.popToLastViewController()
-            })
-            .disposed(by: disposeBag)
-        
-        output.isProfilePrivate
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, data in
-                let (isPrivate, nickname) = data
-                if isPrivate {
-                    owner.rootView.myPageLibraryView.isPrivateUserView(isPrivate: isPrivate, nickname: nickname)
-                    owner.rootView.myPageFeedView.isPrivateUserView(isPrivate: isPrivate, nickname: nickname)
-                }
-            })
-            .disposed(by: disposeBag)
-        
         output.bindGenreData
             .observe(on: MainScheduler.instance)
             .do(onNext: { [weak self] data in
                 self?.rootView.myPageLibraryView.genrePrefrerencesView.bindData(data: data)
             })
             .map { Array($0.genrePreferences.dropFirst(3)) }
-            .bind(to: rootView.myPageLibraryView.genrePrefrerencesView.otherGenreView.genreTableView.rx.items(cellIdentifier: MyPageGenrePreferencesOtherTableViewCell.cellIdentifier,cellType: MyPageGenrePreferencesOtherTableViewCell.self)) { row, data, cell in
-                cell.bindData(data: data)
-                cell.selectionStyle = .none
-            }
-            .disposed(by: disposeBag)
+            .bind(to: rootView.myPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView.rx.items(
+                cellIdentifier: UserPageGenrePreferencesOtherTableViewCell.cellIdentifier,
+                cellType: UserPageGenrePreferencesOtherTableViewCell.self)) { row, data, cell in
+                    cell.bindData(data: data)
+                    cell.selectionStyle = .none
+                }
+                .disposed(by: disposeBag)
         
         output.bindAttractivePointsData
             .observe(on: MainScheduler.instance)
@@ -261,7 +168,7 @@ final class MyPageViewController: UIViewController {
         
         output.bindKeywordCell
             .observe(on: MainScheduler.instance)
-            .bind(to: rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.items(cellIdentifier: MyPageNovelPreferencesCollectionViewCell.cellIdentifier, cellType: MyPageNovelPreferencesCollectionViewCell.self)){ row, data, cell in
+            .bind(to: rootView.myPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.items(cellIdentifier: UserPageNovelPreferencesCollectionViewCell.cellIdentifier, cellType: UserPageNovelPreferencesCollectionViewCell.self)){ row, data, cell in
                 cell.bindData(data: data)
             }
             .disposed(by: disposeBag)
@@ -282,96 +189,18 @@ final class MyPageViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.stickyHeaderAction
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, library in
-                owner.rootView.mainStickyHeaderView.updateSelection(isLibrarySelected: library)
-                owner.rootView.scrolledStickyHeaderView.updateSelection(isLibrarySelected: library)
-                
-                owner.rootView.myPageLibraryView.isHidden = !library
-                owner.rootView.myPageFeedView.isHidden = library
-                
-                owner.rootView.contentView.snp.remakeConstraints {
-                    $0.edges.equalToSuperview()
-                    $0.width.equalToSuperview()
-                    
-                    if library {
-                        $0.bottom.equalTo(owner.rootView.myPageLibraryView.snp.bottom)
-                    } else {
-                        $0.bottom.equalTo(owner.rootView.myPageFeedView.snp.bottom)
-                    }
-                }
-                
-                owner.rootView.layoutIfNeeded()
-                
-            })
-            .disposed(by: disposeBag)
-        
-        output.bindFeedData
-            .observe(on: MainScheduler.instance)
-            .bind(to: rootView.myPageFeedView.myPageFeedTableView.feedTableView.rx.items(
-                cellIdentifier: FeedListTableViewCell.cellIdentifier,
-                cellType: FeedListTableViewCell.self)) { _, element, cell in
-                    cell.bindProfileFeedData(feed: element)
-                    cell.delegate = self
-                }
-                .disposed(by: disposeBag)
-        
-        output.isEmptyFeed
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, isEmpty in
-                owner.rootView.myPageFeedView.isEmptyView(isEmpty: isEmpty)
-            })
-            .disposed(by: disposeBag)
-        
-        output.showFeedDetailButton
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, show in
-                owner.rootView.myPageFeedView.showMoreButton(isShow: show)
-            })
-            .disposed(by: disposeBag)
-        
         output.pushToLibraryViewController
-            .withLatestFrom(output.isMyPage) {
-                (userId, isMyPage) in (userId, isMyPage)
-            }
             .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, data in
-                let (userId, isMyPage) = data
-                if isMyPage {
-                    NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: nil)
-                } else {
-                    owner.pushToLibraryViewController(userId: userId)
-                }
+            .bind(with: self, onNext: { owner, _ in
+                NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: nil)
             })
             .disposed(by: disposeBag)
         
         output.pushToSpecificLibraryViewController
-            .withLatestFrom(output.isMyPage) { (userData, isMyPage) in
-               (userData.0, userData.1, isMyPage)
-            }
             .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, data in
-                let (userId, pageIndex, isMyPage) = data
-                if isMyPage {
-                    NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: pageIndex)
-                } else {
-                    owner.pushToLibraryViewController(userId: userId, pageIndex: pageIndex)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        output.updateButtonWithLibraryView
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, showLibraryView in
-                owner.rootView.showContentView(showLibraryView: showLibraryView)
-            })
-            .disposed(by: disposeBag)
-        
-        output.updateFeedTableViewHeight
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self, onNext: { owner, height in
-                owner.rootView.myPageFeedView.myPageFeedTableView.updateTableViewHeight(height: height)
+            .bind(with: self, onNext: { owner, pageIndex in
+                NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: pageIndex)
+                
             })
             .disposed(by: disposeBag)
         
@@ -382,32 +211,10 @@ final class MyPageViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.pushToMyPageFeedDetailViewController
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, userData in
-                let (id, data) = userData
-                owner.pushToMyPageFeedDetailViewController(userId: id, useData: data)
-            })
-            .disposed(by: disposeBag)
-        
         output.showToastView
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 owner.showToast(.editUserProfile)
-            })
-            .disposed(by: disposeBag)
-        
-        output.pushToNovelDetailViewController
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, novelId in
-                owner.pushToNovelDetailViewController(novelId: novelId)
-            })
-            .disposed(by: disposeBag)
-        
-        output.pushToFeedDetailViewController
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, feedId in
-                owner.pushToFeedDetailViewController(feedId: feedId)
             })
             .disposed(by: disposeBag)
     }
@@ -444,49 +251,11 @@ extension MyPageViewController {
     
     //MARK: - UI
     
-    private func decideNavigation(myPage: Bool, navigationTitle: String) {
-        if myPage {
-            setWSSNavigationBar(title: navigationTitle,
-                                left: nil,
-                                right: rootView.settingButton,
-                                isVisibleBeforeScroll: false)
-        } else {
-            let dropdownButton = WSSDropdownButton().then {
-                $0.makeDropdown(dropdownRootView: self.rootView,
-                                dropdownWidth: 120,
-                                dropdownLayout: .autoInNavigationBar,
-                                dropdownData: [StringLiterals.MyPage.BlockUser.toastText],
-                                textColor: .wssBlack)
-                .observe(on: MainScheduler.instance)
-                .bind(to: dropDownCellTap)
-                .disposed(by: disposeBag)
-            }
-            
-            setWSSNavigationBar(title: navigationTitle,
-                                left: rootView.backButton,
-                                right: dropdownButton,
-                                isVisibleBeforeScroll: false)
-        }
+    private func decideNavigation() {
+        setWSSNavigationBar(title: "마이페이지",
+                            left: nil,
+                            right: rootView.settingButton,
+                            isVisibleBeforeScroll: false)
         
-        rootView.headerView.userImageChangeButton.isHidden = !myPage
     }
 }
-
-extension MyPageViewController: FeedTableViewDelegate {
-    func profileViewDidTap(userId: Int) {
-        return
-    }
-    
-    func dropdownButtonDidTap(feedId: Int, isMyFeed: Bool) {
-        return
-    }
-    
-    func likeViewDidTap(feedId: Int, isLiked: Bool) {
-        return
-    }
-    
-    func connectedNovelViewDidTap(novelId: Int) {
-        self.feedConnectedNovelViewDidTap.accept(novelId)
-    }
-}
-

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/MyPageViewController.swift
@@ -196,7 +196,6 @@ final class MyPageViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: nil)
-                print("😼 서재 탭\n")
             })
             .disposed(by: disposeBag)
         
@@ -204,7 +203,6 @@ final class MyPageViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, pageIndex in
                 NotificationCenter.default.post(name: NotificationName.moveToLibraryTab, object: pageIndex)
-                print("😼😼특별 서재 탭\n")
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageFeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageFeedDetailViewController.swift
@@ -55,6 +55,8 @@ final class UserPageFeedDetailViewController: UIViewController, UIScrollViewDele
         swipeBackGesture()
     }
     
+    //MARK: - Bind
+    
     private func register() {
         rootView.userPageFeedDetailTableView.register(FeedListTableViewCell.self,
                                                     forCellReuseIdentifier: FeedListTableViewCell.cellIdentifier)
@@ -121,6 +123,8 @@ final class UserPageFeedDetailViewController: UIViewController, UIScrollViewDele
             .disposed(by: disposeBag)        
     }
 }
+
+//MARK: - FeedTableViewDelegate
 
 extension UserPageFeedDetailViewController: FeedTableViewDelegate {
     func profileViewDidTap(userId: Int) {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageFeedDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageFeedDetailViewController.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageFeedDetailViewController.swift
+//  UserPageFeedDetailViewController.swift
 //  WSSiOS
 //
 //  Created by 신지원 on 12/3/24.
@@ -11,21 +11,21 @@ import RxSwift
 import RxRelay
 import RxGesture
 
-final class MyPageFeedDetailViewController: UIViewController, UIScrollViewDelegate {
+final class UserPageFeedDetailViewController: UIViewController, UIScrollViewDelegate {
     
     //MARK: - Properties
     
     private let disposeBag = DisposeBag()
-    private let viewModel: MyPageFeedDetailViewModel
+    private let viewModel: UserPageFeedDetailViewModel
     private let viewWillAppearRelay = PublishRelay<Void>()
  
     //MARK: - Components
     
-    private let rootView = MyPageFeedDetailView()
+    private let rootView = UserPageFeedDetailView()
     
     // MARK: - Life Cycle
     
-    init(viewModel: MyPageFeedDetailViewModel) {
+    init(viewModel: UserPageFeedDetailViewModel) {
         
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -56,12 +56,12 @@ final class MyPageFeedDetailViewController: UIViewController, UIScrollViewDelega
     }
     
     private func register() {
-        rootView.myPageFeedDetailTableView.register(FeedListTableViewCell.self,
+        rootView.userPageFeedDetailTableView.register(FeedListTableViewCell.self,
                                                     forCellReuseIdentifier: FeedListTableViewCell.cellIdentifier)
     }
     
     private func delegate() {
-        rootView.myPageFeedDetailTableView.rx
+        rootView.userPageFeedDetailTableView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
     }
@@ -75,29 +75,29 @@ final class MyPageFeedDetailViewController: UIViewController, UIScrollViewDelega
     }
     
     private func bindViewModel() {
-        let loadNextPageTrigger = rootView.myPageFeedDetailTableView.rx.contentOffset
+        let loadNextPageTrigger = rootView.userPageFeedDetailTableView.rx.contentOffset
             .map { [weak self] contentOffset in
                 guard let self = self else { return false }
                 let offsetY = contentOffset.y
-                let contentHeight = self.rootView.myPageFeedDetailTableView.contentSize.height
-                let frameHeight = self.rootView.myPageFeedDetailTableView.frame.height
+                let contentHeight = self.rootView.userPageFeedDetailTableView.contentSize.height
+                let frameHeight = self.rootView.userPageFeedDetailTableView.frame.height
                 return offsetY + frameHeight >= contentHeight - 10
             }
             .distinctUntilChanged()
             .filter { $0 }
             .map { _ in () }
         
-        let input = MyPageFeedDetailViewModel.Input(
+        let input = UserPageFeedDetailViewModel.Input(
             loadNextPageTrigger: loadNextPageTrigger,
             viewWillAppearEvent: viewWillAppearRelay.asObservable(),
-            feedTableViewItemSelected: rootView.myPageFeedDetailTableView.rx.itemSelected
+            feedTableViewItemSelected: rootView.userPageFeedDetailTableView.rx.itemSelected
         )
         
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         
         output.bindFeedData
             .observe(on: MainScheduler.instance)
-            .bind(to: rootView.myPageFeedDetailTableView.rx.items(
+            .bind(to: rootView.userPageFeedDetailTableView.rx.items(
                 cellIdentifier: FeedListTableViewCell.cellIdentifier,
                 cellType: FeedListTableViewCell.self)) { _, element, cell in
                     cell.bindProfileFeedData(feed: element)
@@ -122,7 +122,7 @@ final class MyPageFeedDetailViewController: UIViewController, UIScrollViewDelega
     }
 }
 
-extension MyPageFeedDetailViewController: FeedTableViewDelegate {
+extension UserPageFeedDetailViewController: FeedTableViewDelegate {
     func profileViewDidTap(userId: Int) {
         return
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
@@ -51,16 +51,16 @@ final class UserPageViewController: UIViewController {
         bindViewModel()
         
         AmplitudeManager.shared.track(AmplitudeEvent.MyPage.otherMypage)
-        hideTabBar()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
         self.viewWillAppearEvent.onNext(())
-        decideNavigation(navigationTitle: navigationTitle)
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        setNavigation(userNickname: navigationTitle)
         swipeBackGesture()
+        hideTabBar()
     }
     
     override func viewDidLayoutSubviews() {
@@ -385,7 +385,7 @@ extension UserPageViewController {
     
     //MARK: - UI
     
-    private func decideNavigation(navigationTitle: String) {
+    private func setNavigation(userNickname: String) {
         let dropdownButton = WSSDropdownButton().then {
             $0.makeDropdown(dropdownRootView: self.rootView,
                             dropdownWidth: 120,
@@ -397,7 +397,7 @@ extension UserPageViewController {
             .disposed(by: disposeBag)
         }
         
-        setWSSNavigationBar(title: navigationTitle,
+        setWSSNavigationBar(title: userNickname,
                             left: rootView.backButton,
                             right: dropdownButton,
                             isVisibleBeforeScroll: false)
@@ -421,4 +421,3 @@ extension UserPageViewController: FeedTableViewDelegate {
         self.feedConnectedNovelViewDidTap.accept(novelId)
     }
 }
-

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
@@ -69,7 +69,7 @@ final class UserPageViewController: UIViewController {
         headerViewHeightRelay.accept(rootView.headerView.layer.frame.height)
     }
     
-    //MARK: - Register
+    //MARK: - Bind
     
     private func register() {
         rootView.userPageLibraryView.novelPrefrerencesView.preferencesCollectionView
@@ -100,8 +100,6 @@ final class UserPageViewController: UIViewController {
             .setDelegate(self)
             .disposed(by: disposeBag)
     }
-    
-    //MARK: - Bind
     
     private func bindViewModel() {
         let inventoryStatusButtonDidTap = Observable<Int>.merge(
@@ -360,6 +358,8 @@ final class UserPageViewController: UIViewController {
     }
 }
 
+//MARK: - UIScroll 관련 Delegate
+
 extension UserPageViewController: UICollectionViewDelegateFlowLayout, UIScrollViewDelegate, UITableViewDelegate {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let keywords = viewModel.bindKeywordRelay.value
@@ -381,10 +381,9 @@ extension UserPageViewController: UICollectionViewDelegateFlowLayout, UIScrollVi
     }
 }
 
+//MARK: - UI
+
 extension UserPageViewController {
-    
-    //MARK: - UI
-    
     private func setNavigation(userNickname: String) {
         let dropdownButton = WSSDropdownButton().then {
             $0.makeDropdown(dropdownRootView: self.rootView,
@@ -403,6 +402,8 @@ extension UserPageViewController {
                             isVisibleBeforeScroll: false)
     }
 }
+
+//MARK: - FeedTableViewDelegate
 
 extension UserPageViewController: FeedTableViewDelegate {
     func profileViewDidTap(userId: Int) {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewController/UserPageViewController.swift
@@ -1,0 +1,424 @@
+//
+//  UserPageViewController.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 5/20/25.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class UserPageViewController: UIViewController {
+    
+    //MARK: - Properties
+    
+    private let disposeBag = DisposeBag()
+    private let viewModel: UserPageViewModel
+    
+    private var navigationTitle: String = ""
+    private var dropDownCellTap = PublishSubject<String>()
+    private let headerViewHeightRelay = BehaviorRelay<Double>(value: 0)
+    private let viewWillAppearEvent = PublishSubject<Void>()
+    private let feedConnectedNovelViewDidTap = PublishRelay<Int>()
+    
+    //MARK: - UI Components
+    
+    private var rootView = UserPageView()
+    
+    // MARK: - Life Cycle
+    
+    init(viewModel: UserPageViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        delegate()
+        register()
+        bindViewModel()
+        
+        AmplitudeManager.shared.track(AmplitudeEvent.MyPage.otherMypage)
+        hideTabBar()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        self.viewWillAppearEvent.onNext(())
+        decideNavigation(navigationTitle: navigationTitle)
+        swipeBackGesture()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        headerViewHeightRelay.accept(rootView.headerView.layer.frame.height)
+    }
+    
+    //MARK: - Register
+    
+    private func register() {
+        rootView.userPageLibraryView.novelPrefrerencesView.preferencesCollectionView
+            .register(UserPageNovelPreferencesCollectionViewCell.self,
+                      forCellWithReuseIdentifier: UserPageNovelPreferencesCollectionViewCell.cellIdentifier)
+        
+        rootView.userPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView
+            .register(UserPageGenrePreferencesOtherTableViewCell.self,
+                      forCellReuseIdentifier: UserPageGenrePreferencesOtherTableViewCell.cellIdentifier)
+        
+        rootView.userPageFeedView.userPageFeedTableView.feedTableView
+            .register(FeedListTableViewCell.self,
+                      forCellReuseIdentifier: FeedListTableViewCell.cellIdentifier)
+    }
+    
+    private func delegate() {
+        rootView.scrollView.rx
+            .setDelegate(self)
+            .disposed(by: disposeBag)
+        
+        rootView.userPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx
+            .setDelegate(self)
+            .disposed(by: disposeBag)
+        
+        rootView.userPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView.delegate = self
+        
+        rootView.userPageFeedView.userPageFeedTableView.feedTableView.rx
+            .setDelegate(self)
+            .disposed(by: disposeBag)
+    }
+    
+    //MARK: - Bind
+    
+    private func bindViewModel() {
+        let inventoryStatusButtonDidTap = Observable<Int>.merge(
+            rootView.userPageLibraryView.inventoryView.readStatusButtons.enumerated().map { index, button in
+                button.rx.tap
+                    .map { index }
+            })
+        
+        let genrePreferenceButtonDidTap = Observable.merge(
+            rootView.userPageLibraryView.genrePrefrerencesView.userPageGenreOpenButton.rx.tap.map { true },
+            rootView.userPageLibraryView.genrePrefrerencesView.userPageGenreCloseButton.rx.tap.map { false }
+        )
+        
+        let libraryButtonDidTap = Observable.merge(
+            rootView.mainStickyHeaderView.libraryButton.rx.tap.map { true },
+            rootView.scrolledStickyHeaderView.libraryButton.rx.tap.map { true }
+        )
+        
+        let feedButtonDidTap = Observable.merge(
+            rootView.mainStickyHeaderView.feedButton.rx.tap.map { true },
+            rootView.scrolledStickyHeaderView.feedButton.rx.tap.map { true }
+        )
+        
+        let input = UserPageViewModel.Input(
+            viewWillAppearEvent: self.viewWillAppearEvent,
+            headerViewHeight: headerViewHeightRelay.asDriver(),
+            resizefeedTableViewHeight: rootView.userPageFeedView.userPageFeedTableView.feedTableView.rx.observe(CGSize.self, "contentSize"),
+            resizeKeywordCollectionViewHeight: rootView.userPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.observe(CGSize.self, "contentSize"),
+            scrollOffset: rootView.scrollView.rx.contentOffset.asDriver(),
+            dropdownButtonDidTap: dropDownCellTap,
+            backButtonDidTap: rootView.backButton.rx.tap,
+            genrePreferenceButtonDidTap: genrePreferenceButtonDidTap,
+            libraryButtonDidTap: libraryButtonDidTap,
+            feedButtonDidTap: feedButtonDidTap,
+            inventoryViewDidTap: rootView.userPageLibraryView.inventoryView.inventoryTitleView.rx.tapGesture()
+                .when(.recognized)
+                .asObservable(),
+            inventorySpecificPageViewDidTap: inventoryStatusButtonDidTap,
+            feedDetailButtonDidTap: rootView.userPageFeedView.userPageFeedDetailButton.rx.tap,
+            feedTableViewItemSelected: rootView.userPageFeedView.userPageFeedTableView.feedTableView.rx.itemSelected.asObservable(),
+            feedConnectedNovelViewDidTap: feedConnectedNovelViewDidTap.asObservable())
+        
+        let output = viewModel.transform(from: input, disposeBag: disposeBag)
+        
+        output.profileData
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                owner.rootView.headerView.bindData(data: data)
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateNavigationBar
+            .asDriver()
+            .drive(with: self, onNext: { owner, data in
+                let (update, navigationTitle) = data
+                owner.navigationTitle = navigationTitle
+                owner.navigationItem.title = update ? navigationTitle : ""
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateStickyHeader
+            .asDriver()
+            .drive(with: self, onNext: { owner, update in
+                owner.rootView.scrolledStickyHeaderView.isHidden = !update
+                owner.rootView.mainStickyHeaderView.isHidden = update
+                owner.rootView.headerView.isHidden = update
+            })
+            .disposed(by: disposeBag)
+        
+        output.popViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                owner.popToLastViewController()
+            })
+            .disposed(by: disposeBag)
+        
+        output.isProfilePrivate
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                let (isPrivate, nickname) = data
+                if isPrivate {
+                    owner.rootView.userPageLibraryView.isPrivateUserView(isPrivate: isPrivate, nickname: nickname)
+                    owner.rootView.userPageFeedView.isPrivateUserView(isPrivate: isPrivate, nickname: nickname)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        output.bindGenreData
+            .observe(on: MainScheduler.instance)
+            .do(onNext: { [weak self] data in
+                self?.rootView.userPageLibraryView.genrePrefrerencesView.bindData(data: data)
+            })
+            .map { Array($0.genrePreferences.dropFirst(3)) }
+            .bind(to: rootView.userPageLibraryView.genrePrefrerencesView.userPageOtherGenreView.genreTableView.rx.items(
+                cellIdentifier: UserPageGenrePreferencesOtherTableViewCell.cellIdentifier,
+                cellType: UserPageGenrePreferencesOtherTableViewCell.self)) { row, data, cell in
+                cell.bindData(data: data)
+                cell.selectionStyle = .none
+            }
+            .disposed(by: disposeBag)
+        
+        output.bindAttractivePointsData
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                owner.rootView.userPageLibraryView.novelPrefrerencesView.bindPreferencesDetailData(data: data)
+                
+            })
+            .disposed(by: disposeBag)
+        
+        output.isExistPreferneces
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, isExist in
+                if !isExist {
+                    owner.rootView.userPageLibraryView.updatePreferencesEmptyView(isEmpty: !isExist)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        output.bindKeywordCell
+            .observe(on: MainScheduler.instance)
+            .bind(to: rootView.userPageLibraryView.novelPrefrerencesView.preferencesCollectionView.rx.items(
+                cellIdentifier: UserPageNovelPreferencesCollectionViewCell.cellIdentifier,
+                cellType: UserPageNovelPreferencesCollectionViewCell.self)){ row, data, cell in
+                cell.bindData(data: data)
+            }
+            .disposed(by: disposeBag)
+        
+        output.bindInventoryData
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                owner.rootView.userPageLibraryView.inventoryView.bindData(data: data)
+            })
+            .disposed(by: disposeBag)
+        
+        output.showGenreOtherView
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, show in
+                owner.rootView.userPageLibraryView.genrePrefrerencesView.updateView(showOtherGenreView: show)
+                owner.rootView.userPageLibraryView.updateGenreViewHeight(isExpanded: show)
+                owner.rootView.layoutIfNeeded()
+            })
+            .disposed(by: disposeBag)
+        
+        output.stickyHeaderAction
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, library in
+                owner.rootView.mainStickyHeaderView.updateSelection(isLibrarySelected: library)
+                owner.rootView.scrolledStickyHeaderView.updateSelection(isLibrarySelected: library)
+                
+                owner.rootView.userPageLibraryView.isHidden = !library
+                owner.rootView.userPageFeedView.isHidden = library
+                
+                owner.rootView.contentView.snp.remakeConstraints {
+                    $0.edges.equalToSuperview()
+                    $0.width.equalToSuperview()
+                    
+                    if library {
+                        $0.bottom.equalTo(owner.rootView.userPageLibraryView.snp.bottom)
+                    } else {
+                        $0.bottom.equalTo(owner.rootView.userPageFeedView.snp.bottom)
+                    }
+                }
+                
+                owner.rootView.layoutIfNeeded()
+                
+            })
+            .disposed(by: disposeBag)
+        
+        output.bindFeedData
+            .observe(on: MainScheduler.instance)
+            .bind(to: rootView.userPageFeedView.userPageFeedTableView.feedTableView.rx.items(
+                cellIdentifier: FeedListTableViewCell.cellIdentifier,
+                cellType: FeedListTableViewCell.self)) { _, element, cell in
+                    cell.bindProfileFeedData(feed: element)
+                    cell.delegate = self
+                }
+                .disposed(by: disposeBag)
+        
+        output.isEmptyFeed
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, isEmpty in
+                owner.rootView.userPageFeedView.isEmptyView(isEmpty: isEmpty)
+            })
+            .disposed(by: disposeBag)
+        
+        output.showFeedDetailButton
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, show in
+                owner.rootView.userPageFeedView.showMoreButton(isShow: show)
+            })
+            .disposed(by: disposeBag)
+        
+        output.pushToLibraryViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, userId in
+                owner.pushToLibraryViewController(userId: userId)
+            })
+            .disposed(by: disposeBag)
+        
+        output.pushToSpecificLibraryViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, data in
+                let (userId, pageIndex) = data
+                owner.pushToLibraryViewController(userId: userId, pageIndex: pageIndex)
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateButtonWithLibraryView
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, showLibraryView in
+                owner.rootView.showContentView(showLibraryView: showLibraryView)
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateFeedTableViewHeight
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, height in
+                owner.rootView.userPageFeedView.userPageFeedTableView.updateTableViewHeight(height: height)
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateKeywordCollectionViewHeight
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, height in
+                owner.rootView.userPageLibraryView.novelPrefrerencesView.updateKeywordViewHeight(height: height)
+            })
+            .disposed(by: disposeBag)
+        
+        output.pushToUserPageFeedDetailViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self as UIViewController, onNext: { owner, userData in
+                let (id, data) = userData
+                owner.pushToUserPageFeedDetailViewController(userId: id, userData: data)
+            })
+            .disposed(by: disposeBag)
+        
+        output.pushToNovelDetailViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, novelId in
+                owner.pushToNovelDetailViewController(novelId: novelId)
+            })
+            .disposed(by: disposeBag)
+        
+        output.pushToFeedDetailViewController
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, feedId in
+                owner.pushToFeedDetailViewController(feedId: feedId)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    //MARK: - Custom Method
+    
+    func scrollToTop() {
+        self.rootView.scrollView.setContentOffset(CGPoint(x: 0, y: -self.rootView.scrollView.contentInset.top), animated: true)
+    }
+}
+
+extension UserPageViewController: UICollectionViewDelegateFlowLayout, UIScrollViewDelegate, UITableViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let keywords = viewModel.bindKeywordRelay.value
+        guard indexPath.row < keywords.count else {
+            return CGSize(width: 0, height: 0)
+        }
+        let keyword = keywords[indexPath.row]
+        let text = "\(keyword.keywordName) \(keyword.keywordCount)"
+        
+        
+        let width = (text as NSString).size(withAttributes: [NSAttributedString.Key.font: UIFont.Body2]).width + 24
+        return CGSize(width: width, height: 37)
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y < 0 {
+            scrollView.contentOffset.y = 0
+        }
+    }
+}
+
+extension UserPageViewController {
+    
+    //MARK: - UI
+    
+    private func decideNavigation(navigationTitle: String) {
+        let dropdownButton = WSSDropdownButton().then {
+            $0.makeDropdown(dropdownRootView: self.rootView,
+                            dropdownWidth: 120,
+                            dropdownLayout: .autoInNavigationBar,
+                            dropdownData: [StringLiterals.MyPage.BlockUser.toastText],
+                            textColor: .wssBlack)
+            .observe(on: MainScheduler.instance)
+            .bind(to: dropDownCellTap)
+            .disposed(by: disposeBag)
+        }
+        
+        setWSSNavigationBar(title: navigationTitle,
+                            left: rootView.backButton,
+                            right: dropdownButton,
+                            isVisibleBeforeScroll: false)
+    }
+}
+
+extension UserPageViewController: FeedTableViewDelegate {
+    func profileViewDidTap(userId: Int) {
+        return
+    }
+    
+    func dropdownButtonDidTap(feedId: Int, isMyFeed: Bool) {
+        return
+    }
+    
+    func likeViewDidTap(feedId: Int, isLiked: Bool) {
+        return
+    }
+    
+    func connectedNovelViewDidTap(novelId: Int) {
+        self.feedConnectedNovelViewDidTap.accept(novelId)
+    }
+}
+

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditAvatarViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditAvatarViewModel.swift
@@ -35,7 +35,7 @@ final class MyPageEditAvatarViewModel: ViewModelType {
     }
     
     struct Output {
-        let bindAvatarImageCell = BehaviorRelay<[(String, Bool)]>(value: [])
+        let bindAvatarImageCell = BehaviorRelay<[(URL?, Bool)]>(value: [])
         let updateAvatarData = PublishRelay<(AvatarEntity,String)>()
         let dismissModalViewController = PublishRelay<Void>()
     }
@@ -53,7 +53,7 @@ final class MyPageEditAvatarViewModel: ViewModelType {
                 owner.totalAvatarData = avatarList.avatars
                 
                 //셀 바인딩을 위한 튜플 생성
-                let avatarImage = avatarList.avatars.map { ($0.avatarImage , $0.isRepresentative)}
+                let avatarImage = avatarList.avatars.map { ($0.avatarImageURL , $0.isRepresentative)}
                 output.bindAvatarImageCell.accept(avatarImage)
                 
                 //View 바인딩을 위한 대표아바타ID 저장
@@ -84,8 +84,8 @@ final class MyPageEditAvatarViewModel: ViewModelType {
             .subscribe(with: self, onNext: { owner, _ in
                 let avatarId = owner.lastTappedAvatarId.value
                 if (avatarId != owner.defaultAvatarId) {
-                    let avatarImage = owner.totalAvatarData[avatarId-1].avatarImage
-                    NotificationCenter.default.post(name: NSNotification.Name("ChangRepresentativeAvatar"), object: (avatarId, avatarImage))
+                    let avatarImage = owner.totalAvatarData[avatarId-1].avatarImageURL
+                    NotificationCenter.default.post(name: NotificationName.changeRepresentativeAvatar, object: (avatarId, avatarImage))
                 }
                 output.dismissModalViewController.accept(())
             })

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -57,7 +57,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     struct Input {
         let backButtonDidTap: ControlEvent<Void>
         let completeButtonDidTap: ControlEvent<Void>
-        let profileViewDidTap: ControlEvent<Void>
+        let profileViewDidTap: Observable<UITapGestureRecognizer>
         let avatarImageNotification: Observable<Notification>
         
         let updateNicknameText: Observable<String>

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -35,7 +35,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     private var userNickname = BehaviorRelay<String>(value: "")
     private let userIntro = BehaviorRelay<String>(value: "")
     private let userGenre = BehaviorRelay<[String]>(value: [])
-    private let userImage = BehaviorRelay<String>(value: "")
+    private let userImage = BehaviorRelay<URL?>(value: nil)
     
     // Action Relay
     private var changeCompleteButton = BehaviorRelay<Bool>(value: false)
@@ -77,10 +77,10 @@ final class MyPageEditProfileViewModel: ViewModelType {
         let popViewController = PublishRelay<Bool>()
         let bindProfileData = BehaviorRelay<MyProfileEntity>(value: MyProfileEntity(nickname: "",
                                                                                     intro: "",
-                                                                                    avatarImage: "",
-                                                                                    genrePreferences: []))
+                                                                                    genrePreferences: [],
+                                                                                    avatarImageURL: nil))
         let pushToAvatarViewController = PublishRelay<String>()
-        let updateProfileImage = PublishRelay<String>()
+        let updateProfileImage = PublishRelay<URL?>()
         
         let nicknameText = BehaviorRelay<String>(value: "")
         let editingTextField = BehaviorRelay<Bool>(value: false)
@@ -105,7 +105,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
             self.userNickname.accept(profileData.nickname)
             self.userIntro.accept(profileData.intro)
             self.userGenre.accept(profileData.genrePreferences)
-            self.userImage.accept(profileData.avatarImage)
+            self.userImage.accept(profileData.avatarImageURL)
             
             output.bindProfileData.accept(profileData)
             
@@ -116,7 +116,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
                     owner.userNickname.accept(profileData.nickname)
                     owner.userIntro.accept(profileData.intro)
                     owner.userGenre.accept(profileData.genrePreferences)
-                    owner.userImage.accept(profileData.avatarImage)
+                    owner.userImage.accept(profileData.avatarImageURL)
                     
                     output.bindProfileData.accept(profileData)
                     
@@ -143,7 +143,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
             .flatMapLatest{ _ -> Observable<Void> in
                 var updatedFields: [String: Any] = [:]
                 
-                if self.userImage.value != self.profileData?.avatarImage && self.avatarId != -1  {
+                if self.userImage.value != self.profileData?.avatarImageURL && self.avatarId != -1  {
                     updatedFields["avatarId"] = self.avatarId
                 }
                 
@@ -203,7 +203,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
         
         input.avatarImageNotification
             .subscribe(with: self, onNext: { owner, notification in
-                guard let avatarData = notification.object as? (Int, String) else { return }
+                guard let avatarData = notification.object as? (Int, URL) else { return }
                 owner.avatarId = avatarData.0
                 owner.userImage.accept(avatarData.1)
                 output.updateProfileImage.accept(avatarData.1)
@@ -328,7 +328,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     }
     
     private func changeInfoData() {
-        if (self.userNickname.value == profileData?.nickname && self.userIntro.value == profileData?.intro && self.userGenre.value == profileData?.genrePreferences && self.userImage.value == self.profileData?.avatarImage) {
+        if (self.userNickname.value == profileData?.nickname && self.userIntro.value == profileData?.intro && self.userGenre.value == profileData?.genrePreferences && self.userImage.value == self.profileData?.avatarImageURL) {
             self.changeCompleteButton.accept(self.checkDuplicatedButton.value)
         }
         else {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -76,7 +76,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
         let bindGenreCell = BehaviorRelay<[(String, Bool)]>(value: [])
         let popViewController = PublishRelay<Bool>()
         let bindProfileData = BehaviorRelay<MyProfileEntity>(value: MyProfileEntity(nickname: "",
-                                                                                    intro: "",
+                                                                                    introdution: "",
                                                                                     genrePreferences: [],
                                                                                     avatarImageURL: nil))
         let pushToAvatarViewController = PublishRelay<String>()
@@ -103,7 +103,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
             guard let profileData = self.profileData else { fatalError("프로필 데이터가 전달되지 않음") }
             
             self.userNickname.accept(profileData.nickname)
-            self.userIntro.accept(profileData.intro)
+            self.userIntro.accept(profileData.introdution)
             self.userGenre.accept(profileData.genrePreferences)
             self.userImage.accept(profileData.avatarImageURL)
             
@@ -114,7 +114,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
                 .subscribe(with: self, onNext: { owner, profileData in
                     owner.profileData = profileData
                     owner.userNickname.accept(profileData.nickname)
-                    owner.userIntro.accept(profileData.intro)
+                    owner.userIntro.accept(profileData.introdution)
                     owner.userGenre.accept(profileData.genrePreferences)
                     owner.userImage.accept(profileData.avatarImageURL)
                     
@@ -151,7 +151,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
                     updatedFields["nickname"] = self.userNickname.value
                 }
                 
-                if self.userIntro.value != self.profileData?.intro {
+                if self.userIntro.value != self.profileData?.introdution {
                     updatedFields["intro"] = self.userIntro.value
                 }
                 
@@ -328,7 +328,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
     }
     
     private func changeInfoData() {
-        if (self.userNickname.value == profileData?.nickname && self.userIntro.value == profileData?.intro && self.userGenre.value == profileData?.genrePreferences && self.userImage.value == self.profileData?.avatarImageURL) {
+        if (self.userNickname.value == profileData?.nickname && self.userIntro.value == profileData?.introdution && self.userGenre.value == profileData?.genrePreferences && self.userImage.value == self.profileData?.avatarImageURL) {
             self.changeCompleteButton.accept(self.checkDuplicatedButton.value)
         }
         else {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageEditProfileViewModel.swift
@@ -169,7 +169,7 @@ final class MyPageEditProfileViewModel: ViewModelType {
                     UserDefaults.standard.setValue(self.userNickname.value, forKey: StringLiterals.UserDefault.userNickname)
                     
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        NotificationCenter.default.post(name: NSNotification.Name("EditProfile"), object: nil)
+                        NotificationCenter.default.post(name: NotificationName.editProfile, object: nil)
                     }
                     
                     output.popViewController.accept(true)

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageLibraryViewModel.swift
@@ -1,0 +1,226 @@
+//
+//  MyPageLibraryViewModel.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 1/22/25.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class MyPageLibraryViewModel: ViewModelType {
+    
+    // MARK: - Properties
+    
+    private let userRepository: UserInfoRepository
+    private let disposeBag = DisposeBag()
+    
+    /// 초기값은 내 프로필로 설정
+    private let isMyPage = BehaviorRelay<Bool>(value: true)
+    private var profileId: Int
+    
+    private let isExistPrefernecesRelay = BehaviorRelay<Bool>(value: false)
+    private let isProfilePrivate = PublishRelay<Bool>()
+    
+    private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusResponse>(value: UserNovelStatusResponse(interestNovelCount: 0,
+                                                                                               watchingNovelCount: 0,
+                                                                                               watchedNovelCount: 0,
+                                                                                               quitNovelCount: 0))
+    private let pushToLibraryViewControllerRelay = PublishRelay<Int>()
+    private let bindGenreDataRelay = BehaviorRelay<UserGenrePreferencesListEntity>(value: UserGenrePreferencesListEntity(genrePreferences: []))
+    private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
+    
+    private let bindAttractivePointsDataRelay = BehaviorRelay<[String]>(value: [])
+    let bindKeywordRelay = BehaviorRelay<[KeywordEntity]>(value: [])
+    private let updateButtonWithLibraryViewRelay = BehaviorRelay<Bool>(value: true)
+    private let updateKeywordCollectionViewHeightRelay = PublishRelay<CGFloat>()
+    
+    // MARK: - Life Cycle
+    
+    init(userRepository: UserInfoRepository, profileId: Int) {
+        self.userRepository = userRepository
+        self.profileId = profileId
+    }
+    
+    struct Input {
+        let viewWillAppearEvent: PublishSubject<Void>
+        let genrePreferenceButtonDidTap: Observable<Bool>
+        let inventoryViewDidTap: Observable<UITapGestureRecognizer>
+        let resizeKeywordCollectionViewHeight: Observable<CGSize?>
+    }
+    
+    struct Output {
+        let isExistPreferneces: BehaviorRelay<Bool>
+        let isProfilePrivate: PublishRelay<Bool>
+        
+        let bindInventoryData: BehaviorRelay<UserNovelStatusResponse>
+        let pushToLibraryViewController: PublishRelay<Int>
+        let bindGenreData: BehaviorRelay<UserGenrePreferencesListEntity>
+        let showGenreOtherView: BehaviorRelay<Bool>
+        let bindAttractivePointsData: BehaviorRelay<[String]>
+        let bindKeywordCell: BehaviorRelay<[KeywordEntity]>
+        let updateKeywordCollectionViewHeight: PublishRelay<CGFloat>
+    }
+    
+    func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        input.viewWillAppearEvent
+            .flatMapLatest { [weak self] _ -> Observable<Void> in
+                guard let self = self else { return .empty() }
+                
+                return Observable.zip(
+                    self.updateMyPageLibraryInventoryData(),
+                    self.updateMyPageLibraryPreferenceData()
+                )
+                /// flatMap 체인에서 반환 타입을 일관되게 만들어야 하기 때문에 함수의 리턴값인 <CGFloat> 을 <Void> 로 조정
+                .flatMap { _, _ -> Observable<Void> in
+                    self.handleKeywordCollectionViewHeight(resizeKeywordCollectionViewHeight: input.resizeKeywordCollectionViewHeight)
+                        .map { _ in () }
+                }
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
+        
+        input.genrePreferenceButtonDidTap
+            .subscribe(with: self, onNext: { owner, _ in
+                let currentState = owner.showGenreOtherViewRelay.value
+                owner.showGenreOtherViewRelay.accept(!currentState)
+            })
+            .disposed(by: disposeBag)
+        
+        input.inventoryViewDidTap
+            .bind(with: self, onNext: { owner, _ in
+                self.pushToLibraryViewControllerRelay.accept(owner.profileId)
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(isExistPreferneces: isExistPrefernecesRelay,
+                      isProfilePrivate: isProfilePrivate,
+                      bindInventoryData: bindInventoryDataRelay,
+                      pushToLibraryViewController: pushToLibraryViewControllerRelay,
+                      bindGenreData: bindGenreDataRelay,
+                      showGenreOtherView: showGenreOtherViewRelay,
+                      bindAttractivePointsData: bindAttractivePointsDataRelay,
+                      bindKeywordCell: bindKeywordRelay,
+                      updateKeywordCollectionViewHeight: updateKeywordCollectionViewHeightRelay)
+    }
+    
+    // MARK: - Custom Method
+    
+    /// 비공개처리된 유저
+    private func isPrivateUserError(_ error: Error) -> Bool {
+        if let networkError = error as? RxCocoaURLError {
+            switch networkError {
+            case .httpRequestFailed(_, let data):
+                if let data = data {
+                    do {
+                        let errorInfo = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
+                        return errorInfo.code == "USER-015"
+                    } catch {}
+                }
+                
+            default:
+                return false
+            }
+        }
+        return false
+    }
+    
+    /// 서재 데이터 바인딩
+    /// 보관함-장르취향-작품취향 서버연결
+    private func updateMyPageLibraryInventoryData() -> Observable<Void> {
+        return getInventoryData(userId: self.profileId)
+            .flatMap { [weak self] inventory -> Observable<Void> in
+                guard let self else { return .just(()) }
+                self.bindInventoryDataRelay.accept(inventory)
+                return .just(())
+            }
+        /// private 유저일 경우 에러를 배출함
+            .catch { [weak self] error in
+                guard let self else { return .empty() }
+                
+                if self.isPrivateUserError(error) {
+                    self.isProfilePrivate.accept(true)
+                }
+                return .empty()
+            }
+    }
+    
+    //취향분석 데이터 바인딩
+    private func updateMyPageLibraryPreferenceData() -> Observable<Void> {
+        return getNovelPreferenceData(userId: self.profileId)
+            .flatMap { [weak self] preference -> Observable<Bool> in
+                guard let self else { return .just(false) }
+                
+                //작품취향 분기처리
+                //1. 매력포인트, 키워드 둘 다 있을 때
+                //2. 매력포인트만 있을 때
+                //3. 키워드만 있을 때
+                // => 각각의 뷰만 뜨게 함
+                
+                //4. 둘 다 없을 때
+                //=> emptyView 처리
+                //=> 이 경우 장르 취향도 데이터가 없기 때문에 false 반환
+                let keywords = preference.keywords
+                if preference.attractivePoints == [] && keywords.isEmpty {
+                    self.isExistPrefernecesRelay.accept(false)
+                    return .just(false)
+                } else {
+                    self.isExistPrefernecesRelay.accept(true)
+                    self.bindAttractivePointsDataRelay.accept(preference.attractivePoints)
+                    self.bindKeywordRelay.accept(keywords)
+                    return .just(true)
+                }
+            }
+            .catch { [weak self] error in
+                guard let self else { return .empty() }
+                
+                if self.isPrivateUserError(error) {
+                    self.isProfilePrivate.accept(true)
+                }
+                return .just(false)
+            }
+        
+        /// 장르 취향
+            .flatMap { [weak self] isExist -> Observable<Void> in
+                guard let self else { return .empty() }
+                if isExist {
+                    return self.getGenrePreferenceData(userId: self.profileId)
+                        .do(onNext: { data in
+                            if !data.genrePreferences.isEmpty {
+                                self.bindGenreDataRelay.accept(data)
+                            }
+                        })
+                        .map { _ in Void() }
+                } else {
+                    return .just(Void())
+                }
+            }
+    }
+    
+    private func handleKeywordCollectionViewHeight(resizeKeywordCollectionViewHeight: Observable<CGSize?>) -> Observable<CGFloat> {
+        return resizeKeywordCollectionViewHeight
+            .map { $0?.height ?? 0 }
+            .do(onNext: { [weak self] height in
+                self?.updateKeywordCollectionViewHeightRelay.accept(height)
+            })
+    }
+    
+    // MARK: - API
+    
+    private func getNovelPreferenceData(userId: Int) -> Observable<UserNovelPreferencesEntity> {
+        return userRepository.getUserNovelPreferences(userId: userId)
+            .asObservable()
+    }
+    
+    private func getGenrePreferenceData(userId: Int) -> Observable<UserGenrePreferencesListEntity> {
+        return userRepository.getUserGenrePreferences(userId: userId)
+            .asObservable()
+    }
+    
+    private func getInventoryData(userId: Int) -> Observable<UserNovelStatusResponse> {
+        return userRepository.getUserNovelStatus(userId: userId)
+            .asObservable()
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageLibraryViewModel.swift
@@ -16,22 +16,17 @@ final class MyPageLibraryViewModel: ViewModelType {
     
     private let userRepository: UserInfoRepository
     private let disposeBag = DisposeBag()
-    
-    /// 초기값은 내 프로필로 설정
-    private let isMyPage = BehaviorRelay<Bool>(value: true)
     private var profileId: Int
     
     private let isExistPrefernecesRelay = BehaviorRelay<Bool>(value: false)
     private let isProfilePrivate = PublishRelay<Bool>()
-    
-    private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusResponse>(value: UserNovelStatusResponse(interestNovelCount: 0,
-                                                                                               watchingNovelCount: 0,
-                                                                                               watchedNovelCount: 0,
-                                                                                               quitNovelCount: 0))
+    private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusEntity>(value: UserNovelStatusEntity(interestNovelCount: 0,
+                                                                                                           watchingNovelCount: 0,
+                                                                                                           watchedNovelCount: 0,
+                                                                                                           quitNovelCount: 0))
     private let pushToLibraryViewControllerRelay = PublishRelay<Int>()
     private let bindGenreDataRelay = BehaviorRelay<UserGenrePreferencesListEntity>(value: UserGenrePreferencesListEntity(genrePreferences: []))
     private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
-    
     private let bindAttractivePointsDataRelay = BehaviorRelay<[String]>(value: [])
     let bindKeywordRelay = BehaviorRelay<[KeywordEntity]>(value: [])
     private let updateButtonWithLibraryViewRelay = BehaviorRelay<Bool>(value: true)
@@ -55,7 +50,7 @@ final class MyPageLibraryViewModel: ViewModelType {
         let isExistPreferneces: BehaviorRelay<Bool>
         let isProfilePrivate: PublishRelay<Bool>
         
-        let bindInventoryData: BehaviorRelay<UserNovelStatusResponse>
+        let bindInventoryData: BehaviorRelay<UserNovelStatusEntity>
         let pushToLibraryViewController: PublishRelay<Int>
         let bindGenreData: BehaviorRelay<UserGenrePreferencesListEntity>
         let showGenreOtherView: BehaviorRelay<Bool>
@@ -211,16 +206,13 @@ final class MyPageLibraryViewModel: ViewModelType {
     
     private func getNovelPreferenceData(userId: Int) -> Observable<UserNovelPreferencesEntity> {
         return userRepository.getUserNovelPreferences(userId: userId)
-            .asObservable()
     }
     
     private func getGenrePreferenceData(userId: Int) -> Observable<UserGenrePreferencesListEntity> {
         return userRepository.getUserGenrePreferences(userId: userId)
-            .asObservable()
     }
     
-    private func getInventoryData(userId: Int) -> Observable<UserNovelStatusResponse> {
+    private func getInventoryData(userId: Int) -> Observable<UserNovelStatusEntity> {
         return userRepository.getUserNovelStatus(userId: userId)
-            .asObservable()
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -52,14 +52,10 @@ final class MyPageViewModel: ViewModelType {
     
     // MARK: - Life Cycle
     
-    init(userRepository: UserRepository, profileId: Int) {
+    init(userRepository: UserRepository) {
         self.userRepository = userRepository
-        if profileId == 0 {
-            let userId = UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
-            self.profileId = userId
-        } else {
-            self.profileId = profileId
-        }
+        let userId = UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
+        self.profileId = userId
     }
     
     struct Input {

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -25,9 +25,9 @@ final class MyPageViewModel: ViewModelType {
     private let updateStickyHeaderRelay = BehaviorRelay<(Bool)>(value: (false))
     private let profileDataRelay = BehaviorRelay<MyProfileEntity>(value: MyProfileEntity(nickname: "",
                                                                                          intro: "",
-                                                                                         avatarImage: "",
-                                                                                         genrePreferences: []))
-    
+                                                                                         genrePreferences: [],
+                                                                                         avatarImageURL: nil))
+                                                                  
     private let isExistPrefernecesRelay = PublishRelay<Bool>()
     private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusEntity>(value: UserNovelStatusEntity(interestNovelCount: 0,
                                                                                                            watchingNovelCount: 0,

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -199,24 +199,6 @@ final class MyPageViewModel: ViewModelType {
     
     // MARK: - Custom Method
     
-    private func updateNavigationRelay(_ error: Error) -> Bool {
-        if let networkError = error as? RxCocoaURLError {
-            switch networkError {
-            case .httpRequestFailed(_, let data):
-                if let data = data {
-                    do {
-                        let errorInfo = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
-                        return errorInfo.code == "USER-018"
-                    } catch {}
-                }
-                
-            default:
-                return false
-            }
-        }
-        return false
-    }
-    
     private func updateHeaderView() -> Observable<Void> {
         return self.getProfileData()
             .do(onNext: { profileData in

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -65,7 +65,7 @@ final class MyPageViewModel: ViewModelType {
         let resizeKeywordCollectionViewHeight: Observable<CGSize?>
         let scrollOffset: Driver<CGPoint>
         let settingButtonDidTap: ControlEvent<Void>
-        let editButtonDidTap: ControlEvent<Void>
+        let editButtonDidTap: Observable<UITapGestureRecognizer>
         let genrePreferenceButtonDidTap: Observable<Bool>
         let inventoryViewDidTap: Observable<UITapGestureRecognizer>
         let inventorySpecificPageViewDidTap: Observable<Int>
@@ -149,7 +149,7 @@ final class MyPageViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.editButtonDidTap
-            .map { self.profileDataRelay.value }
+            .map { _ in self.profileDataRelay.value }
             .bind(to: pushToEditViewControllerRelay)
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -33,7 +33,7 @@ final class MyPageViewModel: ViewModelType {
                                                                                                            watchingNovelCount: 0,
                                                                                                            watchedNovelCount: 0,
                                                                                                            quitNovelCount: 0))
-    let bindKeywordRelay = BehaviorRelay<[KeywordResponse]>(value: [])
+    let bindKeywordRelay = BehaviorRelay<[KeywordEntity]>(value: [])
     private let bindAttractivePointsDataRelay = BehaviorRelay<[String]>(value: [])
     private let bindGenreDataRelay = BehaviorRelay<UserGenrePreferencesListEntity>(value: UserGenrePreferencesListEntity(genrePreferences: []))
     private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
@@ -81,7 +81,7 @@ final class MyPageViewModel: ViewModelType {
         let pushToLibraryViewController: PublishRelay<Int>
         
         let bindAttractivePointsData: BehaviorRelay<[String]>
-        let bindKeywordCell: BehaviorRelay<[KeywordResponse]>
+        let bindKeywordCell: BehaviorRelay<[KeywordEntity]>
         let updateKeywordCollectionViewHeight: PublishRelay<CGFloat>
         let bindGenreData: BehaviorRelay<UserGenrePreferencesListEntity>
         let bindInventoryData: BehaviorRelay<UserNovelStatusEntity>

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/MyPageViewModel.swift
@@ -24,7 +24,7 @@ final class MyPageViewModel: ViewModelType {
     private let updateNavigationRelay = BehaviorRelay<(Bool, String)>(value: (false, ""))
     private let updateStickyHeaderRelay = BehaviorRelay<(Bool)>(value: (false))
     private let profileDataRelay = BehaviorRelay<MyProfileEntity>(value: MyProfileEntity(nickname: "",
-                                                                                         intro: "",
+                                                                                         introdution: "",
                                                                                          genrePreferences: [],
                                                                                          avatarImageURL: nil))
                                                                   

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageFeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageFeedDetailViewModel.swift
@@ -10,13 +10,13 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class MyPageFeedDetailViewModel: ViewModelType {
+final class UserPageFeedDetailViewModel: ViewModelType {
     
     //MARK: - Properties
     
     //init
     private let userRepository: UserInfoRepository
-    private let profileData: MyProfileEntity
+    private let profileData: OtherProfileEntity
     private let profileId: Int
     
     //피드 정보 관련 데이터
@@ -25,7 +25,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
     private var isMyFeed: Bool = false
     
     //무한스크롤 기능
-    private let feedDataRelay = BehaviorRelay<[MyFeedListItem]>(value: [])
+    private let feedDataRelay = BehaviorRelay<[UserFeedListItem]>(value: [])
     private let isLoadableRelay = BehaviorRelay<Bool>(value: true)
     private let lastFeedIdRelay = BehaviorRelay<Int>(value: 0)
     private var isFetching = false
@@ -37,7 +37,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
     
     //MARK: - Life Cycle
     
-    init(userRepository: UserInfoRepository, profileId: Int, profileData: MyProfileEntity) {
+    init(userRepository: UserInfoRepository, profileId: Int, profileData: OtherProfileEntity) {
         self.userRepository = userRepository
         
         self.profileId = profileId
@@ -51,7 +51,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
     }
     
     struct Output {
-        let bindFeedData: BehaviorRelay<[MyFeedListItem]>
+        let bindFeedData: BehaviorRelay<[UserFeedListItem]>
         let isMyPage: PublishRelay<Bool>
         let pushToFeedDetailViewController: Observable<Int>
     }
@@ -65,7 +65,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
             .do(onNext: { [weak self] _ in
                 self?.isFetching = true
             })
-            .flatMapLatest { [weak self] _ -> Observable<MyFeedListEntity> in
+            .flatMapLatest { [weak self] _ -> Observable<UserFeedListEntity> in
                 guard let self = self else { return .empty() }
                 return self.getUserFeed(userId: self.profileId,
                                         lastFeedId: self.lastFeedIdRelay.value,
@@ -78,7 +78,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
                 print(error.localizedDescription)
             })
             .disposed(by: disposeBag)
-
+        
         input.viewWillAppearEvent
             .do(onNext: { [weak self] _ in
                 guard let self = self else { return }
@@ -90,7 +90,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
                 self.isLoadableRelay.accept(true)
                 self.isFetching = true
             })
-            .flatMapLatest { [weak self] _ -> Observable<MyFeedListEntity> in
+            .flatMapLatest { [weak self] _ -> Observable<UserFeedListEntity> in
                 guard let self = self else { return .empty() }
                 return self.getUserFeed(userId: self.profileId,
                                         lastFeedId: 0,
@@ -116,12 +116,12 @@ final class MyPageFeedDetailViewModel: ViewModelType {
                       pushToFeedDetailViewController: self.pushToFeedDetailViewController.asObservable())
     }
     
-    private func updateFeedList(_ feedResult: MyFeedListEntity) {
+    private func updateFeedList(_ feedResult: UserFeedListEntity) {
         let newFeedData = feedResult.feeds
             .map { feed in
-                MyFeedListItem(feed: feed,
-                               avatarImage: self.profileData.avatarImage,
-                               nickname: self.profileData.nickname)
+                UserFeedListItem(feed: feed,
+                                 avatarImage: self.profileData.avatarImageURL,
+                                 nickname: self.profileData.nickname)
             }
         
         if let lastFeed = feedResult.feeds.last {
@@ -135,7 +135,7 @@ final class MyPageFeedDetailViewModel: ViewModelType {
     
     //MARK: - API
     
-    private func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<MyFeedListEntity> {
+    private func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<UserFeedListEntity> {
         return userRepository.getUserFeed(userId: userId, lastFeedId: lastFeedId, size: size)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageFeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageFeedDetailViewModel.swift
@@ -16,7 +16,7 @@ final class UserPageFeedDetailViewModel: ViewModelType {
     
     //init
     private let userRepository: UserInfoRepository
-    private let profileData: OtherProfileEntity
+    private let profileData: UserProfileEntity
     private let profileId: Int
     
     //피드 정보 관련 데이터
@@ -37,7 +37,7 @@ final class UserPageFeedDetailViewModel: ViewModelType {
     
     //MARK: - Life Cycle
     
-    init(userRepository: UserInfoRepository, profileId: Int, profileData: OtherProfileEntity) {
+    init(userRepository: UserInfoRepository, profileId: Int, profileData: UserProfileEntity) {
         self.userRepository = userRepository
         
         self.profileId = profileId

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
@@ -33,7 +33,7 @@ final class UserPageViewModel: ViewModelType {
                                                                                                            watchingNovelCount: 0,
                                                                                                            watchedNovelCount: 0,
                                                                                                            quitNovelCount: 0))
-    let bindKeywordRelay = BehaviorRelay<[KeywordResponse]>(value: [])
+    let bindKeywordRelay = BehaviorRelay<[KeywordEntity]>(value: [])
     private let bindAttractivePointsDataRelay = BehaviorRelay<[String]>(value: [])
     private let bindGenreDataRelay = BehaviorRelay<UserGenrePreferencesListEntity>(value: UserGenrePreferencesListEntity(genrePreferences: []))
     private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
@@ -95,7 +95,7 @@ final class UserPageViewModel: ViewModelType {
         let pushToUserPageFeedDetailViewController: PublishRelay<(Int, UserProfileEntity)>
         
         let bindAttractivePointsData: BehaviorRelay<[String]>
-        let bindKeywordCell: BehaviorRelay<[KeywordResponse]>
+        let bindKeywordCell: BehaviorRelay<[KeywordEntity]>
         let updateKeywordCollectionViewHeight: PublishRelay<CGFloat>
         let bindGenreData: BehaviorRelay<UserGenrePreferencesListEntity>
         let bindInventoryData: BehaviorRelay<UserNovelStatusEntity>

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
@@ -1,8 +1,8 @@
 //
-//  MyPageViewModel.swift
+//  UserPageViewModel.swift
 //  WSSiOS
 //
-//  Created by 신지원 on 7/9/24.
+//  Created by 신지원 on 5/20/25.
 //
 
 import UIKit
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class MyPageViewModel: ViewModelType {
+final class UserPageViewModel: ViewModelType {
     
     // MARK: - Properties
     
@@ -20,14 +20,14 @@ final class MyPageViewModel: ViewModelType {
     
     private let disposeBag = DisposeBag()
     
-    private let isMyPageRelay = BehaviorRelay<Bool>(value: true)
     private let updateNavigationRelay = BehaviorRelay<(Bool, String)>(value: (false, ""))
     private let updateStickyHeaderRelay = BehaviorRelay<(Bool)>(value: (false))
-    private let profileDataRelay = BehaviorRelay<MyProfileEntity>(value: MyProfileEntity(nickname: "",
-                                                                                         intro: "",
-                                                                                         avatarImage: "",
-                                                                                         genrePreferences: []))
-    
+    private let isProfilePrivateRelay = BehaviorRelay<(Bool, String)>(value: (false, ""))
+    private let profileDataRelay = BehaviorRelay<OtherProfileEntity>(value: OtherProfileEntity(nickname: "",
+                                                                                               intro: "",
+                                                                                               genrePreferences: [],
+                                                                                               isProfilePublic: true,
+                                                                                               avatarImageURL: nil))
     private let isExistPrefernecesRelay = PublishRelay<Bool>()
     private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusEntity>(value: UserNovelStatusEntity(interestNovelCount: 0,
                                                                                                            watchingNovelCount: 0,
@@ -38,14 +38,20 @@ final class MyPageViewModel: ViewModelType {
     private let bindGenreDataRelay = BehaviorRelay<UserGenrePreferencesListEntity>(value: UserGenrePreferencesListEntity(genrePreferences: []))
     private let showGenreOtherViewRelay = BehaviorRelay<Bool>(value: false)
     
+    private let bindFeedDataRelay = BehaviorRelay<[UserFeedListItem]>(value: [])
+    private let isEmptyFeedRelay = PublishRelay<Bool>()
+    private let showFeedDetailButtonRelay = BehaviorSubject<Bool>(value: false)
+    
+    private let updateButtonWithLibraryViewRelay = BehaviorRelay<Bool>(value: true)
+    private let updateFeedTableViewHeightRelay = PublishRelay<CGFloat>()
     private let updateKeywordCollectionViewHeightRelay = PublishRelay<CGFloat>()
     
-    private let pushToEditViewControllerRelay = PublishRelay<MyProfileEntity>()
-    private let pushToSettingViewControllerRelay = PublishRelay<Void>()
     private let pushToLibraryViewControllerRelay = PublishRelay<Int>()
-    private let pushToSpecificLibraryViewController = PublishSubject<Int>()
-    
-    private let showToastViewRelay = PublishRelay<Void>()
+    private let pushToUserPageFeedDetailViewControllerRelay = PublishRelay<(Int, OtherProfileEntity)>()
+    private let pushToFeedDetailViewController = PublishRelay<Int>()
+    private let pushToNovelDetailViewController = PublishRelay<Int>()
+    private let popViewControllerRelay = PublishRelay<Void>()
+    private let pushToSpecificLibraryViewController = PublishSubject<(Int,Int)>()
     private let stickyHeaderActionRelay = BehaviorRelay<Bool>(value: true)
     
     private let reloadSubject = PublishSubject<Void>()
@@ -66,23 +72,32 @@ final class MyPageViewModel: ViewModelType {
         let viewWillAppearEvent: PublishSubject<Void>
         
         let headerViewHeight: Driver<Double>
+        let resizefeedTableViewHeight: Observable<CGSize?>
         let resizeKeywordCollectionViewHeight: Observable<CGSize?>
         let scrollOffset: Driver<CGPoint>
-        let settingButtonDidTap: ControlEvent<Void>
-        let editButtonDidTap: ControlEvent<Void>
+        
+        let dropdownButtonDidTap: Observable<String>
+        let backButtonDidTap: ControlEvent<Void>
+        
         let genrePreferenceButtonDidTap: Observable<Bool>
+        let libraryButtonDidTap: Observable<Bool>
+        let feedButtonDidTap: Observable<Bool>
         let inventoryViewDidTap: Observable<UITapGestureRecognizer>
         let inventorySpecificPageViewDidTap: Observable<Int>
-        let editProfileNotification: Observable<Notification>
+        let feedDetailButtonDidTap: ControlEvent<Void>
+        let feedTableViewItemSelected: Observable<IndexPath>
+        let feedConnectedNovelViewDidTap: Observable<Int>
     }
     
     struct Output {
-        let profileData: BehaviorRelay<MyProfileEntity>
+        let isProfilePrivate: BehaviorRelay<(Bool, String)>
+        let profileData: BehaviorRelay<OtherProfileEntity>
         let updateNavigationBar: BehaviorRelay<(Bool, String)>
+        let updateStickyHeader: BehaviorRelay<(Bool)>
         
-        let pushToEditViewController: PublishRelay<MyProfileEntity>
-        let pushToSettingViewController: PublishRelay<Void>
+        let popViewController: PublishRelay<Void>
         let pushToLibraryViewController: PublishRelay<Int>
+        let pushToUserPageFeedDetailViewController: PublishRelay<(Int, OtherProfileEntity)>
         
         let bindAttractivePointsData: BehaviorRelay<[String]>
         let bindKeywordCell: BehaviorRelay<[KeywordResponse]>
@@ -93,14 +108,24 @@ final class MyPageViewModel: ViewModelType {
         let showGenreOtherView: BehaviorRelay<Bool>
         let isExistPreferneces: PublishRelay<Bool>
         
-        let showToastView: PublishRelay<Void>
-        let pushToSpecificLibraryViewController: PublishSubject<Int>
+        let bindFeedData: BehaviorRelay<[UserFeedListItem]>
+        let updateFeedTableViewHeight: PublishRelay<CGFloat>
+        let isEmptyFeed: PublishRelay<Bool>
+        let showFeedDetailButton: BehaviorSubject<Bool>
+        
+        let stickyHeaderAction: BehaviorRelay<Bool>
+        let updateButtonWithLibraryView: BehaviorRelay<Bool>
+        
+        let pushToFeedDetailViewController: Observable<Int>
+        let pushToNovelDetailViewController: Observable<Int>
+        let pushToSpecificLibraryViewController: PublishSubject<(Int, Int)>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         
         //서재 - 보관함 데이터 업데이트
         //서재 - 나머지뷰 업데이트 후 키워드컬렉션뷰 높이 업데이트
+        //피드 - 피드뷰 업데이트 후 피드테이블뷰 높이 업데이트
         Observable.merge(input.viewWillAppearEvent, reloadSubject)
             .flatMapLatest { [weak self] _ -> Observable<Void> in
                 guard let self else { return .empty() }
@@ -108,6 +133,12 @@ final class MyPageViewModel: ViewModelType {
             }
             .flatMapLatest { [weak self]  _ -> Observable<Void> in
                 guard let self else { return .empty() }
+                guard !self.isProfilePrivateRelay.value.0 else { return .empty() }
+                if self.profileId == 0 {
+                    self.profileId =  UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
+                    reloadSubject.onNext(())
+                    return .just(())
+                }
                 return Observable.concat([
                     self.updateMyPageLibraryInventoryData()
                         .map { _ in Void() },
@@ -118,12 +149,21 @@ final class MyPageViewModel: ViewModelType {
                                 .subscribe()
                                 .disposed(by: self.disposeBag)
                         })
+                        .map { _ in Void() },
+                    self.updateMyPageFeedData()
+                        .do(onNext: { [weak self] _ in
+                            guard let self else { return }
+                            self.handleFeedTableViewHeight(resizeFeedTableViewHeight: input.resizefeedTableViewHeight)
+                                .subscribe()
+                                .disposed(by: self.disposeBag)
+                        })
                         .map { _ in Void() }
                 ])
             }
             .subscribe()
             .disposed(by: disposeBag)
         
+        // 스티키 헤더 처리
         input.headerViewHeight
             .asObservable()
             .bind(with: self, onNext: { owner, height in
@@ -135,8 +175,10 @@ final class MyPageViewModel: ViewModelType {
             .asObservable()
             .map{ $0.y }
             .subscribe(with: self, onNext: { owner, scrollHeight in
-                let navigationText = StringLiterals.Navigation.Title.myPage
+                let navigationText = owner.profileDataRelay.value.nickname
+                
                 owner.updateNavigationRelay.accept((scrollHeight > 0, navigationText))
+                owner.updateStickyHeaderRelay.accept(scrollHeight > owner.stickyHeaderHeight)
             })
             .disposed(by: disposeBag)
         
@@ -148,13 +190,36 @@ final class MyPageViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
-        input.settingButtonDidTap
-            .bind(to: pushToSettingViewControllerRelay)
+        input.backButtonDidTap
+            .bind(to: popViewControllerRelay)
             .disposed(by: disposeBag)
         
-        input.editButtonDidTap
-            .map { self.profileDataRelay.value }
-            .bind(to: pushToEditViewControllerRelay)
+        input.libraryButtonDidTap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.stickyHeaderActionRelay.accept(true)
+                owner.updateButtonWithLibraryViewRelay.accept(true)
+            })
+            .disposed(by: disposeBag)
+        
+        input.feedButtonDidTap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.stickyHeaderActionRelay.accept(false)
+                owner.updateButtonWithLibraryViewRelay.accept(false)
+            })
+            .disposed(by: disposeBag)
+        
+        input.dropdownButtonDidTap
+            .filter { $0 == StringLiterals.MyPage.BlockUser.toastText }
+            .flatMapLatest { [weak self] _ -> Observable<Void> in
+                guard let self else { return .empty() }
+                return self.postBlockUser(userId: self.profileId)
+            }
+            .subscribe(with: self, onNext: { owner, _ in
+                AmplitudeManager.shared.track(AmplitudeEvent.MyPage.otherBlock)
+                let nickname = owner.profileDataRelay.value.nickname
+                NotificationCenter.default.post(name: NSNotification.Name("BlockUser"), object: nickname)
+                owner.popViewControllerRelay.accept(())
+            })
             .disposed(by: disposeBag)
         
         input.inventoryViewDidTap
@@ -163,43 +228,66 @@ final class MyPageViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
-        //토스트뷰를 위한 분기처리
-        input.editProfileNotification
+        input.feedDetailButtonDidTap
             .bind(with: self, onNext: { owner, _ in
-                self.showToastViewRelay.accept(())
+                self.pushToUserPageFeedDetailViewControllerRelay.accept((owner.profileId, owner.profileDataRelay.value))
+            })
+            .disposed(by: disposeBag)
+        
+        input.feedTableViewItemSelected
+            .bind(with: self, onNext: { owner, indexPath in
+                let feedId = self.bindFeedDataRelay.value[indexPath.row].feed.feedId
+                self.pushToFeedDetailViewController.accept(feedId)
+            })
+            .disposed(by: disposeBag)
+        
+        input.feedConnectedNovelViewDidTap
+            .bind(with: self, onNext: { owner, novelId in
+                self.pushToNovelDetailViewController.accept(novelId)
             })
             .disposed(by: disposeBag)
         
         input.inventorySpecificPageViewDidTap
             .bind(with: self, onNext: { owner, pageIndex in
-                self.pushToSpecificLibraryViewController.onNext(pageIndex)
+                self.pushToSpecificLibraryViewController.onNext((owner.profileId, pageIndex))
             })
             .disposed(by: disposeBag)
         
         return Output(
+            isProfilePrivate: self.isProfilePrivateRelay,
             profileData: self.profileDataRelay,
             updateNavigationBar: self.updateNavigationRelay,
+            updateStickyHeader: self.updateStickyHeaderRelay,
             
-            pushToEditViewController: self.pushToEditViewControllerRelay,
-            pushToSettingViewController: self.pushToSettingViewControllerRelay,
+            popViewController: self.popViewControllerRelay,
             pushToLibraryViewController: self.pushToLibraryViewControllerRelay,
+            pushToUserPageFeedDetailViewController: self.pushToUserPageFeedDetailViewControllerRelay,
             
             bindAttractivePointsData: self.bindAttractivePointsDataRelay,
             bindKeywordCell: self.bindKeywordRelay,
             updateKeywordCollectionViewHeight: self.updateKeywordCollectionViewHeightRelay,
             bindGenreData: self.bindGenreDataRelay,
             bindInventoryData: self.bindInventoryDataRelay,
+            
             showGenreOtherView: self.showGenreOtherViewRelay,
             isExistPreferneces: self.isExistPrefernecesRelay,
             
-            showToastView: self.showToastViewRelay,
+            bindFeedData: self.bindFeedDataRelay,
+            updateFeedTableViewHeight: self.updateFeedTableViewHeightRelay,
+            isEmptyFeed: self.isEmptyFeedRelay,
+            showFeedDetailButton: self.showFeedDetailButtonRelay,
+            
+            stickyHeaderAction: self.stickyHeaderActionRelay,
+            updateButtonWithLibraryView: self.updateButtonWithLibraryViewRelay,
+            pushToFeedDetailViewController: self.pushToFeedDetailViewController.asObservable(),
+            pushToNovelDetailViewController: self.pushToNovelDetailViewController.asObservable(),
             pushToSpecificLibraryViewController: pushToSpecificLibraryViewController
         )
     }
     
     // MARK: - Custom Method
     
-    private func updateNavigationRelay(_ error: Error) -> Bool {
+    private func isUnknownUserError(_ error: Error) -> Bool {
         if let networkError = error as? RxCocoaURLError {
             switch networkError {
             case .httpRequestFailed(_, let data):
@@ -218,11 +306,33 @@ final class MyPageViewModel: ViewModelType {
     }
     
     private func updateHeaderView() -> Observable<Void> {
-        return self.getProfileData()
+        return self.getOtherProfileData(userId: self.profileId)
             .do(onNext: { profileData in
-                self.profileDataRelay.accept(profileData)
+                let data = OtherProfileEntity(nickname: profileData.nickname,
+                                              intro: profileData.intro,
+                                              genrePreferences: profileData.genrePreferences,
+                                              isProfilePublic: profileData.isProfilePublic,
+                                              avatarImageURL: profileData.avatarImageURL)
+                self.profileDataRelay.accept(data)
+                self.isProfilePrivateRelay.accept((!profileData.isProfilePublic, profileData.nickname))
             })
             .map { _ in }
+            .catch { [weak self] error in
+                guard let self else { return .empty() }
+                
+                //현재 로직상 알 수 없는 유저 프로필을 확인하는 것은 불가능하지만
+                //서버에러에 대응하여 알 수 없음 프로필로 처리
+                if self.isUnknownUserError(error) {
+                    let data = OtherProfileEntity(nickname: "",
+                                                  intro: "",
+                                                  genrePreferences: [],
+                                                  isProfilePublic: true,
+                                                  avatarImageURL: nil)
+                    self.profileDataRelay.accept(data)
+                    self.isProfilePrivateRelay.accept((false, ""))
+                }
+                return .empty()
+            }
     }
     
     //서재 데이터 바인딩
@@ -286,6 +396,48 @@ final class MyPageViewModel: ViewModelType {
             }
     }
     
+    // 활동 데이터 바인딩
+    private func updateMyPageFeedData() -> Observable<Void> {
+        return getUserFeed(userId: self.profileId, lastFeedId: 0, size: 6)
+            .map { feedResult -> [UserFeedListItem] in
+                feedResult.feeds.map { feed in
+                    UserFeedListItem(
+                        feed: feed,
+                        avatarImage: self.profileDataRelay.value.avatarImageURL,
+                        nickname: self.profileDataRelay.value.nickname
+                    )
+                }
+            }
+            .do(onNext: { [weak self] feedCellData in
+                guard let self else { return }
+                
+                if feedCellData.isEmpty {
+                    self.isEmptyFeedRelay.accept(true)
+                } else {
+                    
+                    //5개까지만 활동뷰에 바인딩
+                    //5개를 초과할 경우 더보기 버튼 뜨게 함
+                    self.isEmptyFeedRelay.accept(false)
+                    let hasMoreThanFive = feedCellData.count > 5
+                    self.showFeedDetailButtonRelay.onNext(hasMoreThanFive)
+                    self.bindFeedDataRelay.accept(Array(feedCellData.prefix(5)))
+                }
+            })
+            .catch { [weak self] error in
+                self?.isEmptyFeedRelay.accept(true)
+                return .just([])
+            }
+            .map { _ in Void() }
+    }
+    
+    private func handleFeedTableViewHeight(resizeFeedTableViewHeight: Observable<CGSize?>) -> Observable<CGFloat> {
+        return resizeFeedTableViewHeight
+            .map { $0?.height ?? 0 }
+            .do(onNext: { [weak self] height in
+                self?.updateFeedTableViewHeightRelay.accept(height)
+            })
+    }
+    
     private func handleKeywordCollectionViewHeight(resizeKeywordCollectionViewHeight: Observable<CGSize?>) -> Observable<CGFloat> {
         return resizeKeywordCollectionViewHeight
             .map { $0?.height ?? 0 }
@@ -296,9 +448,8 @@ final class MyPageViewModel: ViewModelType {
     
     // MARK: - API
     
-    private func getProfileData() -> Observable<MyProfileEntity> {
-        return userRepository.userInfoRepository.getMyProfileData()
-            .observe(on: MainScheduler.instance)
+    private func getOtherProfileData(userId: Int) -> Observable<OtherProfileEntity> {
+        return userRepository.userInfoRepository.getOtherProfile(userId: userId)
     }
     
     private func getNovelPreferenceData(userId: Int) -> Observable<UserNovelPreferencesEntity> {
@@ -311,5 +462,15 @@ final class MyPageViewModel: ViewModelType {
     
     private func getInventoryData(userId: Int) -> Observable<UserNovelStatusEntity> {
         return userRepository.userInfoRepository.getUserNovelStatus(userId: userId)
+    }
+    
+    private func postBlockUser(userId: Int) -> Observable<Void> {
+        return userRepository.userBlockRepository.postBlockUser(userId: userId)
+            .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
+            .observe(on: MainScheduler.instance)
+    }
+    
+    private func getUserFeed(userId: Int, lastFeedId: Int, size: Int) -> Observable<UserFeedListEntity> {
+        return userRepository.userInfoRepository.getUserFeed(userId: userId, lastFeedId: lastFeedId, size: size)
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/MyPage/Profile/ProfileViewModel/UserPageViewModel.swift
@@ -23,11 +23,11 @@ final class UserPageViewModel: ViewModelType {
     private let updateNavigationRelay = BehaviorRelay<(Bool, String)>(value: (false, ""))
     private let updateStickyHeaderRelay = BehaviorRelay<(Bool)>(value: (false))
     private let isProfilePrivateRelay = BehaviorRelay<(Bool, String)>(value: (false, ""))
-    private let profileDataRelay = BehaviorRelay<OtherProfileEntity>(value: OtherProfileEntity(nickname: "",
-                                                                                               intro: "",
-                                                                                               genrePreferences: [],
-                                                                                               isProfilePublic: true,
-                                                                                               avatarImageURL: nil))
+    private let profileDataRelay = BehaviorRelay<UserProfileEntity>(value: UserProfileEntity(nickname: "",
+                                                                                             intro: "",
+                                                                                             genrePreferences: [],
+                                                                                             isProfilePublic: true,
+                                                                                             avatarImageURL: nil))
     private let isExistPrefernecesRelay = PublishRelay<Bool>()
     private let bindInventoryDataRelay = BehaviorRelay<UserNovelStatusEntity>(value: UserNovelStatusEntity(interestNovelCount: 0,
                                                                                                            watchingNovelCount: 0,
@@ -47,7 +47,7 @@ final class UserPageViewModel: ViewModelType {
     private let updateKeywordCollectionViewHeightRelay = PublishRelay<CGFloat>()
     
     private let pushToLibraryViewControllerRelay = PublishRelay<Int>()
-    private let pushToUserPageFeedDetailViewControllerRelay = PublishRelay<(Int, OtherProfileEntity)>()
+    private let pushToUserPageFeedDetailViewControllerRelay = PublishRelay<(Int, UserProfileEntity)>()
     private let pushToFeedDetailViewController = PublishRelay<Int>()
     private let pushToNovelDetailViewController = PublishRelay<Int>()
     private let popViewControllerRelay = PublishRelay<Void>()
@@ -60,12 +60,7 @@ final class UserPageViewModel: ViewModelType {
     
     init(userRepository: UserRepository, profileId: Int) {
         self.userRepository = userRepository
-        if profileId == 0 {
-            let userId = UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
-            self.profileId = userId
-        } else {
-            self.profileId = profileId
-        }
+        self.profileId = profileId
     }
     
     struct Input {
@@ -91,13 +86,13 @@ final class UserPageViewModel: ViewModelType {
     
     struct Output {
         let isProfilePrivate: BehaviorRelay<(Bool, String)>
-        let profileData: BehaviorRelay<OtherProfileEntity>
+        let profileData: BehaviorRelay<UserProfileEntity>
         let updateNavigationBar: BehaviorRelay<(Bool, String)>
         let updateStickyHeader: BehaviorRelay<(Bool)>
         
         let popViewController: PublishRelay<Void>
         let pushToLibraryViewController: PublishRelay<Int>
-        let pushToUserPageFeedDetailViewController: PublishRelay<(Int, OtherProfileEntity)>
+        let pushToUserPageFeedDetailViewController: PublishRelay<(Int, UserProfileEntity)>
         
         let bindAttractivePointsData: BehaviorRelay<[String]>
         let bindKeywordCell: BehaviorRelay<[KeywordResponse]>
@@ -133,12 +128,6 @@ final class UserPageViewModel: ViewModelType {
             }
             .flatMapLatest { [weak self]  _ -> Observable<Void> in
                 guard let self else { return .empty() }
-                guard !self.isProfilePrivateRelay.value.0 else { return .empty() }
-                if self.profileId == 0 {
-                    self.profileId =  UserDefaults.standard.integer(forKey: StringLiterals.UserDefault.userId)
-                    reloadSubject.onNext(())
-                    return .just(())
-                }
                 return Observable.concat([
                     self.updateMyPageLibraryInventoryData()
                         .map { _ in Void() },
@@ -217,7 +206,7 @@ final class UserPageViewModel: ViewModelType {
             .subscribe(with: self, onNext: { owner, _ in
                 AmplitudeManager.shared.track(AmplitudeEvent.MyPage.otherBlock)
                 let nickname = owner.profileDataRelay.value.nickname
-                NotificationCenter.default.post(name: NSNotification.Name("BlockUser"), object: nickname)
+                NotificationCenter.default.post(name: NotificationName.blockUser, object: nickname)
                 owner.popViewControllerRelay.accept(())
             })
             .disposed(by: disposeBag)
@@ -308,11 +297,11 @@ final class UserPageViewModel: ViewModelType {
     private func updateHeaderView() -> Observable<Void> {
         return self.getOtherProfileData(userId: self.profileId)
             .do(onNext: { profileData in
-                let data = OtherProfileEntity(nickname: profileData.nickname,
-                                              intro: profileData.intro,
-                                              genrePreferences: profileData.genrePreferences,
-                                              isProfilePublic: profileData.isProfilePublic,
-                                              avatarImageURL: profileData.avatarImageURL)
+                let data = UserProfileEntity(nickname: profileData.nickname,
+                                             intro: profileData.intro,
+                                             genrePreferences: profileData.genrePreferences,
+                                             isProfilePublic: profileData.isProfilePublic,
+                                             avatarImageURL: profileData.avatarImageURL)
                 self.profileDataRelay.accept(data)
                 self.isProfilePrivateRelay.accept((!profileData.isProfilePublic, profileData.nickname))
             })
@@ -323,11 +312,11 @@ final class UserPageViewModel: ViewModelType {
                 //현재 로직상 알 수 없는 유저 프로필을 확인하는 것은 불가능하지만
                 //서버에러에 대응하여 알 수 없음 프로필로 처리
                 if self.isUnknownUserError(error) {
-                    let data = OtherProfileEntity(nickname: "",
-                                                  intro: "",
-                                                  genrePreferences: [],
-                                                  isProfilePublic: true,
-                                                  avatarImageURL: nil)
+                    let data = UserProfileEntity(nickname: "",
+                                                 intro: "",
+                                                 genrePreferences: [],
+                                                 isProfilePublic: true,
+                                                 avatarImageURL: nil)
                     self.profileDataRelay.accept(data)
                     self.isProfilePrivateRelay.accept((false, ""))
                 }
@@ -448,7 +437,7 @@ final class UserPageViewModel: ViewModelType {
     
     // MARK: - API
     
-    private func getOtherProfileData(userId: Int) -> Observable<OtherProfileEntity> {
+    private func getOtherProfileData(userId: Int) -> Observable<UserProfileEntity> {
         return userRepository.userInfoRepository.getOtherProfile(userId: userId)
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
@@ -310,7 +310,7 @@ final class NovelDetailViewController: UIViewController {
         
         output.pushToUserViewController
             .subscribe(with: self, onNext: { owner, userId in
-                owner.pushToMyPageViewController(userId: userId)
+                owner.pushToUserPageViewController(userId: userId)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #562 
<br/>

### 🌟Motivation
피드소소 사일로에서 본인 페이지와 타인페이지의 UI 를 다르게 구현합니다.
따라서 이를 위해 본인 페이지와 타인 페이지의 로직(파일)을 분리하였습니다.
따라서 본인 마이페이지일 때는 MyPage 의 워딩을 사용하지만, 
타인 페이지거나, 본인페이지와 타인페이지에 함께 사용하는 요소들은 UserPage 의 워딩을 사용하였습니다.

> 네이밍을 고민하였는데 MyPage vs OtherPage 보다는 
> UserPage 를 기본으로 하고 본인페이지를 특별한 경우로 하여 MyPage 를 부여하는 게 낫다는 ,,, 개인적인 고민이었습니다
> 좋은 생각있으시면 또 말해주세요!

<br/>

### 🌟Key Changes

바뀐 것이 많아보이지만, 네이밍 수정이 대부분입니다.
UserPage~ 의 파일들 같은 경우 기존 MyPage 에서 본인유저 분기처리 코드만 삭제한 것이고
MyPage ~ 의 파일들도 마찬가지로 기존 MyPage  에서 타유저 분기처리 코드만 삭제한 것입니다.
<br/>

### 🌟Simulation
| 본인페이지 | 타유저페이지 | 
| -- | -- |
|![RPReplay_Final1747763700](https://github.com/user-attachments/assets/856c5ca3-1941-4a0d-a9bb-39914e6b2032)|![RPReplay_Final1747763721](https://github.com/user-attachments/assets/352a3ef1-f993-4e97-b7e7-16ea2b0bc31a)|

<br/>

### 🌟To Reviewer
#561 PR을 (브런치는 Refactor/#560) 머지 후 해당 PR 머지할 예정입니다.
MyPage~ 의 파일들 경우 다음 PR 에서 새로 구현할 예정이라 너그러운 코리 뷰탁드릴게용 🤓
<br/>

