### PR TITLE
[Fix] #668 - 피드 상세 내 StackView spacing 오류 해결

### DIFF
--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -18,9 +18,7 @@ final class FeedDetailContentView: UIView {
     private let contentWrapperView = UIView()
     private let contentLabel = UILabel()
     let addImageView = FeedDetailAddImageView()
-    private let linkNovelWrapperView = UIView()
     let linkNovelView = FeedDetailNovelView()
-    private let reactWrapperView = UIView()
     let reactView = FeedReactView()
     private let dividerView = UIView()
     
@@ -59,31 +57,33 @@ final class FeedDetailContentView: UIView {
         self.addSubviews(stackView,
                          dividerView)
         contentWrapperView.addSubview(contentLabel)
-        linkNovelWrapperView.addSubview(linkNovelView)
-        reactWrapperView.addSubview(reactView)
         stackView.addArrangedSubviews(contentWrapperView,
                                       addImageView,
-                                      linkNovelWrapperView,
-                                      reactWrapperView)
+                                      linkNovelView,
+                                      reactView)
     }
     
     private func setLayout() {
         stackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
-        [contentLabel,  reactView].forEach {
-            $0.snp.makeConstraints {
-                $0.verticalEdges.equalToSuperview()
-                $0.horizontalEdges.equalToSuperview().inset(20)
-            }
+        
+        contentLabel.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        addImageView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
         }
         
         linkNovelView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
+        reactView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+
         dividerView.snp.makeConstraints {
             $0.top.equalTo(stackView.snp.bottom).offset(16)
             $0.height.equalTo(7)
@@ -99,26 +99,26 @@ final class FeedDetailContentView: UIView {
             $0.lineBreakStrategy = .hangulWordPriority
         }
         
-        if data.hasLinkedNovel {
-            stackView.insertArrangedSubview(linkNovelWrapperView, at: 2)
-            guard let novelData = data.novelData else { return }
-            linkNovelView.bindData(novelData: novelData)
-        } else {
-            linkNovelWrapperView.removeFromSuperview()
-        }
-        
-        reactView.do {
-            $0.bindData(likeRating: data.likeCount,
-                        isLiked: data.isLiked,
-                        commentRating: data.commentCount)
-        }
-        
         if data.hasImage {
             stackView.insertArrangedSubview(addImageView, at: 1)
             stackView.setCustomSpacing(data.hasLinkedNovel ? 16 : 30, after: addImageView)
             addImageView.bindImages(imageURLs: data.imageURLs)
         } else {
             addImageView.removeFromSuperview()
+        }
+        
+        if data.hasLinkedNovel {
+            stackView.insertArrangedSubview(linkNovelView, at: 2)
+            guard let novelData = data.novelData else { return }
+            linkNovelView.bindData(novelData: novelData)
+        } else {
+            linkNovelView.removeFromSuperview()
+        }
+        
+        reactView.do {
+            $0.bindData(likeRating: data.likeCount,
+                        isLiked: data.isLiked,
+                        commentRating: data.commentCount)
         }
     }
 }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -108,7 +108,7 @@ final class FeedDetailContentView: UIView {
         }
         
         if data.hasLinkedNovel {
-            stackView.insertArrangedSubview(linkNovelView, at: 2)
+            stackView.insertArrangedSubview(linkNovelView, at: data.hasImage ? 2: 1)
             guard let novelData = data.novelData else { return }
             linkNovelView.bindData(novelData: novelData)
         } else {

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailContentView.swift
@@ -54,13 +54,13 @@ final class FeedDetailContentView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubviews(stackView,
-                         dividerView)
+        self.addSubview(stackView)
         contentWrapperView.addSubview(contentLabel)
         stackView.addArrangedSubviews(contentWrapperView,
                                       addImageView,
                                       linkNovelView,
-                                      reactView)
+                                      reactView,
+                                      dividerView)
     }
     
     private func setLayout() {
@@ -69,7 +69,7 @@ final class FeedDetailContentView: UIView {
         }
         
         contentLabel.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
         }
         
         addImageView.snp.makeConstraints {
@@ -78,14 +78,14 @@ final class FeedDetailContentView: UIView {
         
         linkNovelView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(123)
         }
         
         reactView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
-
+        
         dividerView.snp.makeConstraints {
-            $0.top.equalTo(stackView.snp.bottom).offset(16)
             $0.height.equalTo(7)
             $0.horizontalEdges.equalToSuperview()
         }
@@ -99,20 +99,14 @@ final class FeedDetailContentView: UIView {
             $0.lineBreakStrategy = .hangulWordPriority
         }
         
+        addImageView.isHidden = !data.hasImage
         if data.hasImage {
-            stackView.insertArrangedSubview(addImageView, at: 1)
-            stackView.setCustomSpacing(data.hasLinkedNovel ? 16 : 30, after: addImageView)
             addImageView.bindImages(imageURLs: data.imageURLs)
-        } else {
-            addImageView.removeFromSuperview()
         }
         
-        if data.hasLinkedNovel {
-            stackView.insertArrangedSubview(linkNovelView, at: data.hasImage ? 2: 1)
-            guard let novelData = data.novelData else { return }
+        linkNovelView.isHidden = !data.hasLinkedNovel
+        if let novelData = data.novelData {
             linkNovelView.bindData(novelData: novelData)
-        } else {
-            linkNovelView.removeFromSuperview()
         }
         
         reactView.do {
@@ -120,5 +114,21 @@ final class FeedDetailContentView: UIView {
                         isLiked: data.isLiked,
                         commentRating: data.commentCount)
         }
+        
+        applySpacing(hasImage: data.hasImage,
+                     hasLinkedNovel: data.hasLinkedNovel)
+    }
+    
+    private func applySpacing(hasImage: Bool, hasLinkedNovel: Bool) {
+        stackView.setCustomSpacing(30, after: contentWrapperView)
+        stackView.setCustomSpacing(30, after: addImageView)
+        stackView.setCustomSpacing(30, after: linkNovelView)
+        stackView.setCustomSpacing(30, after: reactView)
+        
+        if hasImage && hasLinkedNovel {
+            stackView.setCustomSpacing(16, after: addImageView)
+        }
+        
+        stackView.setCustomSpacing(16, after: reactView)
     }
 }

