### PR TITLE
[Feat] #630 - Tabbar iOS26 Liquid Glass UI Tabbar 적용을 위한 분기처리 구현

### DIFF
--- a/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS/WSSiOS.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025080901;
+				CURRENT_PROJECT_VERSION = 2025121901;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -380,7 +380,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025080901;
+				CURRENT_PROJECT_VERSION = 2025121901;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -398,7 +398,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
@@ -50,20 +50,33 @@ final class WSSTabBarController: UITabBarController {
     //MARK: - UI
     
     private func setUI() {
-        view.do {
-            $0.backgroundColor = .wssWhite
-        }
+        tabBar.itemPositioning = .centered
         
-        tabBar.do {
-            let border = CALayer()
-            border.backgroundColor = UIColor.wssGray50.cgColor
-            border.frame = CGRect(x: 0, y: 0, width: $0.frame.width, height: 1)
+        if #available(iOS 26.0, *) {
+            tabBar.isTranslucent = true
+            tabBar.tintColor = .wssBlack
+            tabBar.unselectedItemTintColor = .wssGray200
+        } else {
+            let appearance = UITabBarAppearance()
+            appearance.configureWithOpaqueBackground()
             
-            $0.layer.addSublayer(border)
-            $0.isTranslucent = false
-            $0.itemPositioning = .centered
-            $0.layer.masksToBounds = true
-            $0.tintColor = .wssBlack
+            appearance.backgroundColor = .wssWhite
+            appearance.shadowColor = .clear
+            
+            appearance.stackedLayoutAppearance.normal.iconColor = .wssGray200
+            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [
+                .foregroundColor: UIColor.wssGray200
+            ]
+            
+            appearance.stackedLayoutAppearance.selected.iconColor = .wssBlack
+            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [
+                .foregroundColor: UIColor.wssBlack
+            ]
+            
+            tabBar.standardAppearance = appearance
+            tabBar.scrollEdgeAppearance = appearance
+            
+            tabBar.isTranslucent = false
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Base/WSSTabBarItem.swift
@@ -41,14 +41,24 @@ enum WSSTabBarItem: Int, CaseIterable {
         switch self {
         case .home:
             return .icNavigateHomeSelected
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssBlack)
         case .search:
             return .icNavigateSearchSelected
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssBlack)
         case .feed:
             return .icNavigateFeedSelected
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssBlack)
         case .library:
             return .icNavigateLibrarySelected
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssBlack)
         case .myPage:
             return .icNavigateMySelected
+                .withRenderingMode(.alwaysOriginal)
+                .withTintColor(.wssBlack)
         }
     }
     

--- a/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeView.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeView.swift
@@ -70,7 +70,7 @@ final class HomeView: UIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom)
+            $0.bottom.equalToSuperview()
         }
         
         loadingView.snp.makeConstraints {

--- a/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
+++ b/WSSiOS/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryViewController/MyLibraryViewController.swift
@@ -54,7 +54,6 @@ final class MyLibraryViewController: UIViewController {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: true)
         viewWillAppear.accept(())
-        
     }
     
     //MARK: - Bind


### PR DESCRIPTION
### ⭐️Issue
- close #630 
<br/>

### 🌟Motivation
- 이전 작업에서 반영되지 않은 커밋을 추가합니다. 
  - Tabbar iOS26 Liquid Glass UI Tabbar 적용을 위한 분기처리 구현했습니다. 
<br/>

### 🌟Key Changes

- Tabbar iOS 버전에 따른 UI 분기처리
  - iOS26+ : Liquid Glass 적용
  - iOS18-: 기존 탭바 UI 유지 
<br/>


### 🌟Simulation


- 탭바 UI 분기처리 

| iOS 26 이상 | iOS 18 이하 | 
| -- | -- | 
| <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-18 at 14 16 17" src="https://github.com/user-attachments/assets/7aedbe59-7e3c-47e6-a1ec-bad59c567f87" /> | <img width="200" alt="Simulator Screenshot - iPhone 15 Pro - 2025-12-18 at 14 17 31" src="https://github.com/user-attachments/assets/7a359da4-c066-4765-9dac-9aa32c0b5433" /> |

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
