### PR TITLE
[Feat] #571 - 피드 이미지 업로드 기능 구현 마무리

### DIFF
--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -80,54 +80,62 @@ extension Networking {
         return String(format: "%.2fMB", Double(bytes) / (1024.0 * 1024.0))
     }
     
+    // 병렬 처리
     func compressImages(_ images: [UIImage],
                         maxImageSize: Int = MultipartConstants.maxImageSize) -> [Data] {
-        // 압축된 이미지 파일 배열
-        var compressedDatas: [Data] = []
+        var compressedDatas = Array<Data?>(repeating: nil, count: images.count)
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "image.compress.queue", attributes: .concurrent)
         
         for (index, image) in images.enumerated() {
-            
-            // 이미지 압축 품질 설정
-            var quality: CGFloat = 1.0
-            
-            // 이미지 기본 해상도 설정
-            var scale: CGFloat = 0.7
-            
-            // HEIC 파일 타입 기본 해상도 설정 - 0.5
-            if let cgImageSource = CGImageSourceCreateWithData(image.pngData()! as CFData, nil),
-               let utiString = CGImageSourceGetType(cgImageSource) as String?,
-               let utType = UTType(utiString),
-               utType.conforms(to: .heic) {
-                scale = 0.5
-                print("🧾 이미지 \(index) HEIC 포맷으로 감지 → 초기 해상도 0.5 적용")
-            }
-            
-            var data: Data? = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-            print("🖼️ 이미지 \(index) 초기 해상도 \(String(format: "%.2f", scale)) 적용 → 크기: \(formatBytesToMB(data?.count ?? 0))")
-            
-            while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
-                if quality > 0.2 {
-                    quality -= 0.1
-                } else {
-                    scale -= 0.1
-                    if let resizedImage = image.resizedImage(to: scale) {
-                        data = resizedImage.jpegData(compressionQuality: quality)
-                    }
-                    continue
-                }
-                data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-                print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
-            }
-            
-            if let data = data, data.count <= maxImageSize {
-                print("✅ 이미지 \(index) 최종 해상도 \(String(format: "%.2f", scale)), 품질 \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data.count))")
-                compressedDatas.append(data)
-            } else {
-                print("❌ 이미지 \(index) 압축 실패 또는 제한 초과, 빈 데이터 추가")
-                compressedDatas.append(Data())
+            group.enter()
+            queue.async {
+                let compressedData = compressImage(image, index: index, maxImageSize: maxImageSize)
+                compressedDatas[index] = compressedData
+                group.leave()
             }
         }
         
-        return compressedDatas
+        group.wait()
+        
+        return compressedDatas.map { $0 ?? Data() }
+    }
+    
+    private func compressImage(_ image: UIImage, index: Int, maxImageSize: Int) -> Data {
+        var quality: CGFloat = 1.0
+        var scale: CGFloat = 0.7
+        
+        if let cgImageSource = CGImageSourceCreateWithData(image.pngData()! as CFData, nil),
+           let utiString = CGImageSourceGetType(cgImageSource) as String?,
+           let utType = UTType(utiString),
+           utType.conforms(to: .heic) {
+            scale = 0.5
+            print("🧾 이미지 \(index) HEIC 포맷으로 감지 → 초기 해상도 0.5 적용")
+        }
+        
+        var data: Data? = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
+        print("🖼️ 이미지 \(index) 초기 해상도 \(String(format: "%.2f", scale)) 적용 → 크기: \(formatBytesToMB(data?.count ?? 0))")
+        
+        while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
+            if quality > 0.2 {
+                quality -= 0.1
+            } else {
+                scale -= 0.1
+                if let resizedImage = image.resizedImage(to: scale) {
+                    data = resizedImage.jpegData(compressionQuality: quality)
+                }
+                continue
+            }
+            data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
+            print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
+        }
+        
+        if let data = data, data.count <= maxImageSize {
+            print("✅ 이미지 \(index) 최종 해상도 \(String(format: "%.2f", scale)), 품질 \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data.count))")
+            return data
+        } else {
+            print("❌ 이미지 \(index) 압축 실패 또는 제한 초과, 빈 데이터 추가")
+            return Data()
+        }
     }
 }

--- a/WSSiOS/WSSiOS/Resource/Helper/KingFisherRxHelper.swift
+++ b/WSSiOS/WSSiOS/Resource/Helper/KingFisherRxHelper.swift
@@ -56,4 +56,28 @@ final class KingFisherRxHelper {
             }
         }
     }
+    
+    static func kingFisherImage(url: URL?) -> Observable<UIImage> {
+        return Observable.create { observer in
+            
+            guard let imageURL = url else {
+                observer.onError(NetworkServiceError.invalidURLError)
+                return Disposables.create()
+            }
+            
+            let task = KingfisherManager.shared.retrieveImage(with: imageURL) { result in
+                switch result {
+                case .success(let imageResult):
+                    observer.onNext(imageResult.image)
+                    observer.onCompleted()
+                case .failure(let error):
+                    observer.onError(error)
+                }
+            }
+            
+            return Disposables.create {
+                task?.cancel()
+            }
+        }
+    }
 }

