### PR TITLE
[Fix] #656 - MyPageView 스크롤뷰 레이아웃 수정

### DIFF
--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2026013101;
+				CURRENT_PROJECT_VERSION = 2026020201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -383,7 +383,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2026013101;
+				CURRENT_PROJECT_VERSION = 2026020201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9SVDHQS4M3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -401,7 +401,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/Source/Presentation/UserPage/MyPage/MyPageView/MyPageView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/MyPage/MyPageView/MyPageView.swift
@@ -70,8 +70,9 @@ final class MyPageView: UIView {
     
     private func setLayout() {
         scrollView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
-            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
         }
         
         contentView.snp.makeConstraints {


### PR DESCRIPTION
### ⭐️Issue
- close #656 
<br/>

### 🌟Motivation
MyPageView 스크롤뷰 레이아웃 수정했습니다. 
<br/>

### 🌟Key Changes
스크롤 시 일부 뷰가 탭바에 가려지는 현상이 있었습니다. 
스크롤뷰의 bottom을 safeAreaLayoutGuide의 bottom에 맞춰지도록 레이아웃 수정했습니다. 
<br/>

```swift
scrollView.snp.makeConstraints {
    $0.top.equalTo(safeAreaLayoutGuide.snp.top)
    $0.horizontalEdges.equalToSuperview()
    $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
}
```
<br/>

### 🌟Simulation
![Simulator Screen Recording - iPhone 17 Pro - 2026-02-03 at 11 57 21](https://github.com/user-attachments/assets/6cce5c9b-c705-4fc5-981a-0136a72a8410)

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
