### PR TITLE
[Fix] #596-3 서재소소 3차 QA 반영

### DIFF
--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals.swift
@@ -22,6 +22,7 @@ enum StringLiterals {
         static let showReviewFirstDescription = "SHOW_REVIEW_FIRST_DESCRIPTION"
         static let userBirth = "USER_BIRTH"
         static let libraryFilterOption = "LIBRARY_FILTER_OPTION"
+        static let librarySortOption = "LIBRARY_SORT_OPTION"
     }
     
     enum FCMCenter {

--- a/WSSiOS/WSSiOS/Source/Data/Base/SortType.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Base/SortType.swift
@@ -17,15 +17,6 @@ enum SortType: Equatable {
         }
     }
     
-    var libraryQueryText: String {
-        switch self {
-        case .newest:
-            return "RECENT"
-        case .oldest:
-            return "OLD"
-        }
-    }
-    
     var text: String {
         switch self {
         case .newest:
@@ -54,6 +45,17 @@ enum SortType: Equatable {
             return .oldest
         case .oldest:
             return .newest
+        }
+    }
+    
+    static func fromText(_ text: String) -> SortType? {
+        switch text {
+        case "최신 순":
+            return .newest
+        case "오래된 순":
+            return .oldest
+        default:
+            return nil
         }
     }
 }

--- a/WSSiOS/WSSiOS/Source/Data/Repository/MyLibraryRepository/MyLibraryRepository.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Repository/MyLibraryRepository/MyLibraryRepository.swift
@@ -32,7 +32,7 @@ struct DefaultMyLibraryRepository: MyLibraryRepository {
         var queryItem = MyLibraryNovelListQuery(
             lastUserNovelId: lastUserNovelId,
             size: size,
-            sortType: sortType.libraryQueryText)
+            sortType: sortType.queryText)
         queryItem.isInterest = filterOption.interestedOption ? true : nil
         queryItem.novelRating = filterOption.starRatingOption.map { $0.toFloat }
         if !filterOption.readStatusOptions.isEmpty {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
@@ -127,7 +127,7 @@ final class MyLibraryFilterHeaderView: UIView {
         
         let text = switch (isSelected, isMoreThanOne) {
         case (true, false): selectedOption.first?.statusName
-        case (true, true): "\(selectedOption.first?.statusName ?? "") 외\(overCount)"
+        case (true, true): "\(selectedOption.first?.statusName ?? "") 외 \(overCount)"
         case (false, _): StringLiterals.MyLibrary.FilterButton.readStatus
         }
         
@@ -144,7 +144,7 @@ final class MyLibraryFilterHeaderView: UIView {
         
         let text = switch (isSelected, isMoreThanOne) {
         case (true, false): selectedOption.first?.koreanString
-        case (true, true): "\(selectedOption.first?.koreanString ?? "") 외\(overCount)"
+        case (true, true): "\(selectedOption.first?.koreanString ?? "") 외 \(overCount)"
         case (false, _): StringLiterals.MyLibrary.FilterButton.attractivePoint
         }
         

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -81,6 +81,11 @@ final class MyLibraryViewModel: ViewModelType {
             .bind(to: filterOption)
             .disposed(by: disposeBag)
         
+        input.viewWillAppear
+            .map { self.loadSortType() }
+            .bind(to: sortType)
+            .disposed(by: disposeBag)
+        
         input.interestFilterButtonDidTap
             .withLatestFrom(filterOption)
             .map { option in
@@ -96,6 +101,14 @@ final class MyLibraryViewModel: ViewModelType {
             .distinctUntilChanged()
             .bind(with: self, onNext: { owner, selectedOption in
                 owner.saveFilterOption(selectedOption)
+            })
+            .disposed(by: disposeBag)
+        
+        sortType
+            .skip(1)
+            .distinctUntilChanged()
+            .bind(with: self, onNext: { owner, selectedType in
+                owner.saveSortType(selectedType)
             })
             .disposed(by: disposeBag)
         
@@ -266,12 +279,27 @@ final class MyLibraryViewModel: ViewModelType {
         }
     }
     
+    private func saveSortType(_ sortType: SortType) {
+        UserDefaults.standard.set(sortType.text,
+                                  forKey: StringLiterals.UserDefault.librarySortOption)
+    }
+    
+    
     private func loadFilterOption() -> LibraryFilterOption {
         if let savedData = UserDefaults.standard.data(forKey: StringLiterals.UserDefault.libraryFilterOption),
            let loadedFilterOption = try? JSONDecoder().decode(LibraryFilterOption.self, from: savedData) {
             return loadedFilterOption
         } else { 
             return LibraryFilterOption()
+        }
+    }
+    
+    private func loadSortType() -> SortType {
+        if let savedData = UserDefaults.standard.string(forKey: StringLiterals.UserDefault.librarySortOption),
+           let sortType = SortType.fromText(savedData) {
+            return sortType
+        } else {
+            return SortType.newest
         }
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #596 
<br/>

### 🌟Motivation
서재소소 3차 QA 반영
<br/>

### 🌟Key Changes
- 필터 여러개 선택 시 '보는 중 외 1'과 같이 외와 숫자 사이에 띄어쓰기를 추가합니다.
- 최신순 오래된순 정렬 까지 UserDefault에 저장하여 해당 설정이 앱을 껏다 켜도 유지되도록 합니다.
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2025-07-22 at 14 17 57](https://github.com/user-attachments/assets/ae55448e-0f94-4bbc-b650-5b42936b1125)

<br/>

### 🌟To Reviewer
- 기능명세상 정렬까지 디바이스에 저장했어야 한다고 하네요 . .
<br/>

### 🌟Reference

<br/>
