### PR TITLE
[Fix] #616 - 타 유저 피드 내 썸네일 이미지 안보임 이슈 | 타 유저 피드 상세 내 데이터 중복 호출 이슈 

### DIFF
--- a/WSSiOS/WSSiOS/Source/Data/Entity/Feed/TotalFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/Feed/TotalFeedListEntity.swift
@@ -76,7 +76,7 @@ extension TotalFeedListEntity {
                     isModified: $0.isModified,
                     isMyFeed: true,
                     isPublic: $0.isPublic,
-                    thumbnailImageURL: URL(string: $0.thumbnailImage ?? ""),
+                    thumbnailImageURL: $0.thumbnailImage,
                     hasImage: $0.hasImage,
                     imageCount: $0.imageCount)
             })

--- a/WSSiOS/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
@@ -41,7 +41,7 @@ struct UserFeedEntity {
     let relevantCategories: [String]
     let isPublic: Bool
     
-    let thumbnailImage: String?
+    let thumbnailImage: URL?
     let hasImage: Bool
     let imageCount: Int
 }
@@ -63,6 +63,7 @@ extension UserFeedResponse {
         let genre = NewNovelGenre(rawValue: self.genre ?? "")
         let novelGenreColor = genre?.linkColor ?? .genreColorR
         let novelGenreImage = genre?.linkImage ?? .icGenreLinkR
+        let thumbnailImageURL = KingFisherRxHelper.makeImageURLString(path: self.thumbnailUrl ?? "")
         
         return UserFeedEntity(feedId: self.feedId,
                               feedContent: self.feedContent,
@@ -79,7 +80,7 @@ extension UserFeedResponse {
                               feedWriterNovelRating: roundedRating,
                               relevantCategories: translatedGenres,
                               isPublic: isPublic,
-                              thumbnailImage: self.thumbnailUrl,
+                              thumbnailImage: thumbnailImageURL,
                               hasImage: hasImage,
                               imageCount: self.imageCount)
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListTableViewCell.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/FeedList/FeedListTableViewCell.swift
@@ -224,7 +224,7 @@ final class FeedListTableViewCell: UITableViewCell {
         
         // 첨부 이미지 바인딩
         if (feed.feed.hasImage && !feed.feed.isSpoiler) {
-            //feedImageView.bindData(thumbnailImage: feed.feed.thumbnailImage, imageCount: feed.feed.imageCount)
+            feedImageView.bindData(thumbnailImage: feed.feed.thumbnailImage, imageCount: feed.feed.imageCount)
             stackView.insertArrangedSubview(feedImageView, at: 2)
             
             let spacingAfterImage: CGFloat = hasConnectedNovel ? 20 : 10

--- a/WSSiOS/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageFeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageFeedDetailViewModel.swift
@@ -57,7 +57,7 @@ final class UserPageFeedDetailViewModel: ViewModelType {
         input.loadNextPageTrigger
             .filter { [weak self] _ in
                 guard let self = self else { return false }
-                return !self.isFetching && self.isLoadableRelay.value
+                return !self.isFetching && self.isLoadableRelay.value && !self.feedDataRelay.value.isEmpty
             }
             .do(onNext: { [weak self] _ in
                 self?.isFetching = true


### PR DESCRIPTION
### ⭐️Issue
- close #616 
<br/>

### 🌟Motivation
- 타 유저 피드 내 썸네일 이미지 안보임 이슈 수정했습니다. 
- 타 유저 피드 상세 내 데이터 중복 호출 이슈 수정했습니다. 
<br/>

### 🌟Key Changes
- 타 유저 피드에서 썸네일 이미지와 이미지 개수 값이 연결이 안되어있는 걸 확인했습니다. 
(제가 오류가 생겨서 주석처리 해둔 걸 안풀어뒀네요 ㅠㅠ)
해당 사항 반영해서 시뮬레이터 상에서 잘 작동하는 것 확인했습니다. 

- 타 유저 피드 상세로 들어갈 때 데이터가 처음에 2번씩 호출되고 있는 걸 확인했습니다. 
확인해보니, `UserPageFeedDetailViewModel`에서 `viewWillAppearEvent`와 `loadNextPageTrigger`가 모두 초기 데이터를 불러오는 API를 호출하고 있어서 해당 이슈가 발생했습니다. 
따라서, `loadNextPageTrigger`에서 `!self.feedDataRelay.value.isEmpty`라는 코드를 추가하여 초기 데이터가 없을 때에는 무한 스크롤 트리거가 호출되지 않도록 했습니다. 
<br/>


### 🌟Simulation
![Simulator Screen Recording - iPhone 13 mini - 2025-08-12 at 18 35 51](https://github.com/user-attachments/assets/fdfe13dc-4077-42ca-9934-4c838074dbe3)

<br/>

### 🌟To Reviewer
배포를 위한 빠른 리뷰 부탁드립니다!
<br/>

### 🌟Reference

<br/>