--- a/WSSiOS/WSSiOS/Resource/Helper/PhotoPickerManager.swift
+++ b/WSSiOS/WSSiOS/Resource/Helper/PhotoPickerManager.swift
@@ -5,22 +5,29 @@
 //  Created by Seoyeon Choi on 5/12/25.
 //
 
+import RxSwift
+import RxRelay
 import PhotosUI
 
 final class PhotoPickerManager: NSObject {
     private weak var presentingViewController: UIViewController?
-    var didSelectImages: (([UIImage]) -> Void)?
+    private let pickerSubject = PublishSubject<[UIImage]>()
+    
+    var selectedImages: Observable<[UIImage]> {
+        return pickerSubject.asObservable()
+    }
+    
     let maximumImageCount = FeedEdit.imageMaxCount
     
     init(presentingViewController: UIViewController) {
         self.presentingViewController = presentingViewController
     }
-
+    
     func presentPicker() {
         var config = PHPickerConfiguration()
         config.selectionLimit = self.maximumImageCount
         config.filter = .images
-
+        
         let picker = PHPickerViewController(configuration: config)
         picker.delegate = self
         presentingViewController?.present(picker, animated: true)
@@ -31,12 +38,12 @@ extension PhotoPickerManager: PHPickerViewControllerDelegate {
     // 사용자가 사진을 선택한 후 실행되는 델리게이트 메소드
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
-
+        
         let itemProviders = results.map { $0.itemProvider }
-
+        
         var images: [UIImage] = []
         let group = DispatchGroup()
-
+        
         for provider in itemProviders {
             if provider.canLoadObject(ofClass: UIImage.self) {
                 group.enter()
@@ -48,9 +55,9 @@ extension PhotoPickerManager: PHPickerViewControllerDelegate {
                 }
             }
         }
-
+        
         group.notify(queue: .main) { [weak self] in
-            self?.didSelectImages?(images)
+            self?.pickerSubject.onNext(images)
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
@@ -42,10 +42,8 @@ extension FeedResponse {
         let userProfileImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
         let hasImage = self.images.count > 0
         let imageCount = self.images.count
-        //let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeImageURLString(path: $0) }
-        // 테스트용 코드 -> 머지 시 삭제 예정
-        let imageURLs: [URL?] = self.images.map { URL(string: $0)! }
-        
+        let imageURLs: [URL?] = self.images.map { KingFisherRxHelper.makeImageURLString(path: $0) }
+
         //novelID 여부로 novelData 바인딩
         let hasLinkedNovel = self.novelId != nil
         let novelData = makeFeedNovelData()

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSToggleButton.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSToggleButton.swift
@@ -18,7 +18,7 @@ final class WSSToggleButton: UIButton {
     
     // 상태별 스위치 배경 색상
     private let onColor = UIColor.wssPrimary100
-    private let offColor = UIColor.wssGray70
+    private let offColor = UIColor.wssGray100
     
     // 스위치가 이동하는 애니메이션 시간
     private var animationDuration: TimeInterval = 0.20

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditAddImageView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditAddImageView.swift
@@ -35,8 +35,6 @@ final class FeedEditAddImageView: UIView {
     //MARK: - UI
     
     private func setUI() {
-        self.backgroundColor = .wssSecondary50
-        
         addImageCollectionViewLayout.do {
             $0.scrollDirection = .horizontal
             $0.itemSize = CGSize(width: 100, height: 100)

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
@@ -151,4 +151,8 @@ final class FeedEditView: UIView {
     func showloadingView(isLoading: Bool) {
         loadingView.isHidden = !isLoading
     }
+    
+    func enableBackButton(isEnabled: Bool) {
+        backButton.isEnabled = isEnabled
+    }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
@@ -31,6 +31,9 @@ final class FeedEditView: UIView {
     let feedEditNovelConnectView = FeedEditNovelConnectView()
     let feedEditConnectedNovelView = FeedEditConnectedNovelView()
     
+    // 업로드 로딩
+    private let loadingView = WSSLoadingView()
+    
     //MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -81,12 +84,19 @@ final class FeedEditView: UIView {
             $0.axis = .vertical
             $0.spacing = 12
         }
+        
+        loadingView.do {
+            $0.isHidden = true
+        }
     }
     
     private func setHierarchy() {
         self.addSubviews(feedEditPrivateSettingView,
-                         scrollView)
+                         scrollView,
+                         loadingView)
+        
         scrollView.addSubview(stackView)
+        
         stackView.addArrangedSubviews(feedEditCategoryView,
                                       feedEditContentView,
                                       feedEditAddImageView,
@@ -105,6 +115,10 @@ final class FeedEditView: UIView {
             $0.top.equalTo(feedEditPrivateSettingView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(30)
+        }
+        
+        loadingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         stackView.snp.makeConstraints {
@@ -132,5 +146,9 @@ final class FeedEditView: UIView {
             $0.setButtonAttributedTitle(text: StringLiterals.FeedEdit.complete, font: .Title2, color: isAbled ? .wssPrimary100 : .wssGray200)
             $0.isEnabled = isAbled
         }
+    }
+    
+    func showloadingView(isLoading: Bool) {
+        loadingView.isHidden = !isLoading
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
@@ -12,12 +12,14 @@ import Then
 import RxSwift
 
 protocol FeedAddImageCollectionDelegate: AnyObject {
-    func cancelButtonDidTap()
+    func cancelButtonDidTap(at indexPath: IndexPath)
 }
 
 final class FeedAddImageCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
+    
+    var indexPath: IndexPath?
     
     private let disposeBag = DisposeBag()
     weak var delegate: FeedAddImageCollectionDelegate?
@@ -78,7 +80,9 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
     private func bindAction() {
         cancelButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
-                owner.delegate?.cancelButtonDidTap()
+                if let indexPath = owner.indexPath {
+                    owner.delegate?.cancelButtonDidTap(at: indexPath)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
@@ -11,18 +11,11 @@ import SnapKit
 import Then
 import RxSwift
 
-protocol FeedAddImageCollectionDelegate: AnyObject {
-    func cancelButtonDidTap(at indexPath: IndexPath)
-}
-
 final class FeedAddImageCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
-    
-    var indexPath: IndexPath?
-    
+
     private let disposeBag = DisposeBag()
-    weak var delegate: FeedAddImageCollectionDelegate?
     
     //MARK: - Components
     
@@ -37,8 +30,6 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
         setUI()
         setHierarchy()
         setLayout()
-        
-        bindAction()
     }
     
     required init?(coder: NSCoder) {
@@ -73,18 +64,6 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
             $0.size.equalTo(38)
             $0.top.trailing.equalToSuperview()
         }
-    }
-    
-    //MARK: - Bind
-    
-    private func bindAction() {
-        cancelButton.rx.tap
-            .subscribe(with: self, onNext: { owner, _ in
-                if let indexPath = owner.indexPath {
-                    owner.delegate?.cancelButtonDidTap(at: indexPath)
-                }
-            })
-            .disposed(by: disposeBag)
     }
     
     //MARK: - Data

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewCell/FeedAddImageCollectionViewCell.swift
@@ -14,7 +14,9 @@ import RxSwift
 final class FeedAddImageCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
-
+    
+    var cancelButtonTapped: (() -> Void)?
+    
     private let disposeBag = DisposeBag()
     
     //MARK: - Components
@@ -30,6 +32,8 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
         setUI()
         setHierarchy()
         setLayout()
+        
+        bindAction()
     }
     
     required init?(coder: NSCoder) {
@@ -43,6 +47,7 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
             $0.layer.cornerRadius = 8
             $0.clipsToBounds = true
             $0.contentMode = .scaleAspectFill
+            $0.isUserInteractionEnabled = true
         }
         
         cancelButton.do {
@@ -70,5 +75,15 @@ final class FeedAddImageCollectionViewCell: UICollectionViewCell {
     
     func bindData(image: UIImage) {
         feedImageView.image = image
+    }
+    
+    //MARK: - Custom Method
+    
+    private func bindAction() {
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+    }
+    
+    @objc private func cancelTapped() {
+        cancelButtonTapped?()
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -274,6 +274,13 @@ final class FeedEditViewController: UIViewController {
                     cell.bindData(image: element)
                 }
                 .disposed(by: disposeBag)
+        
+        output.showLoadingView
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, isShow in
+                owner.rootView.showloadingView(isLoading: isShow)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -61,8 +61,6 @@ final class FeedEditViewController: UIViewController {
         viewDidLoadEvent.accept(())
         
         AmplitudeManager.shared.track(AmplitudeEvent.Feed.write)
-        
-        rootView.showAddImages(hasImage: false)
     }
     
     //MARK: - UI
@@ -260,10 +258,10 @@ final class FeedEditViewController: UIViewController {
         feedEditViewModel.selectedImages
             .bind(to: rootView.feedEditAddImageView.addImageCollectionView.rx.items(
                 cellIdentifier: FeedAddImageCollectionViewCell.cellIdentifier,
-                cellType: FeedAddImageCollectionViewCell.self)) { indexPath, element, cell in
+                cellType: FeedAddImageCollectionViewCell.self)) { item, element, cell in
                     cell.bindData(image: element)
-            }
-            .disposed(by: disposeBag)
+                }
+                .disposed(by: disposeBag)
     }
     
     // MARK: - Custom Method
@@ -309,18 +307,6 @@ extension FeedEditViewController: UICollectionViewDelegateFlowLayout {
         } else {
             // 이외: 첨부 이미지 컬렉션뷰에 대한 셀 사이즈 지정
             return CGSize(width: 100, height: 100)
-        }
-    }
-}
-
-extension FeedEditViewController: FeedAddImageCollectionDelegate {
-    func cancelButtonDidTap(at indexPath: IndexPath) {
-        var currentImages = feedEditViewModel.selectedImages.value
-        currentImages.remove(at: indexPath.item)
-        feedEditViewModel.selectedImages.accept(currentImages)
-        print("\(indexPath) 클릭..")
-        rootView.feedEditAddImageView.addImageCollectionView.performBatchUpdates {
-            rootView.feedEditAddImageView.addImageCollectionView.deleteItems(at: [indexPath])
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -272,6 +272,18 @@ final class FeedEditViewController: UIViewController {
                 cellIdentifier: FeedAddImageCollectionViewCell.cellIdentifier,
                 cellType: FeedAddImageCollectionViewCell.self)) { item, element, cell in
                     cell.bindData(image: element)
+                    
+                    cell.cancelButtonTapped = {
+                        var currentImages = self.feedEditViewModel.selectedImages.value
+                        guard item < currentImages.count else { return }
+                        
+                        currentImages.remove(at: item)
+                        self.feedEditViewModel.selectedImages.accept(currentImages)
+                        
+                        DispatchQueue.main.async {
+                            self.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
+                        }
+                    }
                 }
                 .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -261,6 +261,12 @@ final class FeedEditViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        output.showAddImageView
+            .subscribe(with: self, onNext: { owner, isShow in
+                owner.rootView.showAddImages(hasImage: isShow)
+            })
+            .disposed(by: disposeBag)
+        
         output.selectedImages
             .bind(to: rootView.feedEditAddImageView.addImageCollectionView.rx.items(
                 cellIdentifier: FeedAddImageCollectionViewCell.cellIdentifier,

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -233,31 +233,34 @@ final class FeedEditViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.presentPhotoPicker
-            .subscribe(with: self, onNext: { owner, _ in
-                let manager = PhotoPickerManager(presentingViewController: owner)
-                owner.photoPickerManager = manager
+            .flatMapLatest { [weak self] _ -> Observable<(newImages: [UIImage], currentImages: [UIImage])> in
+                guard let self = self else { return .empty() }
                 
+                let manager = PhotoPickerManager(presentingViewController: self)
+                self.photoPickerManager = manager
+                
+                let selected: Observable<(newImages: [UIImage], currentImages: [UIImage])> =
                 manager.selectedImages
                     .withLatestFrom(output.selectedImages) { newImages, currentImages in
-                        return (newImages, currentImages)
+                        return (newImages: newImages, currentImages: currentImages)
                     }
-                    .observe(on: MainScheduler.instance)
-                    .subscribe(with: owner, onNext: { owner, data in
-                        let (newImages, currentImages) = data
-                        
-                        if currentImages.count + newImages.count > owner.maximumImageCount {
-                            owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
-                            return
-                        }
-                        
-                        let updatedImages = currentImages + newImages
-                        owner.feedEditViewModel.selectedImages.accept(updatedImages)
-                        owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
-                        owner.rootView.showAddImages(hasImage: !updatedImages.isEmpty)
-                    })
-                    .disposed(by: owner.disposeBag)
                 
                 manager.presentPicker()
+                return selected
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, data in
+                let (newImages, currentImages) = data
+                
+                if currentImages.count + newImages.count > owner.maximumImageCount {
+                    owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
+                    return
+                }
+                
+                let updatedImages = currentImages + newImages
+                owner.feedEditViewModel.selectedImages.accept(updatedImages)
+                owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
+                owner.rootView.showAddImages(hasImage: !updatedImages.isEmpty)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -102,10 +102,6 @@ final class FeedEditViewController: UIViewController {
         rootView.feedEditAddImageView.addImageCollectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
-        
-        rootView.feedEditAddImageView.addImageCollectionView.rx
-            .setDataSource(self)
-            .disposed(by: disposeBag)
     }
     
     private func bindViewModel() {
@@ -240,21 +236,33 @@ final class FeedEditViewController: UIViewController {
         
         output.presentPhotoPicker
             .subscribe(with: self, onNext: { owner, _ in
-                owner.photoPickerManager = PhotoPickerManager(presentingViewController: owner)
-                owner.photoPickerManager?.didSelectImages = { newImages in
-                    var currentImages = owner.feedEditViewModel.selectedImages.value
-                    if currentImages.count + newImages.count > owner.maximumImageCount {
-                        owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
-                        return
-                    }
-                    currentImages.append(contentsOf: newImages)
-                    owner.feedEditViewModel.selectedImages.accept(currentImages)
-
-                    owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
-                    owner.rootView.showAddImages(hasImage: currentImages.count > 0)
-                }
-                owner.photoPickerManager?.presentPicker()
+                let manager = PhotoPickerManager(presentingViewController: owner)
+                owner.photoPickerManager = manager
+                manager.selectedImages
+                    .observe(on: MainScheduler.instance)
+                    .subscribe(with: owner, onNext: { owner, newImages in
+                        var currentImages = owner.feedEditViewModel.selectedImages.value
+                        if currentImages.count + newImages.count > owner.maximumImageCount {
+                            owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
+                            return
+                        }
+                        currentImages.append(contentsOf: newImages)
+                        owner.feedEditViewModel.selectedImages.accept(currentImages)
+                        owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
+                        owner.rootView.showAddImages(hasImage: currentImages.count > 0)
+                    })
+                    .disposed(by: owner.disposeBag)
+                
+                manager.presentPicker()
             })
+            .disposed(by: disposeBag)
+        
+        feedEditViewModel.selectedImages
+            .bind(to: rootView.feedEditAddImageView.addImageCollectionView.rx.items(
+                cellIdentifier: FeedAddImageCollectionViewCell.cellIdentifier,
+                cellType: FeedAddImageCollectionViewCell.self)) { indexPath, element, cell in
+                    cell.bindData(image: element)
+            }
             .disposed(by: disposeBag)
     }
     
@@ -287,6 +295,7 @@ final class FeedEditViewController: UIViewController {
 extension FeedEditViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == rootView.feedEditCategoryView.categoryCollectionView {
+            // 카테고리 컬렉션뷰에 대한 셀 사이즈 지정
             var text: String?
             
             text = self.feedEditViewModel.relevantCategoryList[indexPath.item].withKorean
@@ -298,27 +307,20 @@ extension FeedEditViewController: UICollectionViewDelegateFlowLayout {
             let width = (unwrappedText as NSString).size(withAttributes: [NSAttributedString.Key.font: UIFont.Body2]).width + 26
             return CGSize(width: width, height: 35)
         } else {
+            // 이외: 첨부 이미지 컬렉션뷰에 대한 셀 사이즈 지정
             return CGSize(width: 100, height: 100)
         }
     }
 }
 
-extension FeedEditViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return feedEditViewModel.selectedImages.value.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeedAddImageCollectionViewCell.cellIdentifier, for: indexPath) as? FeedAddImageCollectionViewCell else {
-            return UICollectionViewCell()
-        }
-        cell.bindData(image: feedEditViewModel.selectedImages.value[indexPath.item])
-        return cell
-    }
-}
-
 extension FeedEditViewController: FeedAddImageCollectionDelegate {
-    func cancelButtonDidTap() {
-        
+    func cancelButtonDidTap(at indexPath: IndexPath) {
+        var currentImages = feedEditViewModel.selectedImages.value
+        currentImages.remove(at: indexPath.item)
+        feedEditViewModel.selectedImages.accept(currentImages)
+        print("\(indexPath) 클릭..")
+        rootView.feedEditAddImageView.addImageCollectionView.performBatchUpdates {
+            rootView.feedEditAddImageView.addImageCollectionView.deleteItems(at: [indexPath])
+        }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -236,18 +236,24 @@ final class FeedEditViewController: UIViewController {
             .subscribe(with: self, onNext: { owner, _ in
                 let manager = PhotoPickerManager(presentingViewController: owner)
                 owner.photoPickerManager = manager
+                
                 manager.selectedImages
+                    .withLatestFrom(output.selectedImages) { newImages, currentImages in
+                        return (newImages, currentImages)
+                    }
                     .observe(on: MainScheduler.instance)
-                    .subscribe(with: owner, onNext: { owner, newImages in
-                        var currentImages = owner.feedEditViewModel.selectedImages.value
+                    .subscribe(with: owner, onNext: { owner, data in
+                        let (newImages, currentImages) = data
+                        
                         if currentImages.count + newImages.count > owner.maximumImageCount {
                             owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
                             return
                         }
-                        currentImages.append(contentsOf: newImages)
-                        owner.feedEditViewModel.selectedImages.accept(currentImages)
+                        
+                        let updatedImages = currentImages + newImages
+                        owner.feedEditViewModel.selectedImages.accept(updatedImages)
                         owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
-                        owner.rootView.showAddImages(hasImage: currentImages.count > 0)
+                        owner.rootView.showAddImages(hasImage: !updatedImages.isEmpty)
                     })
                     .disposed(by: owner.disposeBag)
                 
@@ -255,7 +261,7 @@ final class FeedEditViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        feedEditViewModel.selectedImages
+        output.selectedImages
             .bind(to: rootView.feedEditAddImageView.addImageCollectionView.rx.items(
                 cellIdentifier: FeedAddImageCollectionViewCell.cellIdentifier,
                 cellType: FeedAddImageCollectionViewCell.self)) { item, element, cell in

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -296,6 +296,12 @@ final class FeedEditViewController: UIViewController {
                 owner.rootView.showloadingView(isLoading: isShow)
             })
             .disposed(by: disposeBag)
+        
+        output.backButtonIsAbled
+            .subscribe(with: self, onNext: { owner, isAbled in
+                owner.rootView.enableBackButton(isEnabled: isAbled)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -133,6 +133,19 @@ final class FeedEditViewModel: ViewModelType {
                 
                 owner.initialIsPublic = data.isPublic
                 owner.isPublic.accept(data.isPublic)
+                
+                Observable.from(data.imageURLs)
+                    .compactMap { $0 }
+                    .flatMap { url -> Observable<UIImage> in
+                        KingFisherRxHelper.kingFisherImage(url: url)
+                            .catchAndReturn(UIImage())
+                    }
+                    .toArray()
+                    .observe(on: MainScheduler.instance)
+                    .subscribe(onSuccess: { images in
+                        owner.selectedImages.accept(images)
+                    })
+                    .disposed(by: disposeBag)
             }, onError: { owner, error in
                 print(error)
             })

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -33,11 +33,13 @@ final class FeedEditViewModel: ViewModelType {
     private var initialIsSpoiler: Bool?
     private var initialIsPublic: Bool?
     private var initialNovelId: Int?
+    private var initialAddImages: [UIImage]?
     private var isRelevantCategoriesChanged: Bool = false
     private var isFeedContentChanged: Bool = false
     private var isSpoilerChanged: Bool = false
     private var isPublicChanged: Bool = false
     private var isNovelIdChanged: Bool = false
+    private var isAddImagesChanged: Bool = false
     
     // Output
     private let endEditing = PublishRelay<Bool>()
@@ -144,8 +146,10 @@ final class FeedEditViewModel: ViewModelType {
                     .observe(on: MainScheduler.instance)
                     .subscribe(onSuccess: { images in
                         owner.selectedImages.accept(images)
+                        owner.initialAddImages = images
                     })
                     .disposed(by: disposeBag)
+                
             }, onError: { owner, error in
                 print(error)
             })
@@ -290,6 +294,15 @@ final class FeedEditViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        self.selectedImages
+            .skip(1)
+            .subscribe(with: self, onNext: { owner, images in
+                guard let initialImages = owner.initialAddImages else { return }
+                owner.isAddImagesChanged = initialImages != images
+                owner.checkIfCompleteButtonIsAbled()
+            })
+            .disposed(by: disposeBag)
+        
         return Output(endEditing: endEditing.asObservable(),
                       categoryListData: categoryListData.asObservable(),
                       popViewController: popViewController.asObservable(),
@@ -310,7 +323,7 @@ final class FeedEditViewModel: ViewModelType {
     // MARK: - Custom Method
     
     func isInitialFeedChanged() -> Bool {
-        return feedId != nil ? isRelevantCategoriesChanged || isFeedContentChanged || isSpoilerChanged || isPublicChanged || isNovelIdChanged : true
+        return feedId != nil ? isRelevantCategoriesChanged || isFeedContentChanged || isSpoilerChanged || isPublicChanged || isNovelIdChanged || isAddImagesChanged : true
     }
     
     func checkIfCompleteButtonIsAbled() {

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -57,6 +57,7 @@ final class FeedEditViewModel: ViewModelType {
     private let showStopEditingAlert = PublishRelay<Void>()
     private let presentPhotoPicker = PublishRelay<Void>()
     private let showAddImageView = PublishRelay<Bool>()
+    private let showLoadingView = PublishRelay<Bool>()
     var selectedImages = BehaviorRelay<[UIImage]>(value: [])
     
     //MARK: - Life Cycle
@@ -113,6 +114,7 @@ final class FeedEditViewModel: ViewModelType {
         let presentPhotoPicker: Observable<Void>
         let showAddImageView: Observable<Bool>
         let selectedImages: Observable<[UIImage]>
+        let showLoadingView: Observable<Bool>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -184,6 +186,7 @@ final class FeedEditViewModel: ViewModelType {
         input.completeButtonDidTap
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .do(onNext: { _ in
+                self.showLoadingView.accept(true)
                 AmplitudeManager.shared.track(AmplitudeEvent.Feed.writeFeed)
             })
             .withLatestFrom(Observable.combineLatest(isSpoiler, isPublic, selectedImages))
@@ -195,6 +198,7 @@ final class FeedEditViewModel: ViewModelType {
                 }
             }
             .subscribe(with: self, onNext: { owner, _ in
+                owner.showLoadingView.accept(false)
                 NotificationCenter.default.post(name: NotificationName.feedEdited, object: nil)
                 owner.popViewController.accept(())
             }, onError: { owner, error  in
@@ -331,7 +335,8 @@ final class FeedEditViewModel: ViewModelType {
                       showStopEditingAlert: showStopEditingAlert.asObservable(),
                       presentPhotoPicker: presentPhotoPicker.asObservable(),
                       showAddImageView: showAddImageView.asObservable(),
-                      selectedImages: selectedImages.asObservable())
+                      selectedImages: selectedImages.asObservable(),
+                      showLoadingView: showLoadingView.asObservable())
     }
     
     // MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -181,16 +181,20 @@ final class FeedEditViewModel: ViewModelType {
         input.completeButtonDidTap
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .do(onNext: { _ in
+                self.completeButtonIsAbled.accept(false)
                 self.showLoadingView.accept(true)
                 AmplitudeManager.shared.track(AmplitudeEvent.Feed.writeFeed)
             })
             .withLatestFrom(Observable.combineLatest(isSpoiler, isPublic, selectedImages))
             .flatMapLatest { (isSpoiler, isPublic, selectedImages) in
-                if let feedId = self.feedId {
-                    self.putFeed(feedId: feedId, relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
-                } else {
-                    self.postFeed(relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
+                Observable.deferred {
+                    if let feedId = self.feedId {
+                        self.putFeed(feedId: feedId, relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
+                    } else {
+                        self.postFeed(relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
+                    }
                 }
+                .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
             }
             .subscribe(with: self, onNext: { owner, _ in
                 owner.showLoadingView.accept(false)

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -58,6 +58,7 @@ final class FeedEditViewModel: ViewModelType {
     private let presentPhotoPicker = PublishRelay<Void>()
     private let showAddImageView = PublishRelay<Bool>()
     private let showLoadingView = PublishRelay<Bool>()
+    private let backButtonIsAbled = BehaviorRelay<Bool>(value: false)
     var selectedImages = BehaviorRelay<[UIImage]>(value: [])
     
     //MARK: - Life Cycle
@@ -115,6 +116,7 @@ final class FeedEditViewModel: ViewModelType {
         let showAddImageView: Observable<Bool>
         let selectedImages: Observable<[UIImage]>
         let showLoadingView: Observable<Bool>
+        let backButtonIsAbled: Observable<Bool>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -182,6 +184,7 @@ final class FeedEditViewModel: ViewModelType {
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .do(onNext: { _ in
                 self.completeButtonIsAbled.accept(false)
+                self.backButtonIsAbled.accept(false)
                 self.showLoadingView.accept(true)
                 AmplitudeManager.shared.track(AmplitudeEvent.Feed.writeFeed)
             })
@@ -198,6 +201,7 @@ final class FeedEditViewModel: ViewModelType {
             }
             .subscribe(with: self, onNext: { owner, _ in
                 owner.showLoadingView.accept(false)
+                owner.backButtonIsAbled.accept(true)
                 NotificationCenter.default.post(name: NotificationName.feedEdited, object: nil)
                 owner.popViewController.accept(())
             }, onError: { owner, error  in
@@ -339,7 +343,8 @@ final class FeedEditViewModel: ViewModelType {
                       presentPhotoPicker: presentPhotoPicker.asObservable(),
                       showAddImageView: showAddImageView,
                       selectedImages: selectedImages.asObservable(),
-                      showLoadingView: showLoadingView.asObservable())
+                      showLoadingView: showLoadingView.asObservable(),
+                      backButtonIsAbled: backButtonIsAbled.asObservable())
     }
     
     // MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -128,10 +128,7 @@ final class FeedEditViewModel: ViewModelType {
                 }
             }
             .subscribe(with: self, onNext: { owner, data in
-                guard let data = data else {
-                    owner.showAddImageView.accept(false)
-                    return
-                }
+                guard let data = data else { return }
                 
                 owner.initialRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
                 owner.newRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
@@ -148,8 +145,6 @@ final class FeedEditViewModel: ViewModelType {
                 
                 owner.initialIsPublic = data.isPublic
                 owner.isPublic.accept(data.isPublic)
-                
-                owner.showAddImageView.accept(!data.imageURLs.isEmpty)
                 
                 Observable.from(data.imageURLs)
                     .compactMap { $0 }
@@ -320,6 +315,10 @@ final class FeedEditViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        let showAddImageView = self.selectedImages
+            .map { !$0.isEmpty }
+            .distinctUntilChanged()
+        
         return Output(endEditing: endEditing.asObservable(),
                       categoryListData: categoryListData.asObservable(),
                       popViewController: popViewController.asObservable(),
@@ -334,7 +333,7 @@ final class FeedEditViewModel: ViewModelType {
                       showAlreadyConnectedToast: showAlreadyConnectedToast.asObservable(),
                       showStopEditingAlert: showStopEditingAlert.asObservable(),
                       presentPhotoPicker: presentPhotoPicker.asObservable(),
-                      showAddImageView: showAddImageView.asObservable(),
+                      showAddImageView: showAddImageView,
                       selectedImages: selectedImages.asObservable(),
                       showLoadingView: showLoadingView.asObservable())
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -56,6 +56,7 @@ final class FeedEditViewModel: ViewModelType {
     private let showAlreadyConnectedToast = PublishRelay<Void>()
     private let showStopEditingAlert = PublishRelay<Void>()
     private let presentPhotoPicker = PublishRelay<Void>()
+    private let showAddImageView = PublishRelay<Bool>()
     var selectedImages = BehaviorRelay<[UIImage]>(value: [])
     
     //MARK: - Life Cycle
@@ -110,16 +111,26 @@ final class FeedEditViewModel: ViewModelType {
         let showAlreadyConnectedToast: Observable<Void>
         let showStopEditingAlert: Observable<Void>
         let presentPhotoPicker: Observable<Void>
+        let showAddImageView: Observable<Bool>
         let selectedImages: Observable<[UIImage]>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         input.viewDidLoadEvent
-            .compactMap { [weak self] in self?.feedId }
-            .flatMapLatest { feedId in
-                self.getSingleFeed(feedId)
+            .map { [weak self] in self?.feedId }
+            .flatMapLatest { feedId -> Observable<FeedEntity?> in
+                if let feedId = feedId {
+                    return self.getSingleFeed(feedId).map { Optional($0) }
+                } else {
+                    return Observable.just(nil)
+                }
             }
             .subscribe(with: self, onNext: { owner, data in
+                guard let data = data else {
+                    owner.showAddImageView.accept(false)
+                    return
+                }
+                
                 owner.initialRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
                 owner.newRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
                 owner.categoryListData.accept(self.relevantCategoryList)
@@ -135,6 +146,8 @@ final class FeedEditViewModel: ViewModelType {
                 
                 owner.initialIsPublic = data.isPublic
                 owner.isPublic.accept(data.isPublic)
+                
+                owner.showAddImageView.accept(!data.imageURLs.isEmpty)
                 
                 Observable.from(data.imageURLs)
                     .compactMap { $0 }
@@ -317,6 +330,7 @@ final class FeedEditViewModel: ViewModelType {
                       showAlreadyConnectedToast: showAlreadyConnectedToast.asObservable(),
                       showStopEditingAlert: showStopEditingAlert.asObservable(),
                       presentPhotoPicker: presentPhotoPicker.asObservable(),
+                      showAddImageView: showAddImageView.asObservable(),
                       selectedImages: selectedImages.asObservable())
     }
     


### PR DESCRIPTION
### ⭐️Issue
- close #571 
<br/>

### 🌟Motivation
- 사진소소:  피드 내 사진 업로드 기능 구현 마무리 했습니다. 

피드글 수정 시 이미지의 업로드가 가능하다. ✅
작성(수정) 완료를 클릭하면 서버에 multipart 형태로 이미지를 전송한다. ✅ 
피드 작성 시 선택한 사진을 삭제할 수 있다. ✅

<br/>

### 🌟Key Changes

#### 병렬 + 비동기 작업을 통한 피드 업로드 시간 단축 
지난 PR에서 말씀해주신 대로 병렬 + 비동기 로직을 생각해봤습니다. 
```swift
let queue = DispatchQueue(label: "image.compress.queue", attributes: .concurrent)
        
    for (index, image) in images.enumerated() {
        group.enter()
        queue.async {
            let compressedData = compressImage(image, index: index, maxImageSize: maxImageSize)
            compressedDatas[index] = compressedData
            group.leave()
    }
}
```

`queue.async` : **비동기적**으로 작업을 큐에 등록한다. 
즉, 이미지 압축을 즉시 실행하지 않고, 대기열에 넣고 다음 루프로 넘어간다. 

`attributes: .concurrent` : 큐의 특성을 concurrent하게 만들었다. → 동시성 보장 → **병렬처리**

```swift
group.wait()
```

DispatchGroup안에 등록된 모든 비동기 작업들이 완료될 때까지 해당 쓰레드를 블로킹한다.

- 즉, for 루프 안의 `.group.enter()` + `.group.leave()`로 추적된 모든 작업이 끝날 때까지 기다림.

<br/>

#### Closure를 활용한 Cell 내부 버튼 이벤트 구현
X 버튼을 통해 Cell을 삭제하는 기능을 구현해야 했어서, index 관리가 중요했습니다. 
구글링 결과 cell의 tag를 사용하지 않아도 돼서 꼬일 일이 거의 없기 때문에 클로져를 활용해서 구현해봤습니다.
```swift
final class FeedAddImageCollectionViewCell: UICollectionViewCell {
    
    //MARK: - Properties
    
    var cancelButtonTapped: (() -> Void)?

    ....

    //MARK: - Custom Method
    
    private func bindAction() {
        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
    }
    
    @objc private func cancelTapped() {
        cancelButtonTapped?()
    }
```
<br/>


#### PhotoPicker에서 선택한 사진을 cell 과 바인딩 
최대한 이미지 관련 로직을 뷰모델에서 반영하고, UI 로직을 뷰컨에서 관리하고 싶었는데, 
PhotoPicker를 활용하기 위해선 어쩔 수 없이 뷰컨에서 로직을 적용해야 했기 때문에 뷰모델의 변수값을 뷰컨에서 가져와 사용해야 하는 상황이 .. ㅠㅠ 최선을 다해봤지만 코드가 완벽하게 맘에 들진 않네요 .. 흐음 . . 
추후에 다시 수정해볼 생각입니다!
```swift 
output.presentPhotoPicker
            .subscribe(with: self, onNext: { owner, _ in
                let manager = PhotoPickerManager(presentingViewController: owner)
                owner.photoPickerManager = manager
                
                manager.selectedImages
                    .withLatestFrom(output.selectedImages) { newImages, currentImages in
                        return (newImages, currentImages)
                    }
                    .observe(on: MainScheduler.instance)
                    .subscribe(with: owner, onNext: { owner, data in
                        let (newImages, currentImages) = data
                        
                        if currentImages.count + newImages.count > owner.maximumImageCount {
                            owner.showToast(.limitAddImage(limitCount: owner.maximumImageCount))
                            return
                        }
                        
                        let updatedImages = currentImages + newImages
                        owner.feedEditViewModel.selectedImages.accept(updatedImages)
                        owner.rootView.feedEditAddImageView.addImageCollectionView.reloadData()
                        owner.rootView.showAddImages(hasImage: !updatedImages.isEmpty)
                    })
                    .disposed(by: owner.disposeBag)
                
                manager.presentPicker()
            })
            .disposed(by: disposeBag)
```

### 🌟Simulation
- 피드 업로드 내 cell 삭제 기능 구현 및 피드 업로드 

https://github.com/user-attachments/assets/ee0a275c-5393-45f6-8b46-b17d954f349b

- 피드 수정 후 이미지 업로드


https://github.com/user-attachments/assets/a2dd5e26-8abe-4df7-b514-487d0feafdec




<br/>

### 🌟To Reviewer
- 직접 피드 업로드 및 피드 수정을 실기기에서 돌려보시는 걸 추천드립니다 ..! 
<br/>

### 🌟Reference

<br/>
