### PR TITLE
[Fix] #628 - 에러뷰 새로고침 버튼 기능 연결

### DIFF
--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
@@ -200,7 +200,8 @@ final class MyLibraryViewController: UIViewController {
             layoutToggleButtonDidTap: rootView.headerView.layoutToggleButton.rx.tap,
             collectionViewDidReachBottom: collectionViewDidReachBottom,
             tableViewDidReachBottom: tableViewDidReachBottom,
-            novelItemSelected: novelItemSelected
+            novelItemSelected: novelItemSelected,
+            networkErrorRefreshButtonDidTap: rootView.networkErrorView.refreshButton.rx.tap
         )
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewModel/MyLibraryViewModel.swift
@@ -55,6 +55,7 @@ final class MyLibraryViewModel: ViewModelType {
         let collectionViewDidReachBottom: Observable<Void>
         let tableViewDidReachBottom: Observable<Void>
         let novelItemSelected: Observable<IndexPath>
+        let networkErrorRefreshButtonDidTap: ControlEvent<Void>
     }
     
     struct Output {
@@ -137,6 +138,10 @@ final class MyLibraryViewModel: ViewModelType {
         )
         .bind(to: fetchNovelList)
         .disposed(by: disposeBag)
+        
+        input.networkErrorRefreshButtonDidTap
+            .bind(to: reloadNovelList)
+            .disposed(by: disposeBag)
         
         reloadNovelList
             .bind(with: self, onNext: { owner, _ in


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #628 
<br/>

### 🌟Motivation
- API 요청에서 에러 발생 시 에러뷰가 뜨는 건 되어 있는데, 새로고침 버튼 기능 연결이 되어있지 않아 수정합니다.
<br/>

### 🌟Key Changes
- 에러뷰 새로고침 버튼 기능 연결
<br/>


### 🌟Simulation
![Simulator Screen Recording - iPhone 17 Pro - 2025-12-09 at 02 24 14](https://github.com/user-attachments/assets/7c80ad84-3d51-4f08-83ae-37120844c4b4)

<br/>

### 🌟To Reviewer
- 포폴 작성하다가 발견했네욤..
<br/>

### 🌟Reference

<br/>
