### PR TITLE
[Fix] #636 - 타유저페이지 UI 분기처리 개선

### DIFF
--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+MyPage.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+MyPage.swift
@@ -23,7 +23,7 @@ extension StringLiterals {
             static let genrePreferenceTitle = "장르 취향"
             static let novelPreferenceTitle = "작품 취향"
             static let novelPreferenceLabel = "(이)가 매력적인 작품을 선호해요"
-            static let privateLabel = "님의 프로필은\n비공개 상태예요"
+            static let privateLabel = "%@님의 프로필은\n비공개 상태예요"
             static let unknownAlertButtonTitle = "확인"
             static let otherProfileLibrary = "통계"
             static let otherProfileFeed = "활동"

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageAssistantView/UserPagePrivateView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageAssistantView/UserPagePrivateView.swift
@@ -68,9 +68,11 @@ final class UserPagePrivateView: UIView {
         }
     }
     
-    func bindData(nickname: String) {
+    func bindData(_ nickname: String) {
         isPrivateDescriptionLabel.do {
-            $0.applyWSSFont(.body2, with: nickname)
+            let privateDescription = String(format: StringLiterals.MyPage.Profile.privateLabel, nickname)
+           
+            $0.applyWSSFont(.body2, with: privateDescription)
         }
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -87,18 +87,11 @@ final class UserPageFeedView: UIView {
         userPageFeedDetailButtonLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
-        
-        userPagePrivateView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
-        
-        userPageFeedEmptyView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
     }
     
     //MARK: - Data
     
+    // 비공개 유저일 때
     func isPrivateUserPage(nickname: String) {
         userPagePrivateView.isHidden = false
         userPagePrivateView.bindData(nickname)
@@ -110,6 +103,7 @@ final class UserPageFeedView: UIView {
         }
     }
     
+    // 공개 + 작성 글이 없을 때
     func isEmptyFeed() {
         userPageFeedEmptyView.isHidden = false
         
@@ -121,6 +115,5 @@ final class UserPageFeedView: UIView {
     
     func showMoreButton(isShow: Bool) {
         showMoreActivityButtonView.isHidden = !isShow
-        self.stackView.layoutIfNeeded()
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -21,8 +21,7 @@ final class UserPageFeedView: UIView {
     private let showMoreActivityButtonView = UIView()
     let userPageFeedDetailButton = UIButton()
     private let userPageFeedDetailButtonLabel = UILabel()
-    private let paddingViewAfterButton = UIView()
-    
+
     private let userPagePrivateView = UserPagePrivateView()
     private let userPageFeedEmptyView = UserPageFeedEmptyView()
     
@@ -58,10 +57,6 @@ final class UserPageFeedView: UIView {
             }
         }
         
-        paddingViewAfterButton.do {
-            $0.backgroundColor = .wssWhite
-        }
-        
         userPagePrivateView.isHidden = true
         userPageFeedEmptyView.isHidden = true
     }
@@ -70,7 +65,6 @@ final class UserPageFeedView: UIView {
         self.addSubview(stackView)
         stackView.addArrangedSubviews(userPageFeedTableView,
                                       showMoreActivityButtonView,
-                                      paddingViewAfterButton,
                                       userPagePrivateView,
                                       userPageFeedEmptyView)
         showMoreActivityButtonView.addSubview(userPageFeedDetailButton)
@@ -79,7 +73,8 @@ final class UserPageFeedView: UIView {
     
     private func setLayout() {
         stackView.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(40)
         }
         
         userPageFeedDetailButton.snp.makeConstraints {
@@ -91,11 +86,6 @@ final class UserPageFeedView: UIView {
         
         userPageFeedDetailButtonLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        paddingViewAfterButton.snp.makeConstraints {
-            $0.width.equalToSuperview()
-            $0.height.equalTo(40)
         }
         
         userPagePrivateView.snp.makeConstraints {
@@ -114,7 +104,6 @@ final class UserPageFeedView: UIView {
         
         [userPageFeedTableView,
          showMoreActivityButtonView,
-         paddingViewAfterButton,
          userPageFeedEmptyView].forEach { view in
             view.isHidden = true
         }
@@ -126,28 +115,13 @@ final class UserPageFeedView: UIView {
         userPageFeedEmptyView.isHidden = false
         
         [userPageFeedTableView,
-         showMoreActivityButtonView,
-         paddingViewAfterButton].forEach { view in
+         showMoreActivityButtonView].forEach { view in
             view.isHidden = true
         }
     }
     
     func showMoreButton(isShow: Bool) {
         showMoreActivityButtonView.isHidden = !isShow
-        paddingViewAfterButton.isHidden = !isShow
-        
-        if isShow {
-            paddingViewAfterButton.snp.makeConstraints {
-                $0.width.equalToSuperview()
-                $0.height.equalTo(40)
-            }
-        } else {
-            paddingViewAfterButton.snp.makeConstraints {
-                $0.width.bottom.equalToSuperview()
-                $0.height.greaterThanOrEqualTo(40)
-            }
-        }
-        
         self.stackView.layoutIfNeeded()
     }
 }

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageFeedView.swift
@@ -101,14 +101,13 @@ final class UserPageFeedView: UIView {
     
     func isPrivateUserPage(nickname: String) {
         userPagePrivateView.isHidden = false
+        userPagePrivateView.bindData(nickname)
         
         [userPageFeedTableView,
          showMoreActivityButtonView,
          userPageFeedEmptyView].forEach { view in
             view.isHidden = true
         }
-        let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-        userPagePrivateView.bindData(nickname: text)
     }
     
     func isEmptyFeed() {

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
@@ -115,8 +115,7 @@ final class UserPageOverviewView: UIView {
             view.isHidden = true
         }
         
-        let text = nickname + StringLiterals.MyPage.Profile.privateLabel
-        userPagePrivateView.bindData(nickname: text)
+        userPagePrivateView.bindData(nickname)
         userPagePrivateView.isHidden = false
     }
     

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageView/UserPageOverviewView.swift
@@ -87,15 +87,6 @@ final class UserPageOverviewView: UIView {
                 $0.height.equalTo(3)
             }
         }
-        
-        userPagePrivateView.snp.makeConstraints {
-            $0.height.equalTo(450)
-        }
-        
-        preferencesEmptyView.snp.makeConstraints {
-            $0.width.equalToSuperview()
-            $0.height.equalTo(363)
-        }
     }
     
     //MARK: - Custom Method

--- a/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageViewModel.swift
+++ b/WSSiOS/Source/Presentation/UserPage/UserPage/UserPageViewModel/UserPageViewModel.swift
@@ -345,6 +345,10 @@ final class UserPageViewModel: ViewModelType {
         return Observable.zip(genrePreferences, novelPreferences)
             .do(onNext: { [weak self] genre, novel in
                 guard let self else { return }
+                
+                // 비공개 유저일 때는 취향분석 empty 처리하지 않음
+                guard self.profileDataRelay.value.isProfilePublic else { return }
+                
                 let isGenreEmpty = genre.genreTotalCount == 0
                 let isNovelEmpty = novel.attractivePoints.isEmpty && novel.keywords.isEmpty
                 self.isPrefernecesEmptyRelay.accept((isGenreEmpty, isNovelEmpty))
@@ -363,7 +367,9 @@ final class UserPageViewModel: ViewModelType {
             })
             .map { _ in Void() }
             .catch { [weak self] error in
-                self?.isPrefernecesEmptyRelay.accept((true, true))
+                if self?.profileDataRelay.value.isProfilePublic == true {
+                    self?.isPrefernecesEmptyRelay.accept((true, true))
+                }
                 return .just(Void())
             }
     }
@@ -384,7 +390,10 @@ final class UserPageViewModel: ViewModelType {
                 guard let self else { return }
                 
                 if feedCellData.isEmpty {
-                    self.isEmptyFeedRelay.accept(())
+                    // 비공개 유저일 때는 피드가 빈 것이 아니라 비공개 상태이므로 empty 처리하지 않음
+                    if self.profileDataRelay.value.isProfilePublic {
+                        self.isEmptyFeedRelay.accept(())
+                    }
                 } else {
                     
                     //5개까지만 활동뷰에 바인딩
@@ -395,7 +404,9 @@ final class UserPageViewModel: ViewModelType {
                 }
             })
             .catch { [weak self] error in
-                self?.isEmptyFeedRelay.accept(())
+                if self?.profileDataRelay.value.isProfilePublic == true {
+                    self?.isEmptyFeedRelay.accept(())
+                }
                 return .just([])
             }
             .map { _ in Void() }


### PR DESCRIPTION
### ⭐️Issue
- close #636 
<br/>

### 🌟Motivation
- 타유저 페이지에서 발생하는 UI 분기처리 버그를 수정했습니다.  
    - 비공개 계정 / 공개 계정(피드 존재) / 공개 계정(피드 없음) 등 다양한 상태에 따라 UI가 올바르게 렌더링되지 않는 문제를 개선했습니다.
<br/>

### 🌟Key Changes
- 타유저 페이지 내 불필요한 컴포넌트 제거 및 레이아웃 정리
- `String Format`을 사용하여 문자열 바인딩 로직 개선
- 뷰 레이아웃 높이 강제 설정(hardcoded height) 제거
- 피드가 공개 상태일 때 `emptyView`가 정상적으로 노출되도록 수정
<br/>


### 🌟Simulation
| 비공개 | 공개 + 피드 존재  | 
| -- |  -- | 
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-01 at 17 45 14](https://github.com/user-attachments/assets/8cebba34-77f5-47ab-833f-5dcbef5a7cc6) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-01 at 17 46 28](https://github.com/user-attachments/assets/192bf904-06d9-4f31-88e7-be1d6e8c0dd5) |


 
<br/>

### 🌟To Reviewer
- UI 분기 케이스(비공개 / 공개+피드 있음 / 공개+피드 없음)를 중심으로 리뷰 부탁드립니다.
- 하드코딩된 높이값 제거로 인한 레이아웃 변화를 확인해 주세요.
<br/>

### 🌟Reference

<br/>