--- a/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailNovelView.swift
+++ b/WSSiOS/Source/Presentation/FeedDetail/FeedDetailView/FeedDetailAssistantView/FeedDetailNovelView.swift
@@ -80,7 +80,6 @@ final class FeedDetailNovelView: UIView {
     private func setLayout() {
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-            $0.height.equalTo(123)
         }
         
         novelImageView.snp.makeConstraints {


### PR DESCRIPTION
### ⭐️Issue
- close #668
<br/>

### 🌟Motivation
피드 상세 내 StackView Spacing 관련한 레이아웃 문제를 해결했습니다. 
<br/>

### 🌟Key Changes
####  조건부 UI 처리 방식 개선
기존 `insertArrangedSubview` / `removeFromSuperview` 방식을 제거했습니다. 
`isHidden` 기반으로 조건부 UI 제어하도록 구조를 변경했습니다. 

####  StackView Spacing 규칙 재정의
기본 spacing을 30으로 통일하고,
다음 조건에 따라 `customSpacing` 적용하도록 했습니다. 

- 첨부 이미지 + 연결 작품이 모두 존재할 경우 → 이미지 뒤 spacing 16

- reactView 뒤 spacing은 항상 10 유지

`applySpacing()` 함수로 spacing 로직을 일원화했습니다. 
`customSpacing` 값이 누적되지 않도록 매 바인딩 시 초기화 로직 추가했습니다. 

#### Result
StackView spacing이 의도한 디자인 스펙에 맞게 안정적으로 동작하도록 했습니다. 
제약 충돌 및 spacing 비정상적으로 축소되는 현상 해결했습니다. 
<br/>


### 🌟Simulation
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-02-16 at 23 01 58](https://github.com/user-attachments/assets/7e965dd8-c6ce-42bf-bd44-d5e76d059afc) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-02-16 at 23 01 42](https://github.com/user-attachments/assets/9411b7c8-8fc9-4f27-8322-7efc87fd254a) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-02-16 at 23 01 23](https://github.com/user-attachments/assets/e7cb9c9b-c5c4-4a91-b4c6-77d6909dd390) | 
| -- | -- | -- | 
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
