### PR TITLE
[Feat] #678 - 피드 작성 카테고리 선택 로직 제거

### DIFF
--- a/WSSiOS/Network/Feed/FeedService.swift
+++ b/WSSiOS/Network/Feed/FeedService.swift
@@ -11,8 +11,8 @@ import RxSwift
 
 protocol FeedService {
     func getFeedList(lastFeedId: Int, size: Int, feedsOption: String) -> Single<TotalFeedListResponse>
-    func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void>
-    func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void>
+    func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void>
+    func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void>
 }
 
 final class DefaultFeedService: NSObject, Networking, FeedService {
@@ -47,9 +47,8 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
         }
     }
     
-    func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void> {
-        let feed = FeedContentRequest(relevantCategories: relevantCategories,
-                                      feedContent: feedContent,
+    func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void> {
+        let feed = FeedContentRequest(feedContent: feedContent,
                                       novelId: novelId,
                                       isSpoiler: isSpoiler,
                                       isPublic: isPublic)
@@ -88,10 +87,9 @@ final class DefaultFeedService: NSObject, Networking, FeedService {
         }
     }
     
-    func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void> {
+    func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Single<Void> {
         
-        let feed = FeedContentRequest(relevantCategories: relevantCategories,
-                                      feedContent: feedContent,
+        let feed = FeedContentRequest(feedContent: feedContent,
                                       novelId: novelId,
                                       isSpoiler: isSpoiler,
                                       isPublic: isPublic)

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
@@ -55,7 +55,7 @@ extension StringLiterals {
         
         enum Filter {
             static let title = "글 찾기 필터"
-            static let genre = "장르"
+            static let genre = "카테고리"
             static let visibliltyOption = "공개여부"
             static let bottomButton = "해당하는 글 보기"
         }

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Feed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum FeedEdit {
-    static let imageMaxCount = 5;
+    static let imageMaxCount = 5
 }
 
 extension StringLiterals {
@@ -16,6 +16,7 @@ extension StringLiterals {
         static let complete = "완료"
         static let edit = "수정"
         static let setPrivate = "나만 보는 기록"
+        static let spoilrSetting = "잠깐, 스포일러가 있나요?"
         
         enum Category {
             static let category = "기록 작성"

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+MyPage.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+MyPage.swift
@@ -23,7 +23,7 @@ extension StringLiterals {
             static let genrePreferenceTitle = "장르 취향"
             static let novelPreferenceTitle = "작품 취향"
             static let novelPreferenceLabel = "(이)가 매력적인 작품을 선호해요"
-            static let privateLabel = "님의 프로필은\n비공개 상태예요"
+            static let privateLabel = "%@님의 프로필은\n비공개 상태예요"
             static let unknownAlertButtonTitle = "확인"
             static let otherProfileLibrary = "통계"
             static let otherProfileFeed = "활동"

--- a/WSSiOS/Resource/Extensions/UILabel+.swift
+++ b/WSSiOS/Resource/Extensions/UILabel+.swift
@@ -139,6 +139,16 @@ extension TextAttributeSet {
         return self
     }
     
+    func partialFont(font: UIFont, rangeString: String) -> TextAttributeSet {
+        let nsString = self.attributedString.string as NSString
+        let range = nsString.range(of: rangeString)
+        
+        if range.location != NSNotFound {
+            self.attributedString.addAttribute(.font, value: font, range: range)
+        }
+        return self
+    }
+    
     func partialColor(color: UIColor, rangeString: String) -> TextAttributeSet {
         let nsString = self.attributedString.string as NSString
         let range = nsString.range(of: rangeString)

--- a/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -236,7 +236,6 @@ extension UIViewController {
     }
     
     func pushToFeedEditViewController(feedId: Int? = nil,
-                                      relevantCategories: [NewNovelGenre] = [],
                                       novelId: Int? = nil,
                                       novelTitle: String? = nil) {
         let viewController = FeedEditViewController(
@@ -248,7 +247,6 @@ extension UIViewController {
                     feedDetailService: DefaultFeedDetailService()
                 ),
                 feedId: feedId,
-                relevantCategories: relevantCategories,
                 novelId: novelId,
                 novelTitle: novelTitle
             )

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -237,7 +237,6 @@ enum NewNovelGenre: String, CaseIterable {
 }
 
 extension NewNovelGenre {
-    static let feedEditGenres: [NewNovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .drama, .mystery, .lightNovel, .bl, .etc]
     static let onboardingGenres: [NewNovelGenre] = [.romance, .romanceFantasy, .bl, .fantasy, .modernFantasy, .wuxia, .lightNovel, .drama, .mystery]
     static let feedMaleGenres: [NewNovelGenre] = [.all, .fantasy, .modernFantasy, .wuxia, .drama, .mystery, .lightNovel, .romance, .romanceFantasy, .bl, .etc]
     static let feedFemaleGenres: [NewNovelGenre] = [.all, .romance, .romanceFantasy, .bl, .fantasy, .modernFantasy, .wuxia, .drama, .mystery, .lightNovel, .etc]

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -240,5 +240,5 @@ extension NewNovelGenre {
     static let onboardingGenres: [NewNovelGenre] = [.romance, .romanceFantasy, .bl, .fantasy, .modernFantasy, .wuxia, .lightNovel, .drama, .mystery]
     static let feedMaleGenres: [NewNovelGenre] = [.all, .fantasy, .modernFantasy, .wuxia, .drama, .mystery, .lightNovel, .romance, .romanceFantasy, .bl, .etc]
     static let feedFemaleGenres: [NewNovelGenre] = [.all, .romance, .romanceFantasy, .bl, .fantasy, .modernFantasy, .wuxia, .drama, .mystery, .lightNovel, .etc]
-    static let feedFilterGenres: [NewNovelGenre] = [.romance, .romanceFantasy, .fantasy, .modernFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl]
+    static let feedFilterGenres: [NewNovelGenre] = [.romance, .romanceFantasy, .fantasy, .modernFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl, .etc]
 }

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -71,7 +71,7 @@ enum NewNovelGenre: String, CaseIterable {
         case .bl:
             return "BL"
         case .etc:
-            return "기타"
+            return "그 외"
         case .error:
             return "error"
         }

--- a/WSSiOS/Source/Data/DTO/Feed/FeedResponse.swift
+++ b/WSSiOS/Source/Data/DTO/Feed/FeedResponse.swift
@@ -25,7 +25,6 @@ struct FeedResponse: Decodable {
     var title: String?
     var novelRatingCount: Int?
     var novelRating: Float?
-    var relevantCategories: [String]
     
     var isSpoiler: Bool
     var isModified: Bool
@@ -74,7 +73,6 @@ extension FeedResponse {
                                                 likeCount: 1,
                                                 isLiked: true,
                                                 commentCount: 2,
-                                                relevantCategories: [],
                                                 isSpoiler: false,
                                                 isModified: false,
                                                 isMyFeed: true,
@@ -90,7 +88,6 @@ extension FeedResponse {
                                                  likeCount: 1,
                                                  isLiked: true,
                                                  commentCount: 2,
-                                                 relevantCategories: [],
                                                  isSpoiler: false,
                                                  isModified: false,
                                                  isMyFeed: true,
@@ -107,7 +104,6 @@ extension FeedResponse {
                                                likeCount: 1,
                                                isLiked: true,
                                                commentCount: 2,
-                                               relevantCategories: [],
                                                isSpoiler: false,
                                                isModified: false,
                                                isMyFeed: true,
@@ -129,7 +125,6 @@ extension FeedResponse {
                                                   title: "웹소설 제목",
                                                   novelRatingCount: 10,
                                                   novelRating: 1.2,
-                                                  relevantCategories: [],
                                                   isSpoiler: false,
                                                   isModified: false,
                                                   isMyFeed: true,

--- a/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
+++ b/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct TotalFeedListResponse: Decodable {
-    let category: String
     let isLoadable: Bool
     let feeds: [TotalFeedResponse]
 }
@@ -27,7 +26,6 @@ struct TotalFeedResponse: Decodable {
     let title: String?
     let novelRatingCount: Int?
     let novelRating: Float?
-    let relevantCategories: [String]
     let isSpoiler: Bool
     let isModified: Bool
     let isMyFeed: Bool

--- a/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
+++ b/WSSiOS/Source/Data/DTO/TotalFeedListResponse.swift
@@ -40,7 +40,6 @@ struct TotalFeedResponse: Decodable {
 }
 
 struct FeedContentRequest: Encodable {
-    let relevantCategories: [String]
     let feedContent: String
     let novelId: Int?
     let isSpoiler: Bool

--- a/WSSiOS/Source/Data/DTO/UserFeedListResponse.swift
+++ b/WSSiOS/Source/Data/DTO/UserFeedListResponse.swift
@@ -27,7 +27,6 @@ struct UserFeedResponse: Decodable {
     let title: String?
     let novelRating: Float?
     let novelRatingCount: Int?
-    let relevantCategories: [String]
     let isPublic: Bool
     let genre: String?
     let feedWriterNovelRating: Float?

--- a/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
+++ b/WSSiOS/Source/Data/Entity/Feed/FeedEntity.swift
@@ -20,7 +20,6 @@ struct FeedEntity {
     let likeCount: Int
     let isLiked: Bool
     let commentCount: Int
-    let genreCategories: [String]
     
     // 피드 연결 작품 관련
     let hasLinkedNovel: Bool
@@ -57,7 +56,6 @@ extension FeedResponse {
                           likeCount: self.likeCount,
                           isLiked: self.isLiked,
                           commentCount: self.commentCount,
-                          genreCategories: self.relevantCategories,
                           hasLinkedNovel: hasLinkedNovel,
                           novelData: novelData,
                           isSpoiler: self.isSpoiler,

--- a/WSSiOS/Source/Data/Entity/Feed/TotalFeedListEntity.swift
+++ b/WSSiOS/Source/Data/Entity/Feed/TotalFeedListEntity.swift
@@ -9,16 +9,14 @@ import Foundation
 import UIKit
 
 struct TotalFeedListEntity {
-    let category: String
     let isLoadable: Bool
     let feeds: [TotalFeedEntity]
 }
 
 extension TotalFeedListResponse {
     func toEntity() -> TotalFeedListEntity {
-        return TotalFeedListEntity(category: self.category,
-                               isLoadable: self.isLoadable,
-                               feeds: self.feeds.map { $0.toEntity() })
+        return TotalFeedListEntity(isLoadable: self.isLoadable,
+                                   feeds: self.feeds.map { $0.toEntity() })
     }
 }
 
@@ -39,7 +37,6 @@ struct TotalFeedEntity {
     let novelGenreImage: UIImage
     let feedWriterNovelRating: Float
     
-    let relevantCategories: String
     let isSpoiler: Bool
     let isModified: Bool
     let isMyFeed: Bool
@@ -53,7 +50,6 @@ struct TotalFeedEntity {
 extension TotalFeedListEntity {
     static func from(userFeedListEntity: UserFeedListEntity, myProfileEntity: MyProfileEntity, userId: Int) -> TotalFeedListEntity {
         TotalFeedListEntity(
-            category: "all",
             isLoadable: userFeedListEntity.isLoadable,
             feeds: userFeedListEntity.feeds.map {
                 TotalFeedEntity(
@@ -71,7 +67,6 @@ extension TotalFeedListEntity {
                     novelGenreColor: $0.novelGenreColor,
                     novelGenreImage: $0.novelGenreImage,
                     feedWriterNovelRating: $0.feedWriterNovelRating,
-                    relevantCategories: $0.relevantCategories.joined(separator: ", "),
                     isSpoiler: $0.isSpoiler,
                     isModified: $0.isModified,
                     isMyFeed: true,
@@ -86,7 +81,6 @@ extension TotalFeedListEntity {
 extension TotalFeedResponse {
     func toEntity() -> TotalFeedEntity {
         let avatarImageURL = KingFisherRxHelper.makeImageURLString(path: self.avatarImage)
-        let categoryText = self.relevantCategories.joined(separator: ", ")
         let roundedRating: Float
         if let userNovelRating = self.feedWriterNovelRating {
             roundedRating = round(userNovelRating * 10) / 10
@@ -116,7 +110,6 @@ extension TotalFeedResponse {
             novelGenreColor: novelGenreColor,
             novelGenreImage: novelGenreImage,
             feedWriterNovelRating: roundedRating,
-            relevantCategories: categoryText,
             isSpoiler: self.isSpoiler,
             isModified: self.isModified,
             isMyFeed: self.isMyFeed,
@@ -130,8 +123,7 @@ extension TotalFeedResponse {
 
 // test repository를 위한 entity 더미 데이터
 extension TotalFeedListEntity {
-    static let dummyFullData = TotalFeedListEntity(category: "all",
-                                                   isLoadable: true,
+    static let dummyFullData = TotalFeedListEntity(isLoadable: true,
                                                    feeds: [
                                                     TotalFeedEntity(feedId: 10003,
                                                                     userId: 31313131,
@@ -147,7 +139,6 @@ extension TotalFeedListEntity {
                                                                     novelGenreColor: .genreColorBL,
                                                                     novelGenreImage: .icGenreLinkBL,
                                                                     feedWriterNovelRating: 3.33,
-                                                                    relevantCategories: "없을걸",
                                                                     isSpoiler: false,
                                                                     isModified: false,
                                                                     isMyFeed: true,
@@ -169,7 +160,6 @@ extension TotalFeedListEntity {
                                                                     novelGenreColor: .genreColorBL,
                                                                     novelGenreImage: .icGenreLinkBL,
                                                                     feedWriterNovelRating: 3.33,
-                                                                    relevantCategories: "없을걸",
                                                                     isSpoiler: false,
                                                                     isModified: false,
                                                                     isMyFeed: false,
@@ -191,7 +181,6 @@ extension TotalFeedListEntity {
                                                                     novelGenreColor: .genreColorBL,
                                                                     novelGenreImage: .icGenreLinkBL,
                                                                     feedWriterNovelRating: 3.33,
-                                                                    relevantCategories: "없을걸",
                                                                     isSpoiler: false,
                                                                     isModified: false,
                                                                     isMyFeed: false,
@@ -213,7 +202,6 @@ extension TotalFeedListEntity {
                                                                     novelGenreColor: .genreColorBL,
                                                                     novelGenreImage: .icGenreLinkBL,
                                                                     feedWriterNovelRating: -1,
-                                                                    relevantCategories: "없을걸",
                                                                     isSpoiler: false,
                                                                     isModified: false,
                                                                     isMyFeed: false,

--- a/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
+++ b/WSSiOS/Source/Data/Entity/UserFeedListEntity.swift
@@ -37,8 +37,7 @@ struct UserFeedEntity {
     let novelGenreColor: UIColor
     let novelGenreImage: UIImage
     let feedWriterNovelRating: Float
-    
-    let relevantCategories: [String]
+
     let isPublic: Bool
     
     let thumbnailImage: URL?
@@ -56,10 +55,6 @@ extension UserFeedResponse {
         }
         
         let hasImage = self.thumbnailUrl != nil && self.imageCount > 0
-        let translatedGenres = self.relevantCategories.compactMap {
-            NewNovelGenre(rawValue: $0)?.withKorean
-        }
-        
         let genre = NewNovelGenre(rawValue: self.genre ?? "")
         let novelGenreColor = genre?.linkColor ?? .genreColorR
         let novelGenreImage = genre?.linkImage ?? .icGenreLinkR
@@ -78,7 +73,6 @@ extension UserFeedResponse {
                               novelGenreColor: novelGenreColor,
                               novelGenreImage: novelGenreImage,
                               feedWriterNovelRating: roundedRating,
-                              relevantCategories: translatedGenres,
                               isPublic: isPublic,
                               thumbnailImage: thumbnailImageURL,
                               hasImage: hasImage,

--- a/WSSiOS/Source/Data/Repository/FeedRepository.swift
+++ b/WSSiOS/Source/Data/Repository/FeedRepository.swift
@@ -11,8 +11,8 @@ import RxSwift
 
 protocol FeedRepository {
     func getFeedData(lastFeedId: Int, size: Int?, feedsOption: String) -> Observable<TotalFeedListEntity>
-    func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void>
-    func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void>
+    func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void>
+    func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void>
 }
 
 struct TestFeedRepository: FeedRepository {
@@ -20,11 +20,11 @@ struct TestFeedRepository: FeedRepository {
         return Observable.just(TotalFeedListEntity.dummyFullData)
     }
     
-    func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+    func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
         return Observable.just(())
     }
     
-    func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+    func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
         return Observable.just(())
     }
 }
@@ -43,13 +43,13 @@ struct DefaultFeedRepository: FeedRepository {
             .asObservable()
     }
     
-    func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
-        return feedService.postFeed(relevantCategories: relevantCategories, feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
+    func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+        return feedService.postFeed(feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
             .asObservable()
     }
     
-    func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
-        return feedService.putFeed(feedId: feedId, relevantCategories: relevantCategories, feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
+    func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+        return feedService.putFeed(feedId: feedId, feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
             .asObservable()
     }
     

--- a/WSSiOS/Source/Presentation/Base/FeedList/FeedListCategoryView.swift
+++ b/WSSiOS/Source/Presentation/Base/FeedList/FeedListCategoryView.swift
@@ -57,10 +57,4 @@ final class FeedListCategoryView: UIView {
     func bindData(relevantCategories: String) {
         categoryLabel.applyWSSFont(.body2, with: relevantCategories)
     }
-
-    
-    // 임시 bindData, MyPage Entity 작업하면서 삭제할 것
-    func temporaryBindData(relevantCategories: [String]) {
-        categoryLabel.applyWSSFont(.body2, with: relevantCategories.joined(separator: ", "))
-    }
 }

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentSpoilerView.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentSpoilerView.swift
@@ -42,7 +42,12 @@ final class FeedEditContentSpoilerView: UIView {
         }
         
         spoilerNoticeLabel.do {
-            $0.applyWSSFont(.body3, with: "잠깐, 스포일러가 있나요?")
+            $0.applyWSSFont(.body3, with: StringLiterals.FeedEdit.spoilrSetting)
+            $0.makeAttribute(with: StringLiterals.FeedEdit.spoilrSetting)?
+                .lineHeight(WSSFont.body3.lineHeightMultiple)
+                .kerning(kerningPixel: WSSFont.body3.kerningPixel)
+                .partialFont(font: UIFont(name: "Pretendard-SemiBold", size: 14)!, rangeString: "스포일러")
+                .applyAttribute()
             $0.textColor = .wssGray200
         }
         

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditAssistantView/FeedEditContentView.swift
@@ -90,7 +90,7 @@ final class FeedEditContentView: UIView {
         feedTextWrapperView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(5)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(309)
+            $0.height.equalTo(335)
         }
         
         spoilerView.snp.makeConstraints {

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditView/FeedEditView.swift
@@ -20,8 +20,6 @@ final class FeedEditView: UIView {
     private let stackView = UIStackView()
     // 비공개 설정
     let feedEditPrivateSettingView = FeedEditPrivateSettingView()
-    // 장르 카테고리
-    let feedEditCategoryView = FeedEditCategoryView()
     // 작품 피드 작성
     let feedEditContentView = FeedEditContentView()
     // 작품 이미지 첨부
@@ -97,8 +95,7 @@ final class FeedEditView: UIView {
         
         scrollView.addSubview(stackView)
         
-        stackView.addArrangedSubviews(feedEditCategoryView,
-                                      feedEditContentView,
+        stackView.addArrangedSubviews(feedEditContentView,
                                       feedEditAddImageView,
                                       novelConnectStackView)
         novelConnectStackView.addArrangedSubviews(feedEditNovelConnectView,
@@ -126,8 +123,6 @@ final class FeedEditView: UIView {
             $0.bottom.equalTo(scrollView.contentLayoutGuide).offset(-30)
             $0.width.equalTo(UIScreen.main.bounds.width)
         }
-        
-        stackView.setCustomSpacing(12, after: feedEditCategoryView)
     }
     
     //MARK: - Custom Method

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewController/FeedEditViewController.swift
@@ -83,20 +83,12 @@ final class FeedEditViewController: UIViewController {
     //MARK: - Bind
     
     private func register() {
-        rootView.feedEditCategoryView.categoryCollectionView
-            .register(FeedCategoryCollectionViewCell.self,
-                      forCellWithReuseIdentifier: FeedCategoryCollectionViewCell.cellIdentifier)
-        
         rootView.feedEditAddImageView.addImageCollectionView
             .register(FeedAddImageCollectionViewCell.self,
                       forCellWithReuseIdentifier: FeedAddImageCollectionViewCell.cellIdentifier)
     }
     
     private func delegate() {
-        rootView.feedEditCategoryView.categoryCollectionView.rx
-            .setDelegate(self)
-            .disposed(by: disposeBag)
-        
         rootView.feedEditAddImageView.addImageCollectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
@@ -121,8 +113,6 @@ final class FeedEditViewController: UIViewController {
             completeButtonDidTap: rootView.completeButton.rx.tap,
             spoilerButtonDidTap: rootView.feedEditContentView.spoilerView.spoilerButton.rx.tap,
             publicButtonDidTap: rootView.feedEditPrivateSettingView.privateSettingButton.rx.tap,
-            categoryCollectionViewItemSelected: rootView.feedEditCategoryView.categoryCollectionView.rx.itemSelected.asObservable(),
-            categoryCollectionViewItemDeselected: rootView.feedEditCategoryView.categoryCollectionView.rx.itemDeselected.asObservable(),
             feedContentUpdated: rootView.feedEditContentView.feedTextView.rx.text.orEmpty.distinctUntilChanged().asObservable(),
             feedContentViewDidBeginEditing: rootView.feedEditContentView.feedTextView.rx.didBeginEditing,
             feedContentViewDidEndEditing: rootView.feedEditContentView.feedTextView.rx.didEndEditing,
@@ -139,21 +129,6 @@ final class FeedEditViewController: UIViewController {
             .subscribe(with: self, onNext: { owner, endEditing in
                 owner.view.endEditing(endEditing)
             })
-            .disposed(by: disposeBag)
-        
-        output.categoryListData.bind(to: rootView.feedEditCategoryView.categoryCollectionView.rx.items(
-            cellIdentifier: FeedCategoryCollectionViewCell.cellIdentifier,
-            cellType: FeedCategoryCollectionViewCell.self)) { item, element, cell in
-                let indexPath = IndexPath(item: item, section: 0)
-                
-                if self.feedEditViewModel.newRelevantCategories.contains(element) {
-                    self.rootView.feedEditCategoryView.categoryCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
-                } else {
-                    self.rootView.feedEditCategoryView.categoryCollectionView.deselectItem(at: indexPath, animated: false)
-                }
-                
-                cell.bindData(category: element)
-            }
             .disposed(by: disposeBag)
         
         output.popViewController
@@ -334,21 +309,8 @@ final class FeedEditViewController: UIViewController {
 
 extension FeedEditViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if collectionView == rootView.feedEditCategoryView.categoryCollectionView {
-            // 카테고리 컬렉션뷰에 대한 셀 사이즈 지정
-            var text: String?
-            
-            text = self.feedEditViewModel.relevantCategoryList[indexPath.item].withKorean
-            
-            guard let unwrappedText = text else {
-                return CGSize(width: 0, height: 0)
-            }
-            
-            let width = (unwrappedText as NSString).size(withAttributes: [NSAttributedString.Key.font: UIFont.Body2]).width + 26
-            return CGSize(width: width, height: 37)
-        } else {
-            // 이외: 첨부 이미지 컬렉션뷰에 대한 셀 사이즈 지정
-            return CGSize(width: 100, height: 100)
-        }
+        // 첨부 이미지 컬렉션뷰에 대한 셀 사이즈 지정
+        return CGSize(width: 100, height: 100)
     }
 }
+

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -17,14 +17,11 @@ final class FeedEditViewModel: ViewModelType {
     private let feedRepository: FeedRepository
     private let feedDetailRepository: FeedDetailRepository
     
-    let relevantCategoryList: [NewNovelGenre] = NewNovelGenre.feedEditGenres
-    
     private var isValidFeedContent: Bool = false
     private let feedContentPredicate = NSPredicate(format: "SELF MATCHES %@", "^[\\s]+$")
     private let maximumFeedContentCount: Int = 2000
     
     private let feedId: Int?
-    var newRelevantCategories: [NewNovelGenre] = []
     private var newNovelId: Int?
     private var newFeedContent: String = ""
     
@@ -43,7 +40,6 @@ final class FeedEditViewModel: ViewModelType {
     
     // Output
     private let endEditing = PublishRelay<Bool>()
-    private let categoryListData = BehaviorRelay<[NewNovelGenre]>(value: NewNovelGenre.feedEditGenres)
     private let popViewController = PublishRelay<Void>()
     private let initialFeedContent = BehaviorRelay<String>(value: "")
     private let isSpoiler = BehaviorRelay<Bool>(value: false)
@@ -73,7 +69,6 @@ final class FeedEditViewModel: ViewModelType {
         self.feedDetailRepository = feedDetailRepository
         
         self.feedId = feedId
-        self.newRelevantCategories = relevantCategories
         self.newNovelId = novelId
         
         self.connectedNovelTitle.accept(novelTitle)
@@ -86,8 +81,6 @@ final class FeedEditViewModel: ViewModelType {
         let completeButtonDidTap: ControlEvent<Void>
         let spoilerButtonDidTap: ControlEvent<Void>
         let publicButtonDidTap: ControlEvent<Void>
-        let categoryCollectionViewItemSelected: Observable<IndexPath>
-        let categoryCollectionViewItemDeselected: Observable<IndexPath>
         let feedContentUpdated: Observable<String>
         let feedContentViewDidBeginEditing: ControlEvent<Void>
         let feedContentViewDidEndEditing: ControlEvent<Void>
@@ -100,7 +93,6 @@ final class FeedEditViewModel: ViewModelType {
     
     struct Output {
         let endEditing: Observable<Bool>
-        let categoryListData: Observable<[NewNovelGenre]>
         let popViewController: Observable<Void>
         let initialFeedContent: Observable<String>
         let isSpoiler: Observable<Bool>
@@ -131,11 +123,6 @@ final class FeedEditViewModel: ViewModelType {
             }
             .subscribe(with: self, onNext: { owner, data in
                 guard let data = data else { return }
-                
-                owner.initialRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
-                owner.newRelevantCategories = data.genreCategories.map { NewNovelGenre.withKoreanRawValue(from: $0) }
-                owner.categoryListData.accept(self.relevantCategoryList)
-                
                 owner.initialFeedContent.accept(data.feedContent)
                 
                 owner.initialNovelId = data.novelData?.novelId
@@ -194,9 +181,9 @@ final class FeedEditViewModel: ViewModelType {
             .flatMapLatest { (isSpoiler, isPublic, selectedImages) in
                 Observable.deferred {
                     if let feedId = self.feedId {
-                        self.putFeed(feedId: feedId, relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
+                        self.putFeed(feedId: feedId, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
                     } else {
-                        self.postFeed(relevantCategories: self.newRelevantCategories.map { $0.rawValue }, feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
+                        self.postFeed(feedContent: self.newFeedContent, novelId: self.newNovelId, isSpoiler: isSpoiler, isPublic: isPublic, images: selectedImages)
                     }
                 }
                 .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
@@ -226,22 +213,6 @@ final class FeedEditViewModel: ViewModelType {
             .subscribe(with: self, onNext: { owner, isPublic in
                 owner.isPublic.accept(!isPublic)
                 owner.isPublicChanged = owner.initialIsPublic != owner.isPublic.value
-                owner.checkIfCompleteButtonIsAbled()
-            })
-            .disposed(by: disposeBag)
-        
-        input.categoryCollectionViewItemSelected
-            .subscribe(with: self, onNext: { owner, indexPath in
-                owner.newRelevantCategories.append(owner.relevantCategoryList[indexPath.item])
-                owner.isRelevantCategoriesChanged = Set(self.initialRelevantCategories ?? []) != Set(self.newRelevantCategories)
-                owner.checkIfCompleteButtonIsAbled()
-            })
-            .disposed(by: disposeBag)
-        
-        input.categoryCollectionViewItemDeselected
-            .subscribe(with: self, onNext: { owner, indexPath in
-                owner.newRelevantCategories.removeAll { $0 == owner.relevantCategoryList[indexPath.item]}
-                owner.isRelevantCategoriesChanged = Set(self.initialRelevantCategories ?? []) != Set(self.newRelevantCategories)
                 owner.checkIfCompleteButtonIsAbled()
             })
             .disposed(by: disposeBag)
@@ -331,7 +302,6 @@ final class FeedEditViewModel: ViewModelType {
             .distinctUntilChanged()
         
         return Output(endEditing: endEditing.asObservable(),
-                      categoryListData: categoryListData.asObservable(),
                       popViewController: popViewController.asObservable(),
                       initialFeedContent: initialFeedContent.asObservable(),
                       isSpoiler: isSpoiler.asObservable(),
@@ -357,7 +327,9 @@ final class FeedEditViewModel: ViewModelType {
     }
     
     func checkIfCompleteButtonIsAbled() {
-        self.completeButtonIsAbled.accept(self.isValidFeedContent && !self.newRelevantCategories.isEmpty && self.isInitialFeedChanged())
+        self.completeButtonIsAbled.accept(
+            self.isValidFeedContent && self.isInitialFeedChanged()
+        )
     }
     
     //MARK: - API
@@ -367,13 +339,26 @@ final class FeedEditViewModel: ViewModelType {
             .observe(on: MainScheduler.instance)
     }
     
-    private func postFeed(relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
-        feedRepository.postFeed(relevantCategories: relevantCategories, feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
-            .observe(on: MainScheduler.instance)
+    private func postFeed(feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+        feedRepository.postFeed(
+            feedContent: feedContent,
+            novelId: novelId,
+            isSpoiler: isSpoiler,
+            isPublic: isPublic,
+            images: images
+        )
+        .observe(on: MainScheduler.instance)
     }
     
-    private func putFeed(feedId: Int, relevantCategories: [String], feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
-        feedRepository.putFeed(feedId: feedId, relevantCategories: relevantCategories, feedContent: feedContent, novelId: novelId, isSpoiler: isSpoiler, isPublic: isPublic, images: images)
-            .observe(on: MainScheduler.instance)
+    private func putFeed(feedId: Int, feedContent: String, novelId: Int?, isSpoiler: Bool, isPublic: Bool, images: [UIImage]) -> Observable<Void> {
+        feedRepository.putFeed(
+            feedId: feedId,
+            feedContent: feedContent,
+            novelId: novelId,
+            isSpoiler: isSpoiler,
+            isPublic: isPublic,
+            images: images
+        )
+        .observe(on: MainScheduler.instance)
     }
 }

--- a/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
+++ b/WSSiOS/Source/Presentation/FeedEdit/FeedEditViewModel/FeedEditViewModel.swift
@@ -26,12 +26,10 @@ final class FeedEditViewModel: ViewModelType {
     private var newFeedContent: String = ""
     
     // 기존 피드 수정
-    private var initialRelevantCategories: [NewNovelGenre]?
     private var initialIsSpoiler: Bool?
     private var initialIsPublic: Bool?
     private var initialNovelId: Int?
     private var initialAddImages: [UIImage]?
-    private var isRelevantCategoriesChanged: Bool = false
     private var isFeedContentChanged: Bool = false
     private var isSpoilerChanged: Bool = false
     private var isPublicChanged: Bool = false
@@ -62,7 +60,6 @@ final class FeedEditViewModel: ViewModelType {
     init(feedRepository: FeedRepository,
          feedDetailRepository: FeedDetailRepository,
          feedId: Int? = nil,
-         relevantCategories: [NewNovelGenre] = [],
          novelId: Int? = nil,
          novelTitle: String? = nil) {
         self.feedRepository = feedRepository
@@ -323,7 +320,7 @@ final class FeedEditViewModel: ViewModelType {
     // MARK: - Custom Method
     
     func isInitialFeedChanged() -> Bool {
-        return feedId != nil ? isRelevantCategoriesChanged || isFeedContentChanged || isSpoilerChanged || isPublicChanged || isNovelIdChanged || isAddImagesChanged : true
+        return feedId != nil ? isFeedContentChanged || isSpoilerChanged || isPublicChanged || isNovelIdChanged || isAddImagesChanged : true
     }
     
     func checkIfCompleteButtonIsAbled() {

--- a/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryCell/MyLibraryCollectionViewCell.swift
+++ b/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryCell/MyLibraryCollectionViewCell.swift
@@ -43,6 +43,7 @@ final class MyLibraryCollectionViewCell: UICollectionViewCell {
         novelImageView.do {
             $0.layer.cornerRadius = 8
             $0.clipsToBounds = true
+            $0.contentMode = .scaleAspectFill
         }
         
         readStatusTagView.do {

--- a/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
+++ b/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewController/NovelDetailViewController.swift
@@ -204,9 +204,8 @@ final class NovelDetailViewController: UIViewController {
         output.pushTofeedWriteViewController
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, result in
-                let (genre, novelId, novelTitle) = result
-                owner.pushToFeedEditViewController(relevantCategories: genre,
-                                                   novelId: novelId,
+                let (novelId, novelTitle) = result
+                owner.pushToFeedEditViewController(novelId: novelId,
                                                    novelTitle: novelTitle)
             })
             .disposed(by: disposeBag)

--- a/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewModel/NovelDetailViewModel.swift
+++ b/WSSiOS/Source/Presentation/NovelDetail/NovelDetailViewModel/NovelDetailViewModel.swift
@@ -38,7 +38,7 @@ final class NovelDetailViewModel: ViewModelType {
     private let readStatus = BehaviorRelay<ReadStatus?>(value: nil)
     private let novelGenre = BehaviorRelay<[NewNovelGenre]>(value: [])
     private let pushToAuthorSearchResultViewController = PublishRelay<String>()
-
+    
     // Tab
     private let selectedTab = BehaviorRelay<Tab>(value: Tab.info)
     
@@ -70,7 +70,11 @@ final class NovelDetailViewModel: ViewModelType {
     
     //MARK: - Life Cycle
     
-    init(novelDetailRepository: NovelDetailRepository, feedDetailRepository: FeedDetailRepository, novelId: Int = 0) {
+    init(
+        novelDetailRepository: NovelDetailRepository,
+        feedDetailRepository: FeedDetailRepository,
+        novelId: Int = 0
+    ) {
         self.novelDetailRepository = novelDetailRepository
         self.feedDetailRepository = feedDetailRepository
         self.novelId = novelId
@@ -135,7 +139,7 @@ final class NovelDetailViewModel: ViewModelType {
         // NovelDetailHeader
         let showLargeNovelCoverImage: Driver<Bool>
         let isUserNovelInterested: Driver<Bool>
-        let pushTofeedWriteViewController: Observable<(genre: [NewNovelGenre], novelId: Int, novelTitle: String)>
+        let pushTofeedWriteViewController: Observable<(novelId: Int, novelTitle: String)>
         let pushToReviewViewController: Observable<(isInterest: Bool, readStatus: ReadStatus, novelId: Int, novelTitle: String)>
         let pushToAuthorSearchResultViewController: Observable<String>
         
@@ -275,13 +279,13 @@ final class NovelDetailViewModel: ViewModelType {
             }
             .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .asObservable()
-
+        
         input.authorLabelDidTap
             .subscribe(with: self, onNext: { owner, authorName in
                 owner.pushToAuthorSearchResultViewController.accept(authorName)
             })
             .disposed(by: disposeBag)
-
+        
         input.interestButtonDidTap
             .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .do(onNext: { _ in
@@ -308,8 +312,7 @@ final class NovelDetailViewModel: ViewModelType {
                 AmplitudeManager.shared.track(AmplitudeEvent.Novel.novelWriteButton)
             })
             .map { _ in
-                (genre: self.novelGenre.value,
-                 novelId: self.novelId,
+                (novelId: self.novelId,
                  novelTitle: self.novelTitle)
             }
         
@@ -319,8 +322,7 @@ final class NovelDetailViewModel: ViewModelType {
                 AmplitudeManager.shared.track(AmplitudeEvent.Novel.novelWriteFloatingButton)
             })
             .map { _ in
-                (genre: self.novelGenre.value,
-                 novelId: self.novelId,
+                (novelId: self.novelId,
                  novelTitle: self.novelTitle)
             }
         

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageAssistantView/UserPagePrivateView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageAssistantView/UserPagePrivateView.swift
@@ -68,9 +68,11 @@ final class UserPagePrivateView: UIView {
         }
     }
     
-    func bindData(nickname: String) {
+    func bindData(_ nickname: String) {
         isPrivateDescriptionLabel.do {
-            $0.applyWSSFont(.body2, with: nickname)
+            let privateDescription = String(format: StringLiterals.MyPage.Profile.privateLabel, nickname)
+           
+            $0.applyWSSFont(.body2, with: privateDescription)
         }
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -87,18 +87,11 @@ final class UserPageFeedView: UIView {
         userPageFeedDetailButtonLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
-        
-        userPagePrivateView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
-        
-        userPageFeedEmptyView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
     }
     
     //MARK: - Data
     
+    // 비공개 유저일 때
     func isPrivateUserPage(nickname: String) {
         userPagePrivateView.isHidden = false
         userPagePrivateView.bindData(nickname)
@@ -110,6 +103,7 @@ final class UserPageFeedView: UIView {
         }
     }
     
+    // 공개 + 작성 글이 없을 때
     func isEmptyFeed() {
         userPageFeedEmptyView.isHidden = false
         
@@ -121,6 +115,5 @@ final class UserPageFeedView: UIView {
     
     func showMoreButton(isShow: Bool) {
         showMoreActivityButtonView.isHidden = !isShow
-        self.stackView.layoutIfNeeded()
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -21,8 +21,7 @@ final class UserPageFeedView: UIView {
     private let showMoreActivityButtonView = UIView()
     let userPageFeedDetailButton = UIButton()
     private let userPageFeedDetailButtonLabel = UILabel()
-    private let paddingViewAfterButton = UIView()
-    
+
     private let userPagePrivateView = UserPagePrivateView()
     private let userPageFeedEmptyView = UserPageFeedEmptyView()
     
@@ -58,10 +57,6 @@ final class UserPageFeedView: UIView {
             }
         }
         
-        paddingViewAfterButton.do {
-            $0.backgroundColor = .wssWhite
-        }
-        
         userPagePrivateView.isHidden = true
         userPageFeedEmptyView.isHidden = true
     }
@@ -70,7 +65,6 @@ final class UserPageFeedView: UIView {
         self.addSubview(stackView)
         stackView.addArrangedSubviews(userPageFeedTableView,
                                       showMoreActivityButtonView,
-                                      paddingViewAfterButton,
                                       userPagePrivateView,
                                       userPageFeedEmptyView)
         showMoreActivityButtonView.addSubview(userPageFeedDetailButton)
@@ -79,7 +73,8 @@ final class UserPageFeedView: UIView {
     
     private func setLayout() {
         stackView.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(40)
         }
         
         userPageFeedDetailButton.snp.makeConstraints {
@@ -91,11 +86,6 @@ final class UserPageFeedView: UIView {
         
         userPageFeedDetailButtonLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        paddingViewAfterButton.snp.makeConstraints {
-            $0.width.equalToSuperview()
-            $0.height.equalTo(40)
         }
         
         userPagePrivateView.snp.makeConstraints {
@@ -114,7 +104,6 @@ final class UserPageFeedView: UIView {
         
         [userPageFeedTableView,
          showMoreActivityButtonView,
-         paddingViewAfterButton,
          userPageFeedEmptyView].forEach { view in
             view.isHidden = true
         }
@@ -126,28 +115,13 @@ final class UserPageFeedView: UIView {
         userPageFeedEmptyView.isHidden = false
         
         [userPageFeedTableView,
-         showMoreActivityButtonView,
-         paddingViewAfterButton].forEach { view in
+         showMoreActivityButtonView].forEach { view in
             view.isHidden = true
         }
     }
     
     func showMoreButton(isShow: Bool) {
         showMoreActivityButtonView.isHidden = !isShow
-        paddingViewAfterButton.isHidden = !isShow
-        
-        if isShow {
-            paddingViewAfterButton.snp.makeConstraints {
-                $0.width.equalToSuperview()
-                $0.height.equalTo(40)
-            }
-        } else {
-            paddingViewAfterButton.snp.makeConstraints {
-                $0.width.bottom.equalToSuperview()
-                $0.height.greaterThanOrEqualTo(40)
-            }
-        }
-        
         self.stackView.layoutIfNeeded()
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -101,14 +101,13 @@ final class UserPageFeedView: UIView {
     
     func isPrivateUserPage(nickname: String) {
         userPagePrivateView.isHidden = false
+        userPagePrivateView.bindData(nickname)
         
         [userPageFeedTableView,
          showMoreActivityButtonView,
          userPageFeedEmptyView].forEach { view in
             view.isHidden = true
         }
-        let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-        userPagePrivateView.bindData(nickname: text)
     }
     
     func isEmptyFeed() {

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
@@ -115,8 +115,7 @@ final class UserPageOverviewView: UIView {
             view.isHidden = true
         }
         
-        let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-        userPagePrivateView.bindData(nickname: text)
+        userPagePrivateView.bindData(nickname)
         userPagePrivateView.isHidden = false
     }
     

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
@@ -87,15 +87,6 @@ final class UserPageOverviewView: UIView {
                 $0.height.equalTo(3)
             }
         }
-        
-        userPagePrivateView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
-        
-        preferencesEmptyView.snp.makeConstraints {
-            $0.width.equalToSuperview()
-            $0.height.equalTo(363)
-        }
     }
     
     //MARK: - Custom Method

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageViewModel.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageViewModel.swift
@@ -345,6 +345,10 @@ final class UserPageViewModel: ViewModelType {
         return Observable.zip(genrePreferences, novelPreferences)
             .do(onNext: { [weak self] genre, novel in
                 guard let self else { return }
+                
+                // 비공개 유저일 때는 취향분석 empty 처리하지 않음
+                guard self.profileDataRelay.value.isProfilePublic else { return }
+                
                 let isGenreEmpty = genre.genreTotalCount == 0
                 let isNovelEmpty = novel.attractivePoints.isEmpty && novel.keywords.isEmpty
                 self.isPrefernecesEmptyRelay.accept((isGenreEmpty, isNovelEmpty))
@@ -363,7 +367,9 @@ final class UserPageViewModel: ViewModelType {
             })
             .map { _ in Void() }
             .catch { [weak self] error in
-                self?.isPrefernecesEmptyRelay.accept((true, true))
+                if self?.profileDataRelay.value.isProfilePublic == true {
+                    self?.isPrefernecesEmptyRelay.accept((true, true))
+                }
                 return .just(Void())
             }
     }
@@ -384,7 +390,10 @@ final class UserPageViewModel: ViewModelType {
                 guard let self else { return }
                 
                 if feedCellData.isEmpty {
-                    self.isEmptyFeedRelay.accept(())
+                    // 비공개 유저일 때는 피드가 빈 것이 아니라 비공개 상태이므로 empty 처리하지 않음
+                    if self.profileDataRelay.value.isProfilePublic {
+                        self.isEmptyFeedRelay.accept(())
+                    }
                 } else {
                     
                     //5개까지만 활동뷰에 바인딩
@@ -395,7 +404,9 @@ final class UserPageViewModel: ViewModelType {
                 }
             })
             .catch { [weak self] error in
-                self?.isEmptyFeedRelay.accept(())
+                if self?.profileDataRelay.value.isProfilePublic == true {
+                    self?.isEmptyFeedRelay.accept(())
+                }
                 return .just([])
             }
             .map { _ in Void() }


### PR DESCRIPTION
### ⭐️Issue
- close #678
<br/>

### 🌟Motivation
- 기획 개편으로 피드 작성 내 카테고리 선택 로직을 제거했습니다. 
<br/>

### 🌟Key Changes
해당 기능과 관련된 코드를 전부 제거했습니다. 
피드 작성 시 UI를 수정했습니다. 
<br/>


### 🌟Simulation
| <img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-01 at 16 28 21" src="https://github.com/user-attachments/assets/9b8d664c-0382-4b7d-b6e2-115616e527c7" /> | <img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-01 at 16 28 38" src="https://github.com/user-attachments/assets/18b67abf-0607-4fbd-b29b-6567d8264787" /> | 
| -- | -- | 
<br/>

### 🌟To Reviewer
~아직 서버가 미완성 상태라 시뮬레이터로 테스트가 어렵습니다.~
현재 테스트 가능합니다!
<br/>

### 🌟Reference

<br/>
