### PR TITLE
[Feat] #613 - 1.3.0 업데이트를 위한 기획 수정 사항 반영

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025032903;
+				CURRENT_PROJECT_VERSION = 2025080101;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L4327HMP3S;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -353,11 +353,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = websosoDebugProvisioning;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development kr.websoso.debug";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -379,7 +379,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025032903;
+				CURRENT_PROJECT_VERSION = 2025080101;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L4327HMP3S;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -396,7 +396,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
@@ -50,6 +50,8 @@ extension StringLiterals {
         static let spoilerText = "스포일러가 포함된 글 보기"
         static let modifiedText = "(수정됨)"
         static let isPrivate = "나만 보는 기록이에요."
+        static let isEmpty = "아직 남긴 기록이 없어요"
+        static let writeFeed = "글 쓰러 가기"
         
         enum Filter {
             static let title = "글 찾기 필터"

--- a/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+MyLibrary.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/Strings/StringLiterals+MyLibrary.swift
@@ -27,7 +27,7 @@ extension StringLiterals {
         
         enum Empty {
             static let libraryEmpty = "서재가 비어있어요"
-            static let searchButton = "웹소설 찾으러 가기"
+            static let searchButton = "웹소설 찾기"
             static let filterResultEmpty = "해당하는 작품이 없어요\n검색의 범위를 더 넓혀보세요"
         }
     }

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -198,7 +198,7 @@ enum URLs {
     
     enum Contact {
         static let kakao = "http://pf.kakao.com/_kHxlWG"
-        static let inquiry = "https://websoso.notion.site/1c4600bd7468817f9b48e6644c0b6720?pvs=105"
+        static let inquiry = "https://helpwebsoso.notion.site/241a9688d1a38164b3f8efd0b51edaab?pvs=105"
     }
     
     enum Setting {

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -202,7 +202,7 @@ enum URLs {
     }
     
     enum Setting {
-        static let QNAInHompageURL = "https://websoso.notion.site/144600bd746881d4b012fbaf586c264d?pvs=105"
+        static let QNAInHompageURL = "https://helpwebsoso.notion.site/241a9688d1a381548c20dd314d0a0b0a"
         static let instaURL = "https://www.instagram.com/websoso_official/"
         static let termsURL = "https://websoso.notion.site/143600bd746880668556fb005fcef491?pvs=143"
         static let infoURL = "https://websoso.notion.site/143600bd74688050be18f4da31d9403e?pvs=4"

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
@@ -1,0 +1,101 @@
+//
+//  FeedEmptyView.swift
+//  WSSiOS
+//
+//  Created by 신지원 on 8/1/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FeedEmptyView: UIView {
+    
+    //MARK: - Components
+    
+    private let emptyStackView = UIStackView()
+    private let emptyImageView = UIImageView()
+    private let emptyTitleLabel = UILabel()
+    var writeFeedButton = UIButton()
+    private var writeFeedButtonLabel = UILabel()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - UI
+    
+    private func setUI() {
+        self.backgroundColor = .wssWhite
+        
+        emptyStackView.do {
+            $0.axis = .vertical
+            $0.distribution = .fill
+            $0.alignment = .center
+            $0.spacing = 8
+            
+            emptyImageView.do {
+                $0.image = .imgEmpty
+            }
+            
+            emptyTitleLabel.do {
+                $0.applyWSSFont(.body1, with: StringLiterals.Feed.isEmpty)
+                $0.textColor = .wssGray200
+                $0.textAlignment = .center
+            }
+        }
+        
+        writeFeedButton.do {
+            $0.layer.backgroundColor = UIColor.wssPrimary50.cgColor
+            $0.layer.cornerRadius = 12
+        }
+        
+        writeFeedButtonLabel.do {
+            $0.applyWSSFont(.title1, with: StringLiterals.Feed.writeFeed)
+            $0.textColor = .wssPrimary100
+            $0.isUserInteractionEnabled = false
+        }
+    }
+    
+    private func setHierarchy() {
+        self.addSubviews(emptyStackView,
+                         writeFeedButton)
+        emptyStackView.addArrangedSubviews(emptyImageView,
+                                           emptyTitleLabel)
+        writeFeedButton.addSubview(writeFeedButtonLabel)
+    }
+    
+    private func setLayout() {
+        emptyStackView.snp.makeConstraints() {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.leading.equalToSuperview().inset(90)
+        }
+        
+        emptyImageView.snp.makeConstraints() {
+            $0.height.equalTo(48)
+        }
+        
+        writeFeedButton.snp.makeConstraints() {
+            $0.top.equalTo(emptyStackView.snp.bottom).offset(45)
+            $0.centerX.equalToSuperview()
+            $0.leading.equalToSuperview().inset(90)
+            $0.height.equalTo(53)
+            
+            writeFeedButtonLabel.snp.makeConstraints {
+                $0.center.equalToSuperview()
+            }
+        }
+    }
+}

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
@@ -43,17 +43,16 @@ final class FeedEmptyView: UIView {
             $0.axis = .vertical
             $0.distribution = .fill
             $0.alignment = .center
-            $0.spacing = 8
-            
-            emptyImageView.do {
-                $0.image = .imgEmpty
-            }
-            
-            emptyTitleLabel.do {
-                $0.applyWSSFont(.body1, with: StringLiterals.Feed.isEmpty)
-                $0.textColor = .wssGray200
-                $0.textAlignment = .center
-            }
+        }
+        
+        emptyImageView.do {
+            $0.image = .imgEmpty
+        }
+        
+        emptyTitleLabel.do {
+            $0.applyWSSFont(.body1, with: StringLiterals.Feed.isEmpty)
+            $0.textColor = .wssGray200
+            $0.textAlignment = .center
         }
         
         writeFeedButton.do {
@@ -69,18 +68,21 @@ final class FeedEmptyView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubviews(emptyStackView,
-                         writeFeedButton)
+        self.addSubviews(emptyStackView)
         emptyStackView.addArrangedSubviews(emptyImageView,
-                                           emptyTitleLabel)
+                                           emptyTitleLabel,
+                                           writeFeedButton)
         writeFeedButton.addSubview(writeFeedButtonLabel)
     }
     
     private func setLayout() {
         emptyStackView.snp.makeConstraints() {
-            $0.top.equalToSuperview()
-            $0.centerX.equalToSuperview()
-            $0.leading.equalToSuperview().inset(90)
+            $0.edges.equalToSuperview()
+        }
+        
+        emptyStackView.do {
+            $0.setCustomSpacing(8, after: emptyImageView)
+            $0.setCustomSpacing(45, after: emptyTitleLabel)
         }
         
         emptyImageView.snp.makeConstraints() {
@@ -88,9 +90,7 @@ final class FeedEmptyView: UIView {
         }
         
         writeFeedButton.snp.makeConstraints() {
-            $0.top.equalTo(emptyStackView.snp.bottom).offset(45)
-            $0.centerX.equalToSuperview()
-            $0.leading.equalToSuperview().inset(90)
+            $0.horizontalEdges.equalToSuperview().inset(90)
             $0.height.equalTo(53)
             
             writeFeedButtonLabel.snp.makeConstraints {

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/FeedEmptyView.swift
@@ -18,7 +18,7 @@ final class FeedEmptyView: UIView {
     private let emptyImageView = UIImageView()
     private let emptyTitleLabel = UILabel()
     var writeFeedButton = UIButton()
-    private var writeFeedButtonLabel = UILabel()
+    private let writeFeedButtonLabel = UILabel()
     
     // MARK: - Life Cycle
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
@@ -15,7 +15,7 @@ final class FeedPageContentView: UIView {
     //MARK: - Components
     
     let myFeedFilterHeaderView = MyFeedFilterHeaderView()
-    private let emptyView = NovelDetailFeedEmptyView()
+    let emptyView = FeedEmptyView()
     let feedTableView = UITableView(frame: .zero, style: .plain)
     let dropdownView = FeedDetailDropdownView()
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
@@ -61,7 +61,8 @@ final class FeedPageContentView: UIView {
     
     private func setLayout() {
         emptyView.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.centerY.equalToSuperview().inset(-57)
         }
         
         feedTableView.snp.makeConstraints() {

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedPageContentView.swift
@@ -62,7 +62,7 @@ final class FeedPageContentView: UIView {
     private func setLayout() {
         emptyView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.centerY.equalToSuperview().inset(-57)
+            $0.centerY.equalToSuperview()
         }
         
         feedTableView.snp.makeConstraints() {

--- a/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedPageContentViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedPageContentViewController.swift
@@ -294,6 +294,12 @@ final class FeedPageContentViewController: UIViewController {
             .distinctUntilChanged()
             .bind(to: viewModel.filterOption)
             .disposed(by: disposeBag)
+        
+        rootView.emptyView.writeFeedButton.rx.tap
+            .bind(with: self, onNext: { _, _ in
+                self.pushToFeedEditViewController()
+            })
+            .disposed(by: disposeBag)
     }
     
     //MARK: - Custom Method

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryEmptyView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryEmptyView.swift
@@ -75,8 +75,7 @@ final class MyLibraryEmptyView: UIView {
     
     private func setLayout() {
         stackView.snp.makeConstraints() {
-            $0.centerY.equalToSuperview().offset(-59)
-            $0.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
         
         stackView.do {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
@@ -99,7 +99,8 @@ final class MyLibraryView: UIView {
         
         libraryEmptyView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.centerY.equalToSuperview().offset(97)
+            $0.centerY.equalToSuperview().offset(57)
+            
         }
         
         libraryFilterResultEmptyView.snp.makeConstraints {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryView.swift
@@ -98,9 +98,8 @@ final class MyLibraryView: UIView {
         }
         
         libraryEmptyView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(97)
         }
         
         libraryFilterResultEmptyView.snp.makeConstraints {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #613 
<br/>

### 🌟Motivation
기획쪽에서 요청한 수정 사항을 반영하였습니다.
<br/>

### 🌟Key Changes
- URL 수정
- 내 피드 결과 없을 때(=Empty뷰) 디자인 변경
- 내피드 empty뷰와 서재 empty 뷰의 center 내피드 기준으로 동일하게 맞추기
  - 아래 이미지와 같이 이미지-텍스트-버튼 이 동일Y축에 있었으면 좋겠다는 기획요청입니다.
  - center 의 기준은 내피드로 맞춰달라고 요청 받았습니다.
<img width="592" height="385" alt="스크린샷 2025-08-01 오후 8 24 05" src="https://github.com/user-attachments/assets/541891e3-8103-4a9b-ab0c-da32b1096df6" />

- '웹소설 찾으러 가기' -> '웹소설 찾기' 로 워딩 변경

<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 16 Pro - 2025-08-01 at 20 19 54](https://github.com/user-attachments/assets/07fa752b-263b-417b-99b0-e8569e8f7f20)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
