### PR TITLE
[Fix] #651 - 피드 댓글 관련 QA 사항 이슈 수정

### DIFF
--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyView.swift
@@ -17,7 +17,6 @@ final class FeedDetailReplyView: UIView {
     let replyCollectionView = UICollectionView(frame: .zero,
                                                collectionViewLayout: UICollectionViewLayout())
     private let replyCollectionViewLayout = UICollectionViewFlowLayout()
-    let dropdownView = FeedDetailDropdownView()
     
     //MARK: - Life Cycle
     
@@ -46,15 +45,10 @@ final class FeedDetailReplyView: UIView {
             $0.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 60, right: 0)
             replyCollectionView.setCollectionViewLayout($0, animated: true)
         }
-        
-        dropdownView.do {
-            $0.isHidden = true
-        }
     }
     
     private func setHierarchy() {
-        self.addSubviews(replyCollectionView,
-                         dropdownView)
+        self.addSubview(replyCollectionView)
     }
     
     private func setLayout() {
@@ -64,11 +58,6 @@ final class FeedDetailReplyView: UIView {
             $0.bottom.equalToSuperview().inset(40)
             $0.height.equalTo(20)
         }
-        
-        dropdownView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(20)
-        }
     }
     
     //MARK: - Custom Method
@@ -76,35 +65,6 @@ final class FeedDetailReplyView: UIView {
     func updateCollectionViewHeight(height: CGFloat) {
         replyCollectionView.snp.updateConstraints {
             $0.height.equalTo(height)
-        }
-    }
-    
-    func showDropdownView(indexPath: IndexPath, isMyComment: Bool) {
-        dropdownView.do {
-            $0.configureDropdown(isMine: isMyComment)
-            $0.isHidden = false
-        }
-        updateDropdownViewLayout(indexPath: indexPath)
-    }
-    
-    func hideDropdownView() {
-        dropdownView.isHidden = true
-    }
-    
-    func toggleDropdownView() {
-        dropdownView.isHidden.toggle()
-    }
-    
-    func updateDropdownViewLayout(indexPath: IndexPath) {
-        guard let cell = replyCollectionView.cellForItem(at: indexPath) else { return }
-        
-        let cellFrameInSuperview = cell.convert(cell.bounds, to: self)
-        let numberOfItems = replyCollectionView.numberOfItems(inSection: indexPath.section)
-        let isLastTwoCells = indexPath.item >= numberOfItems - 2
-        
-        dropdownView.snp.updateConstraints {
-            $0.top.equalToSuperview().inset(isLastTwoCells ? cellFrameInSuperview.minY - dropdownView.frame.height : cellFrameInSuperview.minY + 40)
-            $0.trailing.equalToSuperview().inset(20)
         }
     }
 }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
@@ -65,19 +65,19 @@ final class FeedDetailReplyWritingView: UIView {
                 $0.textContainer.lineFragmentPadding = 0
                 $0.textContainerInset = .zero
             }
-            
-            replyButton.do {
-                $0.setImage(.icCommentRegister.withRenderingMode(.alwaysOriginal).withTintColor(.wssPrimary100), for: .normal)
-            }
+        }
+        
+        replyButton.do {
+            $0.setImage(.icCommentRegister.withRenderingMode(.alwaysOriginal).withTintColor(.wssPrimary100), for: .normal)
         }
     }
     
     private func setHierarchy() {
         self.addSubviews(userProfileImageView,
-                         textViewBackgroundView)
+                         textViewBackgroundView,
+                         replyButton)
         
-        textViewBackgroundView.addSubviews(replyWritingTextView,
-                                           replyButton)
+        textViewBackgroundView.addSubview(replyWritingTextView)
         replyWritingTextView.addSubview(replyWritingPlaceHolderLabel)
     }
     
