### PR TITLE
[Fix] #622 - 댓글 수정/삭제 후 동일한 댓글 작성 시 버튼 비활성화 되는 버그 해결

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -465,7 +465,6 @@ final class FeedDetailViewModel: ViewModelType {
                     owner.showCommentDeleteAlertView.accept((owner.deleteComment,
                                                              owner.feedId,
                                                              owner.selectedCommentId))
-                    print("owner.initialCommentContent: \(owner.initialCommentContent)")
                 case (.top, false):
                     // 스포일러 댓글 신고하기
                     owner.showCommentSpoilerAlertView.accept((owner.postSpoilerComment,

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -326,58 +326,61 @@ final class FeedDetailViewModel: ViewModelType {
             .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
             .flatMapLatest { [weak self] _ -> Observable<Void> in
                 guard let self = self else { return .empty() }
-
+                
                 if self.isProcessing { return .empty() }
                 self.isProcessing = true
-
+                
                 AmplitudeManager.shared.track(AmplitudeEvent.Feed.writeComment)
-
+                
                 let finishSendingComment: () -> Void = {
                     self.isProcessing = false
                     self.textViewResignFirstResponder.accept(())
+                    
+                    self.initialCommentContent = ""
                     self.updatedCommentContent = ""
+                    
                     self.textViewEmpty.accept(true)
                     self.showPlaceholder.accept(true)
                     self.showLoadingView.accept(false)
                 }
-
+                
                 if self.isCommentEditing {
                     return self.putComment(self.feedId,
                                            self.selectedCommentId,
                                            self.updatedCommentContent)
-                        .flatMapLatest { _ in
-                            self.getSingleFeedComments(self.feedId)
-                                .do(onNext: { newComments in
-                                    self.commentsData.accept(newComments.comments)
-                                    self.showLoadingView.accept(true)
-                                })
-                                .map { _ in () }
-                        }
-                        .do(onNext: {
-                            finishSendingComment()
-                            self.isCommentEditing = false
-                            self.selectedCommentId = 0
-                        }, onError: { _ in
-                            self.isProcessing = false
-                        })
+                    .flatMapLatest { _ in
+                        self.getSingleFeedComments(self.feedId)
+                            .do(onNext: { newComments in
+                                self.commentsData.accept(newComments.comments)
+                                self.showLoadingView.accept(true)
+                            })
+                            .map { _ in () }
+                    }
+                    .do(onNext: {
+                        finishSendingComment()
+                        self.isCommentEditing = false
+                        self.selectedCommentId = 0
+                    }, onError: { _ in
+                        self.isProcessing = false
+                    })
                 } else {
                     return self.postComment(self.feedId,
                                             self.updatedCommentContent)
-                        .flatMapLatest { _ in
-                            self.getSingleFeedComments(self.feedId)
-                                .do(onNext: { newComments in
-                                    self.commentsData.accept(newComments.comments)
-                                    self.showLoadingView.accept(true)
-                                })
-                                .map { _ in () }
-                        }
-                        .do(onNext: {
-                            finishSendingComment()
-                            self.selectedCommentId = 0
-                            self.commentCount.accept(self.commentCount.value + 1)
-                        }, onError: { _ in
-                            self.isProcessing = false
-                        })
+                    .flatMapLatest { _ in
+                        self.getSingleFeedComments(self.feedId)
+                            .do(onNext: { newComments in
+                                self.commentsData.accept(newComments.comments)
+                                self.showLoadingView.accept(true)
+                            })
+                            .map { _ in () }
+                    }
+                    .do(onNext: {
+                        finishSendingComment()
+                        self.selectedCommentId = 0
+                        self.commentCount.accept(self.commentCount.value + 1)
+                    }, onError: { _ in
+                        self.isProcessing = false
+                    })
                 }
             }
             .subscribe()

--- a/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -439,7 +439,6 @@ final class FeedDetailViewModel: ViewModelType {
                     if let index = owner.commentsData.value.firstIndex(where: { $0.commentId == commentId }) {
                         let indexPath = IndexPath(row: index, section: 0)
                         owner.showCommentDropdownView.accept((indexPath, isMyComment))
-                        owner.initialCommentContent = owner.commentsData.value[index].commentContent
                     }
                 }
                 owner.selectedCommentId = commentId
@@ -453,18 +452,30 @@ final class FeedDetailViewModel: ViewModelType {
                 owner.hideCommentDropdownView.accept(())
                 switch result {
                 case (.top, true):
+                    // 댓글 수정하기
                     owner.isCommentEditing = true
                     owner.myCommentEditing.accept(())
+                    
+                    // 수정할 때에만 initialCommentContent가 업데이트되도록 한다.
+                    if let index = owner.commentsData.value.firstIndex(where: { $0.commentId == owner.selectedCommentId }) {
+                        owner.initialCommentContent = owner.commentsData.value[index].commentContent
+                    }
                 case (.bottom, true):
+                    // 댓글 삭제하기
                     owner.showCommentDeleteAlertView.accept((owner.deleteComment,
                                                              owner.feedId,
                                                              owner.selectedCommentId))
-                case (.top, false): owner.showCommentSpoilerAlertView.accept((owner.postSpoilerComment,
-                                                                              owner.feedId,
-                                                                              owner.selectedCommentId))
-                case (.bottom, false): owner.showCommentImpertinenceAlertView.accept((owner.postImpertinenceComment,
-                                                                                      owner.feedId,
-                                                                                      owner.selectedCommentId))
+                    print("owner.initialCommentContent: \(owner.initialCommentContent)")
+                case (.top, false):
+                    // 스포일러 댓글 신고하기
+                    owner.showCommentSpoilerAlertView.accept((owner.postSpoilerComment,
+                                                              owner.feedId,
+                                                              owner.selectedCommentId))
+                case (.bottom, false):
+                    // 부적절한 댓글 신고하기
+                    owner.showCommentImpertinenceAlertView.accept((owner.postImpertinenceComment,
+                                                                   owner.feedId,
+                                                                   owner.selectedCommentId))
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### ⭐️Issue
- close #622 
<br/>

### 🌟Motivation
댓글 수정/삭제 후 동일한 댓글 작성 시 버튼 비활성화 되는 버그를 해결했습니다. 
<br/>

### 🌟Key Changes
댓글 수정 후 및 댓글 삭제 시 동일한 컨텐츠의 댓글을 작성하면 댓글 전송 버튼이 비활성화되는 버그가 있었습니다. 

### 원인 1
댓글 전송 후 `let isNotChanged = comment == owner.initialCommentContent` 라는 플래그 변수를 통해
**댓글 수정** 시 기존 컨텐츠와 비교하며 값이 바뀌었는지 확인하는 로직을 갖고 있었습니다. 

### 해결 1
하지만 **댓글 작성** 시에는 해당 검증 로직이 필요하지 않습니다. 
댓글 작성 후에는 `initialCommentContent = ""` 로 초기화하여 유저가 댓글 작성/수정 후 동일한 댓글을 작성해도 버튼은 활성화 될 수 있도록 로직 반영했습니다. 

<br/>

```swift
let finishSendingComment: () -> Void = {
    self.isProcessing = false
    self.textViewResignFirstResponder.accept(())
                    
    self.initialCommentContent = "" // 추가한 코드 
    self.updatedCommentContent = ""
                    
    self.textViewEmpty.accept(true)
    self.showPlaceholder.accept(true)
    self.showLoadingView.accept(false)
}
```

<br/>
<br/>

### 원인 2
댓글 삭제 후 동일한 내용의 댓글 작성 시 전송 버튼이 비활성화 되는 상황이 있었습니다. 
`FeedDetailViewModel`에서 각 댓글에 대한 ellipsis 버튼에 대한 로직을 정의해두었습니다. `input.commentdotsButtonDidTap`


해당 코드 블럭 내에 
```swift
owner.initialCommentContent = owner.commentsData.value[index].commentContent
```
`initialCommentContent`를 갱신하는 코드가 있었어서, 피드 수정 및 삭제 시 모두 해당 이슈가 있었습니다. 
따라서, 피드 수정 시에만 해당 변수를 갱신할 수 있도록 수정했습니다. 

### 해결 2
`input.commentdotsButtonDidTap`에 있던 위의 코드를 제거했습니다. 
그리고 드롭다운 내 버튼에 대한 로직을 정의한 `input.commentDropdownDidTap`에서 피드 수정 시에만 갱신되도록 수정했습니다. 


<br/>

```swift
input.commentDropdownDidTap
    .map { ($0, self.isMyComment) }
    .subscribe(with: self, onNext: { owner, result in
        owner.hideCommentDropdownView.accept(())
        switch result {
            case (.top, true):
                // 댓글 수정하기
                owner.isCommentEditing = true
                owner.myCommentEditing.accept(())
                    
                // * 수정할 때에만 initialCommentContent가 업데이트되도록 한다.
                if let index = owner.commentsData.value.firstIndex(where: { $0.commentId == owner.selectedCommentId }) {
                    owner.initialCommentContent = owner.commentsData.value[index].commentContent
}
```
<br/>

### 🌟Simulation

#### before
| 댓글 삭제 | 댓글 수정 | 
| -- | -- | 
| ![Simulator Screen Recording - iPhone 13 mini - 2025-10-02 at 18 03 39](https://github.com/user-attachments/assets/8703b430-a69f-44dd-b363-c557233070c7)|  ![Simulator Screen Recording - iPhone 13 mini - 2025-10-02 at 18 03 26](https://github.com/user-attachments/assets/b52fc867-e996-4207-bcc9-df5ea09db643)| 
<br/>

#### after
| 댓글 삭제 | 댓글 수정 | 
| -- | -- | 
|  ![Simulator Screen Recording - iPhone 13 mini - 2025-10-02 at 18 07 50](https://github.com/user-attachments/assets/944178b1-89ce-4f41-9baf-88643592a622)| ![Simulator Screen Recording - iPhone 13 mini - 2025-10-02 at 18 07 38](https://github.com/user-attachments/assets/55e96ab1-709b-4985-9ff3-a0a7ad3678a4) |

<br/>


### 🌟To Reviewer
버그 리포트해주신 기중씨 @GiJungPark 에게 감사합니다 ( _ _ ) b
<br/>

### 🌟Reference

<br/>

