### PR TITLE
[Fix] #596 - 서재소소 QA 사항 반영

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+MyLibrary.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+MyLibrary.swift
@@ -24,5 +24,11 @@ extension StringLiterals {
             static let attractivePoint = "매력포인트"
             static let rating = "별점"
         }
+        
+        enum Empty {
+            static let libraryEmpty = "서재가 비어있어요"
+            static let searchButton = "웹소설 찾으러 가기"
+            static let filterResultEmpty = "해당하는 작품이 없어요\n검색의 범위를 더 넓혀보세요"
+        }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/Base/ReadStatus.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/ReadStatus.swift
@@ -52,14 +52,6 @@ enum ReadStatus: String, CaseIterable {
         }
     }
     
-    var tagText: String {
-        switch self {
-        case .watching: return "보는중"
-        case .watched: return "봤어요"
-        case .quit: return "하차"
-        }
-    }
-    
     var tagBackgroundColor: UIColor {
         switch self {
         case .watching: return .wssPrimary100

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryFilter/LibraryFilterViewController/LibraryFilterViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/LibraryFilter/LibraryFilterViewController/LibraryFilterViewController.swift
@@ -102,6 +102,13 @@ final class LibraryFilterViewController: UIViewController {
             .flatMap { button in
                 button.rx.tap.map { button.status }
             }
+            .withLatestFrom(ratingOption) { tappedButton, currentOption in
+                if tappedButton == currentOption {
+                    return nil
+                } else {
+                    return tappedButton
+                }
+            }
             .bind(to: ratingOption)
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
@@ -126,8 +126,8 @@ final class MyLibraryFilterHeaderView: UIView {
         let overCount = selectedOption.count - 1
         
         let text = switch (isSelected, isMoreThanOne) {
-        case (true, false): selectedOption.first?.tagText
-        case (true, true): "\(selectedOption.first?.tagText ?? "") 외\(overCount)"
+        case (true, false): selectedOption.first?.statusName
+        case (true, true): "\(selectedOption.first?.statusName ?? "") 외\(overCount)"
         case (false, _): StringLiterals.MyLibrary.FilterButton.readStatus
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterResultEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterResultEmptyView.swift
@@ -1,5 +1,5 @@
 //
-//  MyLibraryEmptyView.swift
+//  MyLibraryFilterResultEmptyView.swift
 //  WSSiOS
 //
 //  Created by YunhakLee on 6/25/25.
@@ -10,15 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
-final class MyLibraryEmptyView: UIView {
+final class MyLibraryFilterResultEmptyView: UIView {
     
     //MARK: - Components
     
     private let stackView = UIStackView()
     private let imageView = UIImageView()
     private let descriptionLabel = UILabel()
-    let searchNovelButton = UIButton()
-    private let searchNovelButtonLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -49,52 +47,31 @@ final class MyLibraryEmptyView: UIView {
         }
         
         descriptionLabel.do {
-            $0.applyWSSFont(.body1, with: StringLiterals.MyLibrary.Empty.libraryEmpty)
+            $0.applyWSSFont(.body1, with: StringLiterals.MyLibrary.Empty.filterResultEmpty)
             $0.textColor = .wssGray200
-        }
-        
-        searchNovelButton.do {
-            $0.layer.backgroundColor = UIColor.wssPrimary50.cgColor
-            $0.layer.cornerRadius = 12
-        }
-        
-        searchNovelButtonLabel.do {
-            $0.applyWSSFont(.title1, with: StringLiterals.MyLibrary.Empty.searchButton)
-            $0.textColor = .wssPrimary100
-            $0.isUserInteractionEnabled = false
+            $0.textAlignment = .center
+            $0.numberOfLines = 2
         }
     }
 
     private func setHierarchy() {
         self.addSubviews(stackView)
         stackView.addArrangedSubviews(imageView,
-                                      descriptionLabel,
-                                      searchNovelButton)
-        searchNovelButton.addSubview(searchNovelButtonLabel)
+                                      descriptionLabel)
     }
     
     private func setLayout() {
         stackView.snp.makeConstraints() {
-            $0.centerY.equalToSuperview().offset(-59)
+            $0.centerY.equalToSuperview().offset(-47)
             $0.horizontalEdges.equalToSuperview()
         }
         
         stackView.do {
-            $0.setCustomSpacing(8, after: imageView)
-            $0.setCustomSpacing(45, after: descriptionLabel)
+            $0.spacing = 8
         }
         
         imageView.snp.makeConstraints() {
             $0.height.equalTo(48)
-        }
-        
-        searchNovelButton.snp.makeConstraints() {
-            $0.height.equalTo(53)
-            $0.horizontalEdges.equalToSuperview().inset(90)
-        }
-        
-        searchNovelButtonLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryReadStatusTagView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryReadStatusTagView.swift
@@ -52,7 +52,7 @@ final class MyLibraryReadStatusTagView: UIView {
         self.backgroundColor = readStatus.tagBackgroundColor
         
         statusLabel.do {
-            $0.applyWSSFont(.label2, with: readStatus.tagText)
+            $0.applyWSSFont(.label2, with: readStatus.statusName)
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
@@ -19,6 +19,7 @@ final class MyLibraryView: UIView {
     let libraryCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     let libraryTableView = UITableView(frame: .zero, style: .plain)
     let libraryEmptyView = MyLibraryEmptyView()
+    let libraryFilterResultEmptyView = MyLibraryFilterResultEmptyView()
     let loadingView = WSSLoadingView()
     let networkErrorView = WSSNetworkErrorView()
     
@@ -68,6 +69,7 @@ final class MyLibraryView: UIView {
                          libraryCollectionView,
                          libraryTableView,
                          libraryEmptyView,
+                         libraryFilterResultEmptyView,
                          loadingView,
                          networkErrorView)
     }
@@ -101,6 +103,12 @@ final class MyLibraryView: UIView {
             $0.bottom.equalToSuperview()
         }
         
+        libraryFilterResultEmptyView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+        
         loadingView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
@@ -114,8 +122,12 @@ final class MyLibraryView: UIView {
         }
     }
     
-    func showEmptyLibraryView(isShowing: Bool) {
+    func showLibraryEmptyView(isShowing: Bool) {
         libraryEmptyView.isHidden = !isShowing
+    }
+    
+    func showFilterResultEmptyView(isShowing: Bool) {
+        libraryFilterResultEmptyView.isHidden = !isShowing
     }
     
     func showLibraryListView(selectedType: LayoutType) {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
@@ -129,10 +129,15 @@ final class MyLibraryViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        output.showEmptyLibraryView
-            .observe(on: MainScheduler.instance)
-            .bind(with: self, onNext: { owner, isShowing in
-                owner.rootView.showEmptyLibraryView(isShowing: isShowing)
+        output.showLibraryEmptyView
+            .drive(with: self, onNext: { owner, isShowing in
+                owner.rootView.showLibraryEmptyView(isShowing: isShowing)
+            })
+            .disposed(by: disposeBag)
+        
+        output.showFilterResultEmptyView
+            .drive(with: self, onNext: { owner, isShowing in
+                owner.rootView.showFilterResultEmptyView(isShowing: isShowing)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -31,7 +31,9 @@ final class MyLibraryViewModel: ViewModelType {
     private let reloadNovelList = PublishRelay<Void>()
     private let refreshNovelList = PublishRelay<Void>()
     
-    private let showEmptyLibraryView = BehaviorRelay<Bool>(value: false)
+    private let isLibraryEmpty = BehaviorRelay<Bool>(value: false)
+    private let showLibraryEmptyView = BehaviorRelay<Bool>(value: false)
+    private let showFilterResultEmptyView = BehaviorRelay<Bool>(value: false)
     private let pushToNovelDetailViewController = PublishRelay<Int>()
     private let showLoadingView = BehaviorRelay<Bool>(value: false)
     private let showNetworkErrorView = BehaviorRelay<Bool>(value: false)
@@ -61,7 +63,8 @@ final class MyLibraryViewModel: ViewModelType {
         let selectedLayoutType: Driver<LayoutType>
         let novelCount: Driver<Int>
         let libraryNovelList: Observable<[MyLibraryNovel]>
-        let showEmptyLibraryView: Observable<Bool>
+        let showLibraryEmptyView: Driver<Bool>
+        let showFilterResultEmptyView: Driver<Bool>
         let pushToNovelDetailViewController: Observable<Int>
         let showLoadingView: Observable<Bool>
         let showNetworkErrorView: Observable<Bool>
@@ -164,13 +167,31 @@ final class MyLibraryViewModel: ViewModelType {
             .bind(to: pushToNovelDetailViewController)
             .disposed(by: disposeBag)
         
+        isLibraryEmpty
+            .withLatestFrom(filterOption) { isEmpty, filterOption in
+                return (isEmpty, filterOption != LibraryFilterOption())
+            }
+            .bind(with: self, onNext: { owner, data in
+                let (isLibraryEmpty, isFilterResult) = data
+                if isLibraryEmpty {
+                    owner.showFilterResultEmptyView.accept(isFilterResult)
+                    owner.showLibraryEmptyView.accept(!isFilterResult)
+                } else {
+                    owner.showFilterResultEmptyView.accept(false)
+                    owner.showLibraryEmptyView.accept(false)
+                }
+                
+            })
+            .disposed(by: disposeBag)
+        
         return Output(
             selectedFilterOption: filterOption.asDriver(),
             selectedSortType: sortType.asDriver(),
             selectedLayoutType: layoutType.asDriver(),
             novelCount: novelCount.asDriver(),
             libraryNovelList: libraryNovelList.asObservable(),
-            showEmptyLibraryView: showEmptyLibraryView.asObservable(),
+            showLibraryEmptyView: showLibraryEmptyView.asDriver(),
+            showFilterResultEmptyView: showFilterResultEmptyView.asDriver(),
             pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
             showLoadingView: showLoadingView.asObservable(),
             showNetworkErrorView: showNetworkErrorView.asObservable()
@@ -201,7 +222,7 @@ final class MyLibraryViewModel: ViewModelType {
         isLoadable.accept(true)
         novelCount.accept(0)
         lastUserNovelId.accept(0)
-        showEmptyLibraryView.accept(false)
+        isLibraryEmpty.accept(false)
     }
     
     private func updateLibraryState(with entity: MyLibraryEntity) {
@@ -209,7 +230,7 @@ final class MyLibraryViewModel: ViewModelType {
         isLoadable.accept(entity.isLoadable)
         novelCount.accept(entity.userNovelCount)
         lastUserNovelId.accept(entity.userNovels.last?.userNovelId ?? 0)
-        showEmptyLibraryView.accept(entity.userNovels.isEmpty)
+        isLibraryEmpty.accept(entity.userNovels.isEmpty)
     }
     
     private func updateRequestState(isStarting: Bool, isReloading: Bool = false, isError: Bool = false) {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #596 
<br/>

### 🌟Motivation
- 서재소소 QA 결과를 반영합니다
<br/>

### 🌟Key Changes
- 별점 필터 이미 선택된 항목을 다시 탭하면 선택 해제되도록 수정
- 태그 텍스트 보는중-> 보는 중으로 띄어쓰기 변경
- 필터가 적용된 경우의 EmtpyView와, 서재 자체가 비어있을 때의 EmptyView 구분.
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-10 at 23 13 48](https://github.com/user-attachments/assets/32e6dd10-6e62-4bd3-8833-e7ec53d7102b)

<br/>

### 🌟To Reviewer
- 간단한 수정사항입니다!
<br/>

### 🌟Reference

<br/>
