### PR TITLE
[Fix] #650 - 피드 개수 로딩 오류 수정

### DIFF
--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 26011201;
+				CURRENT_PROJECT_VERSION = 2026013101;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -383,7 +383,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 26011201;
+				CURRENT_PROJECT_VERSION = 2026013101;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/WSSiOS/Info.plist
+++ b/WSSiOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(WSS_BUNDLE_NAME)</string>
 	<key>AMPLITUDE_API_KEY</key>
 	<string>$(AMPLITUDE_API_KEY)</string>
 	<key>APPSTORE_ID</key>

--- a/WSSiOS/Source/Presentation/Feed/Feed/FeedViewModel/FeedPageContentViewModel.swift
+++ b/WSSiOS/Source/Presentation/Feed/Feed/FeedViewModel/FeedPageContentViewModel.swift
@@ -350,17 +350,17 @@ final class FeedPageContentViewModel: ViewModelType {
             .observe(on: MainScheduler.instance)
     }
     
-    func postSpoilerFeed(_ feedId: Int) -> Observable<Void> {
+    private func postSpoilerFeed(_ feedId: Int) -> Observable<Void> {
         feedDetailRepository.postSpoilerFeed(feedId: feedId)
             .observe(on: MainScheduler.instance)
     }
     
-    func postImpertinenceFeed(_ feedId: Int) -> Observable<Void> {
+    private func postImpertinenceFeed(_ feedId: Int) -> Observable<Void> {
         feedDetailRepository.postImpertinenceFeed(feedId: feedId)
             .observe(on: MainScheduler.instance)
     }
     
-    func deleteFeed(_ feedId: Int) -> Observable<Void> {
+    private func deleteFeed(_ feedId: Int) -> Observable<Void> {
         feedDetailRepository.deleteFeed(feedId: feedId)
             .observe(on: MainScheduler.instance)
     }

--- a/WSSiOS/Source/Presentation/Feed/Feed/FeedViewModel/FeedPageContentViewModel.swift
+++ b/WSSiOS/Source/Presentation/Feed/Feed/FeedViewModel/FeedPageContentViewModel.swift
@@ -97,7 +97,7 @@ final class FeedPageContentViewModel: ViewModelType {
             .withLatestFrom(feedList)
             .flatMapLatest { feedList in
                 self.getFeedData(lastFeedId: self.lastFeedId,
-                                 size: feedList.isEmpty ? nil : feedList.count)
+                                 size: nil)
             }
             .subscribe(with: self, onNext: { owner, data in
                 owner.isLoadable = data.isLoadable
@@ -279,6 +279,14 @@ final class FeedPageContentViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        feedPageType
+            .skip(1)
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.resetFeedPagingState()
+                owner.feedTableViewIsRefreshing.accept(())
+            })
+            .disposed(by: disposeBag)
+        
         return Output(
             feedPageType: feedPageType.asDriver(),
             myFeedCount: myFeedCount.asDriver(),
@@ -355,5 +363,14 @@ final class FeedPageContentViewModel: ViewModelType {
     func deleteFeed(_ feedId: Int) -> Observable<Void> {
         feedDetailRepository.deleteFeed(feedId: feedId)
             .observe(on: MainScheduler.instance)
+    }
+    
+    //MARK: - Method
+    
+    private func resetFeedPagingState() {
+        isLoadable = false
+        isFetching = false
+        lastFeedId = 0
+        feedList.accept([])
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ ENV["FASTLANE_XCODE_LIST_TIMEOUT"] = "180"
 private_lane :increment_build_number_with_date do |options|
 app_id = options[:app_identifier]
 
-today = Time.now.strftime("%y%m%d")
+today = Time.now.strftime("%Y%m%d")
 
 latest_build = latest_testflight_build_number(
 app_identifier: app_id


### PR DESCRIPTION
### ⭐️Issue
- close #650
<br/>

### 🌟Motivation
- 내 피드 / 소소 피드 탭을 전환할 때 피드 개수가 비정상적으로 로드되거나, 일부 피드가 보이지 않는 현상이 발생함
- 로그 확인 결과, 서로 다른 피드 탭 간에 pagination 상태(`size`, `lastFeedId`, `feedList`)가 공유되면서 API 요청 파라미터가 왜곡되고 있었음
<br/>

### 🌟Key Changes
- `feedPageType` 변경 시, 이전 피드의 pagination 상태를 초기화하도록 수정
  - `feedList`, `lastFeedId`, `isLoadable`, `isFetching` reset
- 탭 전환 후 기존 refresh 로딩 파이프라인을 재사용해 첫 페이지를 다시 로드하도록 개선
- reload 시 `size = feedList.count`를 사용하던 로직 제거
  - reload는 항상 서버 기본 page size로 첫 페이지를 요청하도록 변경
  - pagination은 `ReachedBottom` 이벤트에서만 처리하도록 책임 분리
<br/>

```swift 
// 초기화 코드 
private func resetFeedPagingState() {
        isLoadable = false
        isFetching = false
        lastFeedId = 0
        feedList.accept([])
    }
```

<br/>

```swift
// 피드 탭 전환 시
// 1. 피드 페이징과 관련된 상태값 초기화
// 2. 피드 테이블뷰 리프레싱하여 데이터 리로드 
feedPageType
    .skip(1)
    .subscribe(with: self, onNext: { owner, _ in
        owner.resetFeedPagingState()
        owner.feedTableViewIsRefreshing.accept(())
    })
    .disposed(by: disposeBag)
```
<br/>
<br/>

### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
