### PR TITLE
[Fix] #618 - 타인 서재 API 호출 및 디코딩 에러 해결

### DIFF
--- a/WSSiOS/WSSiOS/Network/User/UserService.swift
+++ b/WSSiOS/WSSiOS/Network/User/UserService.swift
@@ -50,7 +50,7 @@ final class DefaultUserService: NSObject, Networking {
             URLQueryItem(name: "readStatus", value: readStatus),
             URLQueryItem(name: "lastUserNovelId", value: String(describing: lastUserNovelId)),
             URLQueryItem(name: "size", value: String(describing: size)),
-            URLQueryItem(name: "sortType", value: sortType)
+            URLQueryItem(name: "sortCriteria", value: sortType)
         ]
     }
 }

--- a/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -44,7 +44,7 @@ enum URLs {
             return "\(userBasePath)/\(userId)/feeds"
         }
         static func getUserNovel(userId: Int) -> String {
-            return "\(userBasePath)/\(userId)/novels"
+            return "\(userBasePath)/\(userId)/novels/legacy"
         }
         static let isProfileVisibility = "\(userBasePath)/profile-status"
         static let getAppMinimumVersion = "/minimum-version"

--- a/WSSiOS/WSSiOS/Source/Data/DTO/User/UserNovelListResponse.swift
+++ b/WSSiOS/WSSiOS/Source/Data/DTO/User/UserNovelListResponse.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct UserNovelListResponse: Decodable {
     let userNovelCount: Int
-    let userNovelRating: Float
     let isLoadable: Bool
     let userNovels: [UserNovelResponse]
 }

--- a/WSSiOS/WSSiOS/Source/Data/Entity/User/UserNovelListEntity.swift
+++ b/WSSiOS/WSSiOS/Source/Data/Entity/User/UserNovelListEntity.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct UserNovelListEntity {
     let userNovelCount: Int
-    let userNovelRating: Float
     let isLoadable: Bool
     let userNovels: [UserNovelEntity]
 }
@@ -17,7 +16,6 @@ struct UserNovelListEntity {
 extension UserNovelListResponse {
     func toEntity() -> UserNovelListEntity {
         return UserNovelListEntity(userNovelCount: self.userNovelCount,
-                                   userNovelRating: self.userNovelRating,
                                    isLoadable: self.isLoadable,
                                    userNovels: self.userNovels.map { $0.toEntity() })
     }

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/UserLibrary/UserLibraryViewModel/UserLibraryChildViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/UserLibrary/UserLibraryViewModel/UserLibraryChildViewModel.swift
@@ -152,14 +152,14 @@ final class UserLibraryChildViewModel: ViewModelType {
                     guard let self = self else { return false }
                     return !self.isSortTypeNewestRelay.value
                 }
-                .map { ("newest", true) },
+                .map { (SortType.newest.queryText, true) },
             input.oldestTapped
                 .throttle(.seconds(1), scheduler: MainScheduler.instance)
                 .filter { [weak self] _ in
                     guard let self = self else { return false }
                     return self.isSortTypeNewestRelay.value
                 }
-                .map { ("oldest", false) }
+                .map { (SortType.oldest.queryText, false) }
         )
         .do(onNext: { [weak self] sortType, isNewest in
             self?.isSortTypeNewestRelay.accept(isNewest)

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/UserLibrary/UserLibraryViewModel/UserLibraryChildViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/UserLibrary/UserLibraryViewModel/UserLibraryChildViewModel.swift
@@ -126,7 +126,7 @@ final class UserLibraryChildViewModel: ViewModelType {
                                              data: UserNovelNovelStatus(readStatus: self.initData.readStatus,
                                                                         lastUserNovelId: self.lastNovelIdRelay.value,
                                                                         size: self.initData.size,
-                                                                        sortType: isSortTypeNewestRelay.value ? StringLiterals.Alignment.newest.sortType : StringLiterals.Alignment.oldest.sortType))
+                                                                        sortType: isSortTypeNewestRelay.value ? SortType.newest.queryText : SortType.oldest.queryText))
             }
             .subscribe(with: self, onNext: { owner, novelResult in
                 owner.setNovelListData(novelResult)
@@ -246,7 +246,7 @@ final class UserLibraryChildViewModel: ViewModelType {
             readStatus: self.initData.readStatus,
             lastUserNovelId: self.lastNovelIdRelay.value,
             size: self.initData.size,
-            sortType: self.isSortTypeNewestRelay.value ? StringLiterals.Alignment.newest.sortType : StringLiterals.Alignment.oldest.sortType
+            sortType: self.isSortTypeNewestRelay.value ? SortType.newest.queryText : SortType.oldest.queryText
         )
         
         self.updateCollectionViewWithLoadTriggerRelay.accept(status)


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #618
<br/>

### 🌟Motivation
- 안드&서버에서 서재소소에서 다음 사일로에서 진행 예정이었던 타인 서재 UI 개편을 진행하면서, 서버 API가 기존의 타인 서재 API를 덮어씀에 따라, 기존 타인 서재 UI를 그대로 유지하던 iOS앱과 충돌이 발생한 것을 해결합니다.
<br/>

### 🌟Key Changes
- 기존의 타인 서재 API를 추가 API로 수정한 결과 API 엔드 포인트, Query Text, Response 가 변경되어 이에 맞춰 수정 작업을 진행했습니다.
<br/>


### 🌟Simulation
![Simulator Screen Recording - iPhone 15 Pro - 2025-08-15 at 00 55 32](https://github.com/user-attachments/assets/b52bc5a5-8f22-414e-a640-61fecacb19b2)

<br/>

### 🌟To Reviewer
- 빠른 리뷰 부탁합니다. 간단해요 !
<br/>

### 🌟Reference

<br/>