@@ -95,13 +95,14 @@ final class FeedDetailReplyWritingView: UIView {
         textViewBackgroundView.snp.makeConstraints {
             $0.top.equalTo(userProfileImageView.snp.top)
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(userProfileImageView.snp.trailing).offset(12)
-            $0.trailing.equalToSuperview().inset(17)
+            $0.leading.equalTo(userProfileImageView.snp.trailing).offset(10)
+            $0.trailing.equalTo(replyButton.snp.leading).inset(-10)
             $0.height.equalTo(42)
             
             replyWritingTextView.snp.makeConstraints {
                 $0.centerY.equalToSuperview()
                 $0.leading.equalToSuperview().inset(16)
+                $0.trailing.equalToSuperview().inset(16)
                 
                 let size = CGSize(width: replyWritingTextView.frame.width, height: .infinity)
                 let estimatedHeight = replyWritingTextView.sizeThatFits(size)
@@ -112,13 +113,12 @@ final class FeedDetailReplyWritingView: UIView {
                     $0.centerY.equalToSuperview()
                 }
             }
-            
-            replyButton.snp.makeConstraints {
-                $0.top.equalToSuperview().inset(7)
-                $0.leading.equalTo(replyWritingTextView.snp.trailing)
-                $0.trailing.equalToSuperview().inset(11)
-                $0.size.equalTo(28)
-            }
+        }
+        
+        replyButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(17)
+            $0.trailing.equalToSuperview().inset(17)
+            $0.size.equalTo(28)
         }
     }
     

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailReplyWritingView.swift
@@ -116,7 +116,7 @@ final class FeedDetailReplyWritingView: UIView {
         }
         
         replyButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(17)
+            $0.centerY.equalTo(userProfileImageView.snp.centerY)
             $0.trailing.equalToSuperview().inset(17)
             $0.size.equalTo(28)
         }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailView.swift
