### PR TITLE
[Fix] #606 - 이미지 압축 함수 로직 수정

### DIFF
--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -113,48 +113,57 @@ extension Networking {
         
         // 원본이 이미 작으면 압축 생략
         if originalSize <= maxImageSize {
-            print("이미지 \(index) 압축 생략")
             return originalData
         }
         
-        var data: Data?
+        var bestData: Data? = nil
+        var bestSize: Int = Int.max
         
-        // 원본이 1MB 이하 → quality만 낮춤
         if originalSize <= oneMB {
-            while let compressed =
-                    image.jpegData(compressionQuality: quality),
-                  compressed.count > maxImageSize,
-                  quality > 0.1 {
-                data = compressed
-                
-                print("이미지 \(index) 크기: \(formatBytesToMB(data?.count ?? 0))")
-                quality -= 0.1
+            // quality만 줄여서 시도
+            while quality >= 0.01 {
+                if let compressed = image.jpegData(compressionQuality: quality) {
+                    let size = compressed.count
+                    if size <= maxImageSize {
+                        print("이미지 \(index) 최종 크기: \(formatBytesToMB(size))")
+                        return compressed
+                    }
+                    if size < bestSize {
+                        bestData = compressed
+                        bestSize = size
+                    }
+                }
+                quality -= 0.05
             }
         } else {
-            // 원본이 1MB 초과 → scale 먼저 줄이고 필요 시 quality도 함께 감소
-            data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-            print("이미지 \(index)크기: \(formatBytesToMB(data?.count ?? 0))")
-            
-            while (data == nil || data!.count > maxImageSize) && quality > 0.01 && scale > 0.1 {
-                if quality > 0.2 {
-                    quality -= 0.1
-                } else {
-                    scale -= 0.1
-                    if let resized = image.resizedImage(to: scale) {
-                        data = resized.jpegData(compressionQuality: quality)
+            // scale과 quality를 줄이면서 반복
+            while scale >= 0.1 {
+                if let resized = image.resizedImage(to: scale) {
+                    var tempQuality: CGFloat = 1.0
+                    while tempQuality >= 0.01 {
+                        if let compressed = resized.jpegData(compressionQuality: tempQuality) {
+                            let size = compressed.count
+                            if size <= maxImageSize {
+                                print("이미지 \(index) 최종 크기: \(formatBytesToMB(size))")
+                                return compressed
+                            }
+                            if size < bestSize {
+                                bestData = compressed
+                                bestSize = size
+                            }
+                        }
+                        tempQuality -= 0.05
                     }
-                    continue
                 }
-                data = image.resizedImage(to: scale)?.jpegData(compressionQuality: quality)
-                print("↘️ 해상도: \(String(format: "%.2f", scale)), 품질: \(String(format: "%.2f", quality)) → 크기: \(formatBytesToMB(data?.count ?? 0))")
+                scale -= 0.1
             }
         }
         
-        if let data = data, data.count <= maxImageSize {
-            print("이미지 \(index) 최종 크기: \(formatBytesToMB(data.count))")
-            return data
+        if let bestData = bestData {
+            print("이미지 \(index) 최선 압축 결과 반환 → 크기: \(formatBytesToMB(bestData.count))")
+            return bestData
         } else {
-            print("❌ 이미지 \(index) 압축 실패 또는 제한 초과, 빈 데이터 추가")
+            print("이미지 \(index) 압축 실패, 빈 데이터 반환")
             return Data()
         }
     }

--- a/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
+++ b/WSSiOS/WSSiOS/Network/Foundation/Networking+Multipart.swift
@@ -119,8 +119,8 @@ extension Networking {
         var bestData: Data? = nil
         var bestSize: Int = Int.max
         
+        // 원본이 1MB 이하 → quality만 낮춤
         if originalSize <= oneMB {
-            // quality만 줄여서 시도
             while quality >= 0.01 {
                 if let compressed = image.jpegData(compressionQuality: quality) {
                     let size = compressed.count
@@ -136,10 +136,10 @@ extension Networking {
                 quality -= 0.05
             }
         } else {
-            // scale과 quality를 줄이면서 반복
             while scale >= 0.1 {
                 if let resized = image.resizedImage(to: scale) {
                     var tempQuality: CGFloat = 1.0
+                    // quality만 줄여서 시도
                     while tempQuality >= 0.01 {
                         if let compressed = resized.jpegData(compressionQuality: tempQuality) {
                             let size = compressed.count
@@ -160,7 +160,7 @@ extension Networking {
         }
         
         if let bestData = bestData {
-            print("이미지 \(index) 최선 압축 결과 반환 → 크기: \(formatBytesToMB(bestData.count))")
+            print("⚠️ 이미지 \(index) 최선 압축 결과 반환 → 크기: \(formatBytesToMB(bestData.count))")
             return bestData
         } else {
             print("이미지 \(index) 압축 실패, 빈 데이터 반환")


### PR DESCRIPTION
### ⭐️Issue
- close #606 
<br/>

### 🌟Motivation
- 이미지 압축 함수 `compressImage` 로직을 수정했습니다. 
<br/>

### 🌟Key Changes
#### AS-IS
기존 코드는 이미지 업로드 시 최대 이미지 용량을 **0.25MB 이하**로 제한하고 있으며, 이를 만족하지 못할 경우 빈 데이터를 반환하도록 처리하고 있습니다. 
피드 수정 시, 이미 업로드된 이미지를 다시 불러오게 되는데, 이때 UIImage로 디코딩된 후 다시 압축을 시도하면 원본보다 압축 효율이 떨어져 용량이 다시 커질 수 있습니다. 따라서 압축된 이미지가 다시 0.25MB를 초과하게 되면서, 빈 데이터가 반환되고 서버에는 유효하지 않은 이미지가 전달되어 500 에러가 발생했습니다. 

#### TO-BE
에러가 발생하지 않도록, 압축된 이미지가 0.25MB보다 크게 되더라도 가능한 가장 작게 압축된 데이터를 반환하여 서버 500 에러 방지하도록 했습니다. 
<br/>

### 🌟Simulation
잘 작동합니다. 
<br/>

### 🌟To Reviewer
피드 수정을 반복하면 이미지 압축이 반복적으로 진행되어 점차 이미지 화질이 저하가 발생합니다.. 흠 최대한 scale은 건들지 않고 quality만 줄여 이미지 사이즈를 줄여보고자 하는데 쉽지 않네여 ㅠ
<br/>

### 🌟Reference

<br/>
