### PR TITLE
[Feat] #611 - 1초 간 스플래시 뷰 보여지고 앱 전환 기능 적용 

### DIFF
--- a/WSSiOS/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/WSSiOS/App/SceneDelegate.swift
@@ -25,13 +25,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        self.window = UIWindow(windowScene: windowScene)
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
         
-        checkIsRegistered()
+        let spashViewController = SplashViewController()
+        window.rootViewController = spashViewController
+        window.makeKeyAndVisible()
         
-        APIConstants.isLogined ? setRootToWSSTabBarController() : setRootToLoginViewController()
-        
-        self.window?.makeKeyAndVisible()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.checkIsRegistered()
+            
+            if APIConstants.isLogined {
+                self.setRootToWSSTabBarController()
+            } else {
+                self.setRootToLoginViewController()
+            }
+        }
     }
     
     func setRootToWSSTabBarController() {
@@ -94,7 +103,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-    
-    
 }
-

--- a/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashView.swift
@@ -11,13 +11,14 @@ import SnapKit
 import Then
 
 final class SplashView: UIView {
+    
     //MARK: - UI Components
     
-    let backgroundImageView = UIImageView()
-    let splashAppLogoImageView = UIImageView()
-    let splashAppTypeImageView = UIImageView()
+    private let backgroundImageView = UIImageView()
+    private let splashAppLogoImageView = UIImageView()
+    private let splashAppTypeImageView = UIImageView()
     
-    let middleView = UIView()
+    private let middleView = UIView()
     
     //MARK: - Life Cycle
     
@@ -54,10 +55,9 @@ final class SplashView: UIView {
     
     private func setHierarchy() {
         self.addSubview(backgroundImageView)
-        backgroundImageView.addSubviews(
-            middleView,
-            splashAppLogoImageView,
-            splashAppTypeImageView)
+        backgroundImageView.addSubviews(middleView,
+                                        splashAppLogoImageView,
+                                        splashAppTypeImageView)
     }
     
     private func setLayout() {

--- a/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashView.swift
@@ -1,0 +1,84 @@
+//
+//  SplashView.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 7/31/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SplashView: UIView {
+    //MARK: - UI Components
+    
+    let backgroundImageView = UIImageView()
+    let splashAppLogoImageView = UIImageView()
+    let splashAppTypeImageView = UIImageView()
+    
+    let middleView = UIView()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        backgroundImageView.do {
+            $0.image = .imgSplashBackground
+        }
+        
+        splashAppLogoImageView.do {
+            $0.image = .imgSplashIcon
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        splashAppTypeImageView.do {
+            $0.image = .imgSplashType
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        middleView.isHidden = true
+    }
+    
+    private func setHierarchy() {
+        self.addSubview(backgroundImageView)
+        backgroundImageView.addSubviews(
+            middleView,
+            splashAppLogoImageView,
+            splashAppTypeImageView)
+    }
+    
+    private func setLayout() {
+        backgroundImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        middleView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top)
+            $0.bottom.equalTo(splashAppTypeImageView.snp.top)
+            $0.centerX.equalToSuperview()
+        }
+        
+        splashAppLogoImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalTo(middleView.snp.centerY)
+        }
+        
+        splashAppTypeImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(30)
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashViewController.swift
@@ -1,0 +1,23 @@
+//
+//  SplashViewController.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 7/31/25.
+//
+
+import UIKit
+
+final class SplashViewController: UIViewController {
+    
+    //MARK: - Components
+    
+    private let rootView = SplashView()
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}


### PR DESCRIPTION
### ⭐️Issue
- close #611 
<br/>

### 🌟Motivation
- 1초 간 스플래시 뷰 보여지고 앱 전환 될 수 있도록 구현했습니다. 
<br/>

### 🌟Key Changes
기존 LaunchScreen의 레이아웃과 맞추기 위해 `SplashView` 내에 `middleView`라는 `UIView`를 추가하였습니다. 
해당 뷰는 `safeArea.top`과 `appTypeImageView.top`의 사이를 차지하고 있고, `appIconImageView`는 `middleView`의 `centerY`에 위치할 수 있도록 했습니다. (피그마 디자인에 따르기 위함)

https://github.com/Team-WSS/WSS-iOS/blob/e466b26f56bfd9bd8cfb3ab25765657208a3e050/WSSiOS/WSSiOS/Source/Presentation/Splash/SplashView.swift#L68-L77
<br/>


### 🌟Simulation
- 로그인이 필요할 때 

https://github.com/user-attachments/assets/b507ce57-4526-4868-824e-b8b04f0f6703

- 자동 로그인 시

https://github.com/user-attachments/assets/97b01cec-2528-4935-94ab-2fb52ceb9043



<br/>

### 🌟To Reviewer
스플래시뷰가 보여지는 시간은 안드가 현재 1초동안 보여지고 있다고 하여 해당 시간으로 맞추었습니다!
<br/>

### 🌟Reference

<br/>
