### PR TITLE
[Fix] #685 - 공지사항 상세 글 잘려보이는 오류 해결 

### DIFF
--- a/WSSiOS/Source/Presentation/Home/HomeNotificationDetail/HomeNotificationDetailView/HomeNotificationDetailAssistantView/HomeNotificationDetailContentView.swift
+++ b/WSSiOS/Source/Presentation/Home/HomeNotificationDetail/HomeNotificationDetailView/HomeNotificationDetailAssistantView/HomeNotificationDetailContentView.swift
@@ -82,7 +82,6 @@ final class HomeNotificationDetailContentView: UIView {
             $0.top.equalTo(dividerView.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(40)
-            $0.height.equalTo(0)
         }
     }
     
@@ -90,34 +89,12 @@ final class HomeNotificationDetailContentView: UIView {
         notificationTitleLabel.do {
             $0.applyWSSFont(.headline1, with: data.title)
             $0.numberOfLines = 0
+            $0.lineBreakStrategy = .hangulWordPriority
         }
+        
         createdDateLabel.applyWSSFont(.body5, with: data.createdDate)
         notificationContentTextView.do {
             $0.applyWSSFont(.body2, with: data.content)
         }
-        
-        notificationContentTextView.snp.updateConstraints {
-            $0.height.equalTo(getTextViewLabelHeight(text: data.content))
-        }
-    }
-    
-    private func getTextViewLabelHeight(text: String) -> CGFloat {
-        let labelWidth = UIScreen.main.bounds.width - 40
-        let label = UILabel(frame: .init(x: .zero,
-                                         y: .zero,
-                                         width: labelWidth,
-                                         height: .greatestFiniteMagnitude)
-        )
-        label.do {
-            $0.applyWSSFont(.body2, with: text)
-            $0.textAlignment = .left
-            $0.lineBreakStrategy = .hangulWordPriority
-            $0.numberOfLines = 0
-        }
-        label.sizeToFit()
-        
-        let labelHeight = label.frame.height
-        let resizedLabelHeight = ceil(labelHeight)
-        return resizedLabelHeight
     }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #685
<br/>

### 🌟Motivation
- 공지사항 상세 내 글이 잘려보이는 문제를 해결했습니다. 
<br/>

### 🌟Key Changes
공지사항 상세 화면에서 본문 텍스트가 잘려보이는 문제를 수정했습니다.
기존에는 `notificationContentTextView`의 높이를 동적으로 계산하기 위해 `getTextViewLabelHeight(text:)` 메서드를 별도로 구현하고, `bindData` 시점에 `snp.updateConstraints`로 높이를 직접 지정하는 방식을 사용했습니다. 
이 메서드는 임시 UILabel을 생성해 텍스트를 렌더링한 뒤 sizeToFit()으로 높이를 측정하는 방식이었는데, 실제 TextView의 렌더링 결과와 차이가 발생해 내용이 잘리는 버그가 있었습니다.

이번 수정에서는 해당 수동 높이 계산 로직을 전부 제거하고, 
`setupLayout` 내 초기 constraints에서 $0.height.equalTo(0) 설정도 함께 제거했습니다. 
이를 통해 TextView가 AutoLayout에 의해 콘텐츠 크기에 맞게 자연스럽게 늘어나도록 변경되었습니다.
<br/>

### 🌟Simulation
| 수정 전 | 수정 후 | 
| -- | -- | 
|<img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 23 17 50" src="https://github.com/user-attachments/assets/14a2a9e0-d6d3-4d0c-aa79-2bc01569b569" /> | <img width="300" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 23 13 22" src="https://github.com/user-attachments/assets/de87925b-61dc-4b2a-a39c-2076bd2ba30a" /> | 
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
