### PR TITLE
[Fix] #626 - 댓글뷰와 키보드 사이 공간이 보이는 UI 이슈 수정

### DIFF
--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -210,20 +210,15 @@ final class FeedDetailViewController: UIViewController {
                 self.rootView.replyWritingView.snp.updateConstraints {
                     $0.bottom.equalTo(self.rootView.safeAreaLayoutGuide.snp.bottom).offset(height)
                 }
-                
                 self.rootView.replyView.snp.updateConstraints {
                     $0.bottom.equalToSuperview().offset(height)
                 }
-                
-                UIView.animate(withDuration: 0.0) {
-                    self.rootView.layoutIfNeeded()
-                } completion: { _ in
-                    owner.rootView.scrollView.setContentOffset(
-                        CGPoint(x: 0,
-                                y: max(0, owner.rootView.scrollView.contentSize.height - owner.rootView.scrollView.bounds.height + 20)),
-                        animated: true
-                    )
-                }
+                self.rootView.layoutIfNeeded()
+                owner.rootView.scrollView.setContentOffset(
+                    CGPoint(x: 0,
+                            y: max(0, owner.rootView.scrollView.contentSize.height - owner.rootView.scrollView.bounds.height + 20)),
+                    animated: true
+                )
             })
             .disposed(by: disposeBag)
         
@@ -518,7 +513,7 @@ final class FeedDetailViewController: UIViewController {
                 owner.pushToUserPageViewController(userId: userId)
             })
             .disposed(by: disposeBag)
-
+        
         output.showLoadingView
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, isShow in
@@ -568,7 +563,7 @@ extension FeedDetailViewController: UICollectionViewDelegateFlowLayout {
         label.sizeToFit()
         let labelHeight = label.frame.height
         let resizedLabelHeight = ceil(labelHeight)
-    
+        
         return resizedLabelHeight
     }
 }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -215,11 +215,12 @@ final class FeedDetailViewController: UIViewController {
                     $0.bottom.equalToSuperview().offset(height)
                 }
                 
-                UIView.animate(withDuration: 0.25) {
+                UIView.animate(withDuration: 0.0) {
                     self.rootView.layoutIfNeeded()
                 } completion: { _ in
                     owner.rootView.scrollView.setContentOffset(
-                        CGPoint(x: 0, y: max(0, owner.rootView.scrollView.contentSize.height - owner.rootView.scrollView.bounds.height + 20)),
+                        CGPoint(x: 0,
+                                y: max(0, owner.rootView.scrollView.contentSize.height - owner.rootView.scrollView.bounds.height + 20)),
                         animated: true
                     )
                 }


### PR DESCRIPTION
### ⭐️Issue
- close #626 
<br/>

### 🌟Motivation
댓글뷰와 키보드 사이 공간이 보이는 UI 이슈 수정했습니다. 
<br/>

### 🌟Key Changes
기존 코드: animation을 부여하여 키보드가 올라올 때 자연스럽게 댓글창 위치도 함께 변할 수 있도록 적용하였습니다. 
하지만 0.25초 애니메이션은 키보드 애니메이션과 충돌하면서 중간 프레임에서 틈을 만드는 UI 관련 이슈를 만들게 되었습니다. 
```swift 
UIView.animate(withDuration: 0.25) {
    self.rootView.layoutIfNeeded()
} 
```


<br/>

```swift 
 self.rootView.layoutIfNeeded()
```
따라서, 중복되는 애니메이션을 제거하기 위해 `UIView.animate`를 제거하고 layoutIfNeeded()를 즉시 호출하도록 변경했습니다. 

<br/>


### 🌟Simulation

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
