### PR TITLE
[Feat] #676 - 매력포인트 열거형 내 필력 추가 및 레이아웃 조정

### DIFF
--- a/WSSiOS/Source/Data/Base/AttractivePoint.swift
+++ b/WSSiOS/Source/Data/Base/AttractivePoint.swift
@@ -10,6 +10,7 @@ import UIKit
 enum AttractivePoint: String, CaseIterable, Codable {
     case worldview = "worldview"
     case material = "material"
+    case writingSkill = "writingskill"
     case character = "character"
     case relationship = "relationship"
     case vibe = "vibe"
@@ -18,6 +19,7 @@ enum AttractivePoint: String, CaseIterable, Codable {
         switch self {
         case .worldview: "세계관"
         case .material: "소재"
+        case .writingSkill: "필력"
         case .character: "캐릭터"
         case .relationship: "관계"
         case .vibe: "분위기"
@@ -28,6 +30,8 @@ enum AttractivePoint: String, CaseIterable, Codable {
         switch self {
         case .worldview: .icAttractiveWorldview
         case .material: .icAttractiveMaterial
+        //TODO: - 필력 아이콘 이미지 변경 필요
+        case .writingSkill: .icAttractiveVibe
         case .character: .icAttractiveCharacter
         case .relationship: .icAttractiveRelationship
         case .vibe: .icAttractiveVibe

--- a/WSSiOS/Source/Presentation/NovelReview/NovelReviewView/NovelReviewAssistantView/NovelReviewAttractivePointView.swift
+++ b/WSSiOS/Source/Presentation/NovelReview/NovelReviewView/NovelReviewAssistantView/NovelReviewAttractivePointView.swift
@@ -66,10 +66,10 @@ final class NovelReviewAttractivePointView: UIView {
         
         attractivePointCollectionView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(80)
             $0.top.equalTo(titleLabel.snp.bottom).offset(10)
             $0.bottom.equalToSuperview().inset(32)
-            $0.height.equalTo(35)
+            $0.height.equalTo(84)
         }
     }
 }

--- a/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewCell/NovelReviewAttractivePointCollectionViewCell.swift
+++ b/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewCell/NovelReviewAttractivePointCollectionViewCell.swift
@@ -46,7 +46,7 @@ final class NovelReviewAttractivePointCollectionViewCell: UICollectionViewCell {
     private func setLayout() {
         keywordLink.snp.makeConstraints {
             $0.edges.equalToSuperview()
-            $0.height.equalTo(35)
+            $0.height.equalTo(37)
         }
     }
     

--- a/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewController/NovelReviewViewController.swift
+++ b/WSSiOS/Source/Presentation/NovelReview/NovelReviewViewController/NovelReviewViewController.swift
@@ -228,7 +228,7 @@ extension NovelReviewViewController: UICollectionViewDelegateFlowLayout {
             }
             
             let width = (unwrappedText as NSString).size(withAttributes: [NSAttributedString.Key.font: UIFont.Body2]).width + 26
-            return CGSize(width: width, height: 35)
+            return CGSize(width: width, height: 37)
         } else if collectionView == self.rootView.novelReviewKeywordView.selectedKeywordCollectionView {
             var text: String?
             


### PR DESCRIPTION
### ⭐️Issue
- close #676 
<br/>

### 🌟Motivation
매력포인트 - 필력 태그를 추가했습니다. 
기획 디자인 수정에 따른 레이아웃을 조정했습니다. 
<br/>

### 🌟Key Changes
기존 매력포인트 배열이 한줄이었으나, 디자인 개편으로 두 줄이 되면서 레이아웃을 조정했습니다. 
이외 특이사항 없습니다. 
<br/>

### 🌟Simulation
| 작품 평가 | 내 서재 필터 | 
| -- | --  | 
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-18 at 12 08 29](https://github.com/user-attachments/assets/7919fb85-cb36-4baa-8202-7bb0e71ffc9c) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-18 at 12 08 50](https://github.com/user-attachments/assets/b0c523d2-6faf-45ff-850d-d30628d10ebf) | 
<br/>

### 🌟To Reviewer
내 서재 필터에 있는 필력의 아이콘 이미지가 아직 완성되지 않았습니다. 
추후 에셋이 업데이트 되면 바로 추가하도록 하겠습니다~
<br/>

### 🌟Reference

<br/>