@@ -25,6 +25,7 @@ final class FeedDetailView: UIView {
     let feedContentView = FeedDetailContentView()
     let replyView = FeedDetailReplyView()
     let replyWritingView = FeedDetailReplyWritingView()
+    let replyDropdownView = FeedDetailDropdownView()
     private let replyBottomView = UIView()
     
     private let loadingView = WSSLoadingView()
@@ -63,6 +64,10 @@ final class FeedDetailView: UIView {
             $0.isHidden = true
         }
         
+        replyDropdownView.do {
+            $0.isHidden = true
+        }
+        
         replyBottomView.do {
             $0.backgroundColor = .wssWhite
         }
@@ -81,6 +86,7 @@ final class FeedDetailView: UIView {
                          replyWritingView,
                          replyBottomView,
                          dropdownView,
+                         replyDropdownView,
                          loadingView,
                          networkErrorView)
         scrollView.addSubview(contentView)
@@ -110,6 +116,11 @@ final class FeedDetailView: UIView {
         
         dropdownView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide.snp.top)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        replyDropdownView.snp.makeConstraints {
+            $0.top.equalToSuperview()
             $0.trailing.equalToSuperview().inset(20)
         }
         
@@ -161,5 +172,36 @@ final class FeedDetailView: UIView {
     
     func showNetworkErrorView() {
         networkErrorView.isHidden = false
+    }
+    
+    //MARK: - Reply Dropdown View Methods
+    
+    func showReplyDropdownView(indexPath: IndexPath, isMyComment: Bool) {
+        replyDropdownView.do {
+            $0.configureDropdown(isMine: isMyComment)
+            $0.isHidden = false
+        }
+        updateReplyDropdownViewLayout(indexPath: indexPath)
+    }
+    
+    func hideReplyDropdownView() {
+        replyDropdownView.isHidden = true
+    }
+    
+    func toggleReplyDropdownView() {
+        replyDropdownView.isHidden.toggle()
+    }
+    
+    func updateReplyDropdownViewLayout(indexPath: IndexPath) {
+        guard let cell = replyView.replyCollectionView.cellForItem(at: indexPath) else { return }
+        
+        let cellFrameInSuperview = cell.convert(cell.bounds, to: self)
+        let numberOfItems = replyView.replyCollectionView.numberOfItems(inSection: indexPath.section)
+        let isLastTwoCells = indexPath.item >= numberOfItems - 2
+        
+        replyDropdownView.snp.updateConstraints {
+            $0.top.equalToSuperview().inset(isLastTwoCells ? cellFrameInSuperview.minY - replyDropdownView.frame.height : cellFrameInSuperview.minY + 40)
+            $0.trailing.equalToSuperview().inset(20)
+        }
     }
 }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -103,8 +103,8 @@ final class FeedDetailViewController: UIViewController {
         )
         
         let commentDropdownButtonDidTap = Observable.merge(
-            rootView.replyView.dropdownView.topDropdownButton.rx.tap.map { DropdownButtonType.top },
-            rootView.replyView.dropdownView.bottomDropdownButton.rx.tap.map { DropdownButtonType.bottom }
+            rootView.replyDropdownView.topDropdownButton.rx.tap.map { DropdownButtonType.top },
+            rootView.replyDropdownView.bottomDropdownButton.rx.tap.map { DropdownButtonType.bottom }
         )
         
         let input = FeedDetailViewModel.Input(
@@ -381,20 +381,20 @@ final class FeedDetailViewController: UIViewController {
         output.showCommentDropdownView
             .subscribe(with: self, onNext: { owner, data in
                 let (indexPath, isMyComment) = data
-                owner.rootView.replyView.showDropdownView(indexPath: indexPath,
-                                                          isMyComment: isMyComment)
+                owner.rootView.showReplyDropdownView(indexPath: indexPath,
+                                                     isMyComment: isMyComment)
             })
             .disposed(by: disposeBag)
         
         output.hideCommentDropdownView
             .subscribe(with: self, onNext: { owner, _ in
-                owner.rootView.replyView.hideDropdownView()
+                owner.rootView.hideReplyDropdownView()
             })
             .disposed(by: disposeBag)
         
         output.toggleDropdownView
             .subscribe(with: self, onNext: { owner, _ in
-                owner.rootView.replyView.toggleDropdownView()
+                owner.rootView.toggleReplyDropdownView()
             })
             .disposed(by: disposeBag)
         
@@ -460,7 +460,6 @@ final class FeedDetailViewController: UIViewController {
                 print("Error: \(error)")
             })
             .disposed(by: disposeBag)
-        
         
         output.showCommentImpertinenceAlertView
             .flatMapLatest { postImpertinenceComment, feedId, commentId in

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewController/FeedDetailViewController.swift
@@ -506,9 +506,9 @@ final class FeedDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.myCommentEditing
-            .subscribe(with: self, onNext: { owner, _ in
+            .subscribe(with: self, onNext: { owner, initialContent in
                 owner.rootView.replyWritingView.replyWritingTextView.becomeFirstResponder()
-                owner.rootView.replyWritingView.setCommentText(owner.viewModel.initialCommentContent)
+                owner.rootView.replyWritingView.setCommentText(initialContent)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -465,12 +465,13 @@ final class FeedDetailViewModel: ViewModelType {
                 case (.top, true):
                     // 댓글 수정하기
                     owner.isCommentEditing = true
-                    owner.myCommentEditing.accept(())
                     
                     // 수정할 때에만 initialCommentContent가 업데이트되도록 한다.
                     if let index = owner.commentsData.value.firstIndex(where: { $0.commentId == owner.selectedCommentId }) {
                         owner.initialCommentContent = owner.commentsData.value[index].commentContent
                     }
+                    
+                    owner.myCommentEditing.accept(())
                 case (.bottom, true):
                     // 댓글 삭제하기
                     owner.showCommentDeleteAlertView.accept((owner.deleteComment,

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailViewModel/FeedDetailViewModel.swift
@@ -69,7 +69,7 @@ final class FeedDetailViewModel: ViewModelType {
     let showCommentSpoilerAlertView  = PublishRelay<((Int, Int) -> Observable<Void>, Int, Int)>()
     let showCommentImpertinenceAlertView  = PublishRelay<((Int, Int) -> Observable<Void>, Int, Int)>()
     var isCommentEditing: Bool = false
-    let myCommentEditing = PublishRelay<Void>()
+    let myCommentEditing = PublishRelay<String>()
     let showCommentDeleteAlertView  = PublishRelay<((Int, Int) -> Observable<Void>, Int, Int)>()
     let showWithdrawalUserToastView = PublishRelay<Void>()
     
@@ -167,7 +167,7 @@ final class FeedDetailViewModel: ViewModelType {
         // 댓글 드롭다운 내 이벤트
         let showCommentSpoilerAlertView: Observable<((Int, Int) -> Observable<Void>, Int, Int)>
         let showCommentImpertinenceAlertView: Observable<((Int, Int) -> Observable<Void>, Int, Int)>
-        let myCommentEditing: Observable<Void>
+        let myCommentEditing: Observable<String>
         let showCommentDeleteAlertView: Observable<((Int, Int) -> Observable<Void>, Int, Int)>
         let showWithdrawalUserToastView: Observable<Void>
         
@@ -466,12 +466,13 @@ final class FeedDetailViewModel: ViewModelType {
                     // 댓글 수정하기
                     owner.isCommentEditing = true
                     
-                    // 수정할 때에만 initialCommentContent가 업데이트되도록 한다.
-                    if let index = owner.commentsData.value.firstIndex(where: { $0.commentId == owner.selectedCommentId }) {
-                        owner.initialCommentContent = owner.commentsData.value[index].commentContent
+                    if let index = owner.commentsData.value.firstIndex(
+                        where: { $0.commentId == owner.selectedCommentId }
+                    ) {
+                        let initialContent = owner.commentsData.value[index].commentContent
+                        owner.myCommentEditing.accept(initialContent)
+                        owner.initialCommentContent = initialContent
                     }
-                    
-                    owner.myCommentEditing.accept(())
                 case (.bottom, true):
                     // 댓글 삭제하기
                     owner.showCommentDeleteAlertView.accept((owner.deleteComment,


### PR DESCRIPTION
### ⭐️Issue
- close #651 
<br/>

### 🌟Motivation
피드 댓글 관련 QA 사항을 수정했습니다. 
<br/>

### 🌟Key Changes
- 댓글창 UI를 수정했습니다. 
기존 디자인에서 텍스트뷰 안에 전송 버튼이 있었고, QA 요청에 따라 뷰와 버튼을 분리하였습니다. 

<br/>

- 댓글 드롭다운 내 수정 버튼 클릭 시, 즉시 댓글 초기 내용이 댓글창으로 이동하지 않는 현상을 해결했습니다. 
댓글 수정 시, 초기 내용을 업데이트하는 이벤트가, 초기 내용을 찾는 로직보다 먼저 발생하여, 빈 텍스트가 전달되는 게 원인이었습니다. 
따라서, 이벤트와 로직을 한꺼번에 처리할 수 있도록,
```swift
let myCommentEditing = PublishRelay<Void>()
```
로 정의되어있던 PublishRelay 이벤트를 String을 accpet할 수 있도록 수정하였습니다. 
```swift
let myCommentEditing = PublishRelay<String>()

if let index = owner.commentsData.value.firstIndex(
                          where: { $0.commentId == owner.selectedCommentId }
                      ) {
                          let initialContent = owner.commentsData.value[index].commentContent
                          owner.myCommentEditing.accept(initialContent)
                          owner.initialCommentContent = initialContent
                      }
```
따라서, 해당 이벤트가 한번에 내용을 전달할 수 있도록 하여 위와 같은 시간차가 발생하지 않도록 하였습니다. 

<br/>

- 첫번째 댓글의 드롭다운의 터치가 먹히는 현상을 해결했습니다. 
기존에는 댓글의 드롭다운을 `replyView`에 종속되도록 하였습니다. 그러다보니, 드롭다운의 위치가 다른 뷰에 걸치게 되면 터치가 먹히는 현상이 발생했습니다.
따라서, 댓글의 드롭다운 위치를 `replyView`의 상위뷰인 `FeedDetailView` 즉, rootView에 종속되도록 하여 어느 뷰 위에서도 터치가 될 수 있도록 수정하였습니다. 
<br/>


### 🌟Simulation
![Simulator Screen Recording - iPhone 17 Pro - 2026-02-01 at 00 26 21](https://github.com/user-attachments/assets/e21250f8-e707-434a-8a73-88994b990696)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
