### PR TITLE
[Feat] #660 - 작품 평가 후 / 피드 작성 후 In-App Review 팝업 구현

### DIFF
--- a/WSSiOS/Resource/Helper/AppReviewManager.swift
+++ b/WSSiOS/Resource/Helper/AppReviewManager.swift
@@ -1,0 +1,26 @@
+//
+//  AppReviewManager.swift
+//  WSSiOS
+//
+//  Created by Seoyeon Choi on 2/6/26.
+//
+
+import Foundation
+import StoreKit
+
+final class AppReviewManager {
+    
+    static let shared = AppReviewManager()
+    
+    private init() {}
+    
+    func requestReview() {
+        guard
+            let windowScene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first
+        else { return }
+        
+        SKStoreReviewController.requestReview(in: windowScene)
+    }
+}

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -206,6 +206,7 @@ final class FeedEditViewModel: ViewModelType {
                 owner.backButtonIsAbled.accept(true)
                 NotificationCenter.default.post(name: NotificationName.feedEdited, object: nil)
                 owner.popViewController.accept(())
+                AppReviewManager.shared.requestReview()
             }, onError: { owner, error  in
                 print(error)
             })

--- a/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewModel/NovelReviewViewModel.swift
+++ b/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewModel/NovelReviewViewModel.swift
@@ -158,6 +158,7 @@ final class NovelReviewViewModel: ViewModelType {
             .subscribe(with: self, onNext: { owner, _ in
                 NotificationCenter.default.post(name: NSNotification.Name("NovelReviewed"), object: nil)
                 owner.popViewController.accept(())
+                AppReviewManager.shared.requestReview()
             }, onError: { owner, error  in
                 print(error)
             })


### PR DESCRIPTION
### ⭐️Issue
- close #660 
<br/>

### 🌟Motivation
- In-App Reivew 기능을 추가했습니다. 
<br/>

### 🌟Key Changes
- 작품 평가 후 / 피드 작성 후 팝업이 뜰 수 있도록 했습니다. 
<br/>

### 🌟Simulation
| 피드 작성 후 | 작품 평가 후 | 
| -- | -- | 
|  ![Simulator Screen Recording - iPhone 17 Pro - 2026-02-06 at 21 49 17](https://github.com/user-attachments/assets/fa5932fb-b302-42d5-91c5-7f605ebe73fd)| ![Simulator Screen Recording - iPhone 17 Pro - 2026-02-06 at 21 49 35](https://github.com/user-attachments/assets/64d6f15a-9ece-4c4c-9209-70b8fb1be297) | 
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>

