### PR TITLE
[Fix] #596-2 서재소소 2차 QA 반영

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -21,6 +21,7 @@ enum StringLiterals {
         static let isRegister = "IS_REGISTER"
         static let showReviewFirstDescription = "SHOW_REVIEW_FIRST_DESCRIPTION"
         static let userBirth = "USER_BIRTH"
+        static let libraryFilterOption = "LIBRARY_FILTER_OPTION"
     }
     
     enum FCMCenter {

--- a/WSSiOS/WSSiOS/Source/Data/Base/AttractivePoint.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/AttractivePoint.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum AttractivePoint: String, CaseIterable {
+enum AttractivePoint: String, CaseIterable, Codable {
     case worldview = "worldview"
     case material = "material"
     case character = "character"

--- a/WSSiOS/WSSiOS/Source/Data/Base/NovelRatingStatus.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/NovelRatingStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum NovelRatingStatus: String, CaseIterable {
+enum NovelRatingStatus: String, CaseIterable, Codable {
     case aboveThreePointFive
     case aboveFourPointZero
     case aboveFourPointFive

--- a/WSSiOS/WSSiOS/Source/Data/Base/ReadStatus.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/ReadStatus.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum ReadStatus: String, CaseIterable {
+enum ReadStatus: String, CaseIterable, Codable {
     case watching = "WATCHING"
     case watched = "WATCHED"
     case quit = "QUIT"

--- a/WSSiOS/WSSiOS/Source/Data/Base/SortType.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/SortType.swift
@@ -5,7 +5,7 @@
 //  Created by YunhakLee on 5/26/25.
 //
 
-enum SortType {
+enum SortType: Equatable {
     case newest, oldest
     
     var queryText: String {

--- a/WSSiOS/WSSiOS/Source/Data/Entity/MyLibrary/LibraryFilterOption.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/MyLibrary/LibraryFilterOption.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct LibraryFilterOption: Equatable {
+struct LibraryFilterOption: Equatable, Codable {
     var interestedOption: Bool = false
     var readStatusOptions: [ReadStatus] = []
     var attractivePointOptions: [AttractivePoint] = []

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
@@ -43,7 +43,7 @@ final class MyLibraryFilterHeaderView: UIView {
         self.backgroundColor = .wssWhite
         
         scrollView.do {
-            $0.showsVerticalScrollIndicator = false
+            $0.showsHorizontalScrollIndicator = false
             $0.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryHeaderView.swift
@@ -19,6 +19,7 @@ final class MyLibraryHeaderView: UIView {
     private let countLabel = UILabel()
     let sortButton = WSSSortButton()
     let layoutToggleButton = UIButton()
+    let layoutToggleButtonImageView = UIImageView()
     private let dividerView = UIView()
     
     // MARK: - Life Cycle
@@ -49,9 +50,13 @@ final class MyLibraryHeaderView: UIView {
         }
         
         layoutToggleButton.do {
-            $0.setImage(.layoutList.withTintColor(.wssGray100), for: .normal)
             $0.configuration = .plain()
             $0.configuration?.background.backgroundColor = .white
+        }
+        
+        layoutToggleButtonImageView.do {
+            $0.image = .layoutGrid.withTintColor(.wssGray100)
+            $0.isUserInteractionEnabled = false
         }
         
         dividerView.do {
@@ -66,6 +71,7 @@ final class MyLibraryHeaderView: UIView {
                                       sortButton,
                                       layoutToggleButton,
                                       dividerView)
+        layoutToggleButton.addSubview(layoutToggleButtonImageView)
     }
     
     private func setLayout() {
@@ -87,13 +93,19 @@ final class MyLibraryHeaderView: UIView {
         
         sortButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalTo(layoutToggleButton.snp.leading).offset(-20.5)
+            $0.trailing.equalTo(layoutToggleButton.snp.leading).offset(-10)
         }
         
         layoutToggleButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(9.5)
+            $0.trailing.equalToSuperview().inset(20)
             $0.size.equalTo(33)
+        }
+        
+        layoutToggleButtonImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.size.equalTo(12)
         }
         
         dividerView.snp.makeConstraints {
@@ -103,8 +115,7 @@ final class MyLibraryHeaderView: UIView {
     }
     
     func updateLayoutToggleButton(selectedType: LayoutType) {
-        layoutToggleButton.setImage(selectedType.image.withTintColor(.wssGray100),
-                                    for: .normal)
+        layoutToggleButtonImageView.image = selectedType.image.withTintColor(.wssGray100)
     }
     
     func updateCountLabel(count: Int) {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -164,7 +164,7 @@ final class MyLibraryViewModel: ViewModelType {
             .do(onNext: { [weak self] _ in self?.updateRequestState(isStarting: true)})
             .withLatestFrom(Observable.combineLatest(filterOption, sortType, libraryNovelList))
             .flatMapLatest { (filterOption, sortType, novelList) in
-                let size = novelList.count == 0 ? 12 : novelList.count
+                let size = novelList.count == 0 ? 12 : novelList.count + 12
                 return self.getNovelListData(filterOption: filterOption,
                                              lastUserNovelId: 0,
                                              size: size,

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -76,6 +76,14 @@ final class MyLibraryViewModel: ViewModelType {
             .bind(to: refreshNovelList)
             .disposed(by: disposeBag)
         
+        input.viewWillAppear
+            .map { self.loadFilterOption() }
+            .withLatestFrom(filterOption) {($0, $1)}
+            .filter { $0 != $1 }
+            .map { loaded, _ in return loaded }
+            .bind(to: filterOption)
+            .disposed(by: disposeBag)
+        
         input.interestFilterButtonDidTap
             .withLatestFrom(filterOption)
             .map { option in
@@ -84,6 +92,14 @@ final class MyLibraryViewModel: ViewModelType {
                 return updated
             }
             .bind(to: filterOption)
+            .disposed(by: disposeBag)
+        
+        filterOption
+            .skip(1)
+            .distinctUntilChanged()
+            .bind(with: self, onNext: { owner, selectedOption in
+                owner.saveFilterOption(selectedOption)
+            })
             .disposed(by: disposeBag)
         
         input.sortButtonDidTap
@@ -99,6 +115,7 @@ final class MyLibraryViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         Observable.combineLatest(filterOption, sortType)
+            .distinctUntilChanged{ $0 == $1 }
             .observe(on: MainScheduler.asyncInstance)  // raceCondition을 방지하기 위해 한사이클 다음에 스트림이 작동하도록 하는 역할.
             .map { _ in }
             .bind(to: reloadNovelList)
@@ -149,9 +166,9 @@ final class MyLibraryViewModel: ViewModelType {
             .flatMapLatest { (filterOption, sortType, novelList) in
                 let size = novelList.count == 0 ? 12 : novelList.count
                 return self.getNovelListData(filterOption: filterOption,
-                                      lastUserNovelId: 0,
-                                      size: size,
-                                      sortType: sortType)
+                                             lastUserNovelId: 0,
+                                             size: size,
+                                             sortType: sortType)
             }
             .do(onNext: { [weak self] _ in self?.updateRequestState(isStarting: false)})
             .bind(with: self, onNext: { owner, entity in
@@ -242,6 +259,22 @@ final class MyLibraryViewModel: ViewModelType {
             isFetching.accept(false)
             showNetworkErrorView.accept(isError)
             showLoadingView.accept(false)
+        }
+    }
+    
+    private func saveFilterOption(_ filterOption: LibraryFilterOption) {
+        if let encodedData = try? JSONEncoder().encode(filterOption) {
+            UserDefaults.standard.set(encodedData,
+                                      forKey: StringLiterals.UserDefault.libraryFilterOption)
+        }
+    }
+    
+    private func loadFilterOption() -> LibraryFilterOption {
+        if let savedData = UserDefaults.standard.data(forKey: StringLiterals.UserDefault.libraryFilterOption),
+           let loadedFilterOption = try? JSONDecoder().decode(LibraryFilterOption.self, from: savedData) {
+            return loadedFilterOption
+        } else { 
+            return LibraryFilterOption()
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -78,9 +78,6 @@ final class MyLibraryViewModel: ViewModelType {
         
         input.viewWillAppear
             .map { self.loadFilterOption() }
-            .withLatestFrom(filterOption) {($0, $1)}
-            .filter { $0 != $1 }
-            .map { loaded, _ in return loaded }
             .bind(to: filterOption)
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #596 
<br/>

### 🌟Motivation
- 서재소소 2차 QA 에서 나온 이슈를 수정합니다.
<br/>

### 🌟Key Changes
- 필터 적용사항을 UserDefault로 저장하여, 앱을 재실행해도 유지되도록 구현
- 필터 가로 스크롤 할 때 나타나는 인디케이터 제거
- 레이아웃 토글 버튼 피그마와 동일하게 왼쪽으로 쏠린 터치영역으로 구현
- (자체 QA) 서재에 작품을 추가한 경우, 서재 탭을 들어갈 때 추가된 작품까지 포함해서 보이지 않는 오류 해결.

기존 refreshNovelList 스트림에서는, 이전에 불러왔던 novelList의 크기만큼 다시 정보를 가져오는데, 이러면 추가된 작품이 바로 보이지 않음.
```swift
 refreshNovelList
            .withLatestFrom(isFetching)
            .filter { !$0 }
            .do(onNext: { [weak self] _ in self?.updateRequestState(isStarting: true)})
            .withLatestFrom(Observable.combineLatest(filterOption, sortType, libraryNovelList))
            .flatMapLatest { (filterOption, sortType, novelList) in
                let size = novelList.count == 0 ? 12 : novelList.count
                return self.getNovelListData(filterOption: filterOption,
                                             lastUserNovelId: 0,
                                             size: size,
                                             sortType: sortType)
            }
            .do(onNext: { [weak self] _ in self?.updateRequestState(isStarting: false)})
            .bind(with: self, onNext: { owner, entity in
                owner.updateLibraryState(with: entity)
            })
            .disposed(by: disposeBag)
```

따라서, 스트림 중간에 요청할 데이터 수를 의미하는 size 값을 기존 novelList의 개수에 비해 임의의 큰 값으로 처리해주어서, 추가된 작품이 바로 보일 수 있도록 수정.
```swift
let size = novelList.count == 0 ? 12 : novelList.count + 12
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2025-07-13 at 18 51 41](https://github.com/user-attachments/assets/c4824eed-2699-4f3e-a8b7-52c27608f583)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
