### PR TITLE
[Fix] #593 - 피드 수정 시 이미지 화질 저하되는 이슈 수정

### DIFF
--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -121,8 +121,9 @@ extension Networking {
 
         // 원본이 1MB 이하 → quality만 낮춤
         if originalSize <= oneMB {
-            while (data == nil || data!.count > maxImageSize) && quality > 0.1 {
-                data = image.jpegData(compressionQuality: quality)
+            while let compressed = image.jpegData(compressionQuality: quality), compressed.count > maxImageSize, quality > 0.1 {
+            data = compressed
+        
                 print("이미지 \(index) 크기: \(formatBytesToMB(data?.count ?? 0))")
                 quality -= 0.1
             }

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import UniformTypeIdentifiers
-
 // multipart에 사용되는 값에 대한 열거형
 enum MultipartConstants {
     static let jsonPartName = "feed"
@@ -117,15 +115,6 @@ extension Networking {
         if originalSize <= maxImageSize {
             print("이미지 \(index) 압축 생략")
             return originalData
-        }
-
-        // HEIC 포맷이면 초기 scale 조정
-        if let cgImageSource = CGImageSourceCreateWithData(image.pngData()! as CFData, nil),
-           let utiString = CGImageSourceGetType(cgImageSource) as String?,
-           let utType = UTType(utiString),
-           utType.conforms(to: .heic) {
-            scale = 0.5
-            print("🧾 이미지 \(index) HEIC → 초기 해상도 0.5 적용")
         }
 
         var data: Data?

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -102,48 +102,63 @@ extension Networking {
     }
     
     private func compressImage(_ image: UIImage, index: Int, maxImageSize: Int) -> Data {
-        // 품질
+        let oneMB = 1024 * 1024
         var quality: CGFloat = 1.0
-        // 해상도
         var scale: CGFloat = 0.9
-        
-        if let originalData = image.jpegData(compressionQuality: 1.0) {
-            let originalSize = originalData.count
-            print("이미지 \(index) 원본 사이즈: \(formatBytesToMB(originalSize))")
-            
-            // 원본 사이즈가 최대 사이즈보다 작을 때 -> 압축 생략
-            if originalSize <= maxImageSize {
-                return originalData
-            }
+
+        guard let originalData = image.jpegData(compressionQuality: 1.0) else {
+            return Data()
         }
-        
-        // HEIC 확장자 -> 해상도를 0.5로 설정
+
+        let originalSize = originalData.count
+        print("이미지 \(index) 원본 사이즈: \(formatBytesToMB(originalSize))")
+
+        // 원본이 이미 작으면 압축 생략
+        if originalSize <= maxImageSize {
+            print("이미지 \(index) 압축 생략")
+            return originalData
+        }
+
+        // HEIC 포맷이면 초기 scale 조정
         if let cgImageSource = CGImageSourceCreateWithData(image.pngData()! as CFData, nil),
            let utiString = CGImageSourceGetType(cgImageSource) as String?,
            let utType = UTType(utiString),
            utType.conforms(to: .heic) {
             scale = 0.5
+            print("🧾 이미지 \(index) HEIC → 초기 해상도 0.5 적용")
         }
-        
-        // 초기 해상도(scale) 0.9로 설정
-        var data: Data? = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-        
-        while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
-            if quality > 0.2 {
+
+        var data: Data?
+
+        // 원본이 1MB 이하 → quality만 낮춤
+        if originalSize <= oneMB {
+            while (data == nil || data!.count > maxImageSize) && quality > 0.1 {
+                data = image.jpegData(compressionQuality: quality)
+                print("이미지 \(index) 크기: \(formatBytesToMB(data?.count ?? 0))")
                 quality -= 0.1
-            } else {
-                scale -= 0.1
-                if let resizedImage = image.resizedImage(to: scale) {
-                    data = resizedImage.jpegData(compressionQuality: quality)
-                }
-                continue
             }
+        } else {
+            // 원본이 1MB 초과 → scale 먼저 줄이고 필요 시 quality도 함께 감소
             data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-            print("↘️ 크기: \(formatBytesToMB(data?.count ?? 0))")
+            print("이미지 \(index)크기: \(formatBytesToMB(data?.count ?? 0))")
+
+            while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
+                if quality > 0.2 {
+                    quality -= 0.1
+                } else {
+                    scale -= 0.1
+                    if let resized = image.resizedImage(to: scale) {
+                        data = resized.jpegData(compressionQuality: quality)
+                    }
+                    continue
+                }
+                data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
+                print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
+            }
         }
-        
+
         if let data = data, data.count <= maxImageSize {
-            print("✅ 이미지 \(index) 최종 크기: \(formatBytesToMB(data.count))")
+            print("이미지 \(index) 최종 크기: \(formatBytesToMB(data.count))")
             return data
         } else {
             print("❌ 이미지 \(index) 압축 실패 또는 제한 초과, 빈 데이터 추가")

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -102,8 +102,10 @@ extension Networking {
     }
     
     private func compressImage(_ image: UIImage, index: Int, maxImageSize: Int) -> Data {
+        // 품질
         var quality: CGFloat = 1.0
-        var scale: CGFloat = 0.7
+        // 해상도
+        var scale: CGFloat = 0.9
         
         if let originalData = image.jpegData(compressionQuality: 1.0) {
             let originalSize = originalData.count
@@ -123,7 +125,7 @@ extension Networking {
             scale = 0.5
         }
         
-        // 해상도(scale) 조절
+        // 초기 해상도(scale) 0.9로 설정
         var data: Data? = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
         
         while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -80,7 +80,7 @@ extension Networking {
         return String(format: "%.2fMB", Double(bytes) / (1024.0 * 1024.0))
     }
     
-    // 병렬 처리
+    // 병렬 + 비동기 이미지 압축
     func compressImages(_ images: [UIImage],
                         maxImageSize: Int = MultipartConstants.maxImageSize) -> [Data] {
         var compressedDatas = Array<Data?>(repeating: nil, count: images.count)
@@ -105,16 +105,26 @@ extension Networking {
         var quality: CGFloat = 1.0
         var scale: CGFloat = 0.7
         
+        if let originalData = image.jpegData(compressionQuality: 1.0) {
+            let originalSize = originalData.count
+            print("이미지 \(index) 원본 사이즈: \(formatBytesToMB(originalSize))")
+            
+            // 원본 사이즈가 최대 사이즈보다 작을 때 -> 압축 생략
+            if originalSize <= maxImageSize {
+                return originalData
+            }
+        }
+        
+        // HEIC 확장자 -> 해상도를 0.5로 설정
         if let cgImageSource = CGImageSourceCreateWithData(image.pngData()! as CFData, nil),
            let utiString = CGImageSourceGetType(cgImageSource) as String?,
            let utType = UTType(utiString),
            utType.conforms(to: .heic) {
             scale = 0.5
-            print("🧾 이미지 \(index) HEIC 포맷으로 감지 → 초기 해상도 0.5 적용")
         }
         
+        // 해상도(scale) 조절
         var data: Data? = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-        print("🖼️ 이미지 \(index) 초기 해상도 \(String(format: "%.2f", scale)) 적용 → 크기: \(formatBytesToMB(data?.count ?? 0))")
         
         while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
             if quality > 0.2 {
@@ -127,11 +137,11 @@ extension Networking {
                 continue
             }
             data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-            print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
+            print("↘️ 크기: \(formatBytesToMB(data?.count ?? 0))")
         }
         
         if let data = data, data.count <= maxImageSize {
-            print("✅ 이미지 \(index) 최종 해상도 \(String(format: "%.2f", scale)), 품질 \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data.count))")
+            print("✅ 이미지 \(index) 최종 크기: \(formatBytesToMB(data.count))")
             return data
         } else {
             print("❌ 이미지 \(index) 압축 실패 또는 제한 초과, 빈 데이터 추가")

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -103,27 +103,30 @@ extension Networking {
         let oneMB = 1024 * 1024
         var quality: CGFloat = 1.0
         var scale: CGFloat = 0.9
-
+        
         guard let originalData = image.jpegData(compressionQuality: 1.0) else {
             return Data()
         }
-
+        
         let originalSize = originalData.count
         print("이미지 \(index) 원본 사이즈: \(formatBytesToMB(originalSize))")
-
+        
         // 원본이 이미 작으면 압축 생략
         if originalSize <= maxImageSize {
             print("이미지 \(index) 압축 생략")
             return originalData
         }
-
+        
         var data: Data?
-
+        
         // 원본이 1MB 이하 → quality만 낮춤
         if originalSize <= oneMB {
-            while let compressed = image.jpegData(compressionQuality: quality), compressed.count > maxImageSize, quality > 0.1 {
-            data = compressed
-        
+            while let compressed =
+                    image.jpegData(compressionQuality: quality),
+                  compressed.count > maxImageSize,
+                  quality > 0.1 {
+                data = compressed
+                
                 print("이미지 \(index) 크기: \(formatBytesToMB(data?.count ?? 0))")
                 quality -= 0.1
             }
@@ -131,7 +134,7 @@ extension Networking {
             // 원본이 1MB 초과 → scale 먼저 줄이고 필요 시 quality도 함께 감소
             data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
             print("이미지 \(index)크기: \(formatBytesToMB(data?.count ?? 0))")
-
+            
             while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
                 if quality > 0.2 {
                     quality -= 0.1
@@ -146,7 +149,7 @@ extension Networking {
                 print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
             }
         }
-
+        
         if let data = data, data.count <= maxImageSize {
             print("이미지 \(index) 최종 크기: \(formatBytesToMB(data.count))")
             return data

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedViewController.swift
@@ -127,7 +127,7 @@ final class FeedViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        NotificationCenter.default.rx.notification(Notification.Name("FeedEdited"))
+        NotificationCenter.default.rx.notification(NotificationName.feedEdited)
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, _ in
                 owner.showToast(.feedEdited)

--- a/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
@@ -543,7 +543,7 @@ final class NovelDetailViewController: UIViewController {
             reloadNovelDetailFeed: reloadNovelDetailFeed.asObservable(),
             scrollViewReachedBottom: observeReachedBottom(rootView.scrollView),
             createFeedButtonDidTap: rootView.createFeedButton.rx.tap,
-            feedEditedNotification: NotificationCenter.default.rx.notification(Notification.Name("FeedEdited")).asObservable(),
+            feedEditedNotification: NotificationCenter.default.rx.notification(NotificationName.feedEdited).asObservable(),
             novelReviewedNotification: NotificationCenter.default.rx.notification(Notification.Name("NovelReviewed")).asObservable()
         )
     }


### PR DESCRIPTION
### ⭐️Issue
- close #593 
<br/>

### 🌟Motivation
반복하여 피드 수정 시 이미지 화질 저하되는 이슈를 수정했습니다. 
<br/>

### 🌟Key Changes
#### AS-IS
피드를 수정할 때마다 (장르 바꾸기, 테스트 바꾸기 등등 ..) 함께 올린 사진의 화질이 점점 저하되는 현상이 있었습니다. 
이미지를 보낼 때 이미 **0.25MB**보다 사이즈가 작은 경우에 대해서도 압축이 진행되고 있었다. 이미 0.25MB보다 작은 이미지에 대한 해상도를 또 조절하다보니 해상도가 점점 저하되었던 것 입니다. 

#### TO-BE
아래의 코드를 추가해서 원본 이미지의 사이즈를 구한 뒤, `maxImageSize = 0.25MB`보다 이미 작은 상태이면 따로 이미지 압축을 진행하지 않고 바로 서버에 전송될 수 있도록 반영했습니다. 
```swift
let originalSize = originalData.count
print("이미지 \(index) 원본 사이즈: \(formatBytesToMB(originalSize))")

// 원본이 이미 작으면 압축 생략
if originalSize <= maxImageSize {
        print("이미지 \(index) 압축 생략")
        return originalData
}
```

<br/>

#### 추가적인 이미지 압축 로직 리팩토링
#### AS - IS
기존에는 초기 이미지의 해상도(scale)을 0.7로 조정하여 이미지 사이즈를 확 줄인 뒤, 0.25MB보다 작아질 때까지 품질(quality)를 줄여나가는 로직으로 진행되었습니다. 그런데 원본 이미지 사이즈가 0.25MB보다 조금 큰 상황에서도 해상도를 건들이게 되다보니 아까와 같은 화질 저하 이슈가 생기기도 했고, 압축 로직의 효율이 떨어진다고 판단했습니다. 


#### TO-BE
따라서, 이미지 사이즈가 1MB 이하일 때에는 품질(quality)를 낮춰 픽셀 수 즉, 해상도는 최대한 유지될 수 있도록 했습니다. 
반면에 사이즈가 1MB보다 클 떄에는 해상도를 먼저 줄인 뒤 품질을 조금씩 줄여나갈 수 있도록 했습니다. 
```swift
// 원본이 1MB 이하 → quality만 낮춤
        if originalSize <= oneMB {
            while (data == nil || data!.count > maxImageSize) && quality > 0.1 {
                data = image.jpegData(compressionQuality: quality)
                print("이미지 \(index) 크기: \(formatBytesToMB(data?.count ?? 0))")
                quality -= 0.1
            }
        } else {
            // 원본이 1MB 초과 → scale 먼저 줄이고 필요 시 quality도 함께 감소
            data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
            print("이미지 \(index)크기: \(formatBytesToMB(data?.count ?? 0))")

            while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
                if quality > 0.2 {
                    quality -= 0.1
                } else {
                    scale -= 0.1
                    if let resized = image.resizedImage(to: scale) {
                        data = resized.jpegData(compressionQuality: quality)
                    }
                    continue
                }
                data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
                print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
            }
        }
```

<br/>

### 🌟Simulation

https://github.com/user-attachments/assets/3de4c07b-d68a-4907-a605-82eca51392e3


<br/>

### 🌟To Reviewer
직접 실기기로 테스트 해보시는 걸 추천드립니다!
호옥시 이미지 화질 관련해서 똑같은 이슈가 나타난다면 언제든지 말해주세여 ..
<br/>

### 🌟Reference

<br/>
