### PR TITLE
[Fix] #574 - 상세탐색 모달 올라올 때 배경이 겹쳐 올라오는 현상 해결 

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Extensions/UIView+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIView+.swift
@@ -12,13 +12,6 @@ extension UIView {
         views.forEach { self.addSubview($0) }
     }
     
-    func roundCorners(_ corners: UIRectCorner, radius: CGFloat) {
-        let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
-        let mask = CAShapeLayer()
-        mask.path = path.cgPath
-        self.layer.mask = mask
-    }
-    
     func makeBucketImageURLString(path: String) -> String {
         let bucketURL = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.bucketURL) as? String ?? "Error"
         let scale = Int(UITraitCollection.current.displayScale)

--- a/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -207,8 +207,6 @@ extension UIViewController {
         
         viewController.modalPresentationStyle = .overFullScreen
         self.present(viewController, animated: true)
-        
-        
     }
     
     func dismissModalViewController() {

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchView.swift
@@ -47,8 +47,6 @@ final class DetailSearchView: UIView {
     }
     
     private func setUI() {
-        self.backgroundColor = .black.withAlphaComponent(0.6)
-        
         backgroundView.do {
             $0.backgroundColor = .wssWhite
         }

--- a/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchView.swift
@@ -39,16 +39,13 @@ final class DetailSearchView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        backgroundView.roundCorners([.topLeft, .topRight], radius: 15)
-    }
-    
+
     private func setUI() {
         backgroundView.do {
             $0.backgroundColor = .wssWhite
+            $0.layer.cornerRadius = 15
+            $0.layer.maskedCorners = [.layerMinXMinYCorner,
+                                      .layerMaxXMinYCorner]
         }
         
         cancelModalButton.do {


### PR DESCRIPTION
### ⭐️Issue
- close #574 
<br/>

### 🌟Motivation
- 상세탐색 모달 올라올 때 배경이 겹쳐 올라오는 현상 해결했습니다. 
- 모달 둥근 모서리 만드는 방법을 기존 extension 코드에서 `layer.maskedCorners` 프로퍼티로 변경했습니다. 
<br/>

### 🌟Key Changes
#### 문제상황
상새 탐색뷰는 모달 형태로 보여져야 하기 떄문에 `presentModalViewController`라는 함수에 담겨 호출됩니다.
아래 코드를 보면 이미 모달 함수 내 배경색을 정의해주기 때문에 추가적인 배경색을 적용할 필요가 없었습니다.

#### 해결
`DetailSearchView` UI 내 배경색을 정의하는 코드가 있어 모달이 올라올 때 배경이 겹쳐 보이는 현상이 발생했습니다.
해당 코드를 삭제하여 문제 해결했습니다. 
```swift
func presentModalViewController(_ viewController: UIViewController) {
        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
              let window = windowScene.windows.first else { return }
        
        let blackOverlayView = UIView(frame: window.bounds).then {
            $0.backgroundColor = UIColor.black.withAlphaComponent(0)
            $0.tag = 999
        }
        
        window.addSubview(blackOverlayView)
        
        blackOverlayView.snp.makeConstraints {
            $0.edges.equalToSuperview()
        }
        
        UIView.animate(withDuration: 0.3) {
            blackOverlayView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
        }
        
        viewController.modalPresentationStyle = .overFullScreen
        self.present(viewController, animated: true)
    }
```
https://github.com/user-attachments/assets/faa6afcd-de6d-4d83-838e-5b3d3e3c7968


<br/>


### 🌟Simulation
https://github.com/user-attachments/assets/b3dc38d7-2059-4910-a844-61bd394265f9


<br/>

### 🌟To Reviewer
나기 감사 👍
<br/>

### 🌟Reference

<br/>
