### PR TITLE
[Fix] #671 - 피드에서 스크롤 위치 업데이트 되는 오류 수정

### DIFF
--- a/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
+++ b/WSSiOS/Source/Presentation/Base/WSSTabBarController.swift
@@ -143,10 +143,8 @@ final class WSSTabBarController: UITabBarController {
 }
 
 extension WSSTabBarController: UITabBarControllerDelegate {
-    
-    //MARK: - Delegate
-    
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        
         guard let selectedIndex = viewControllers?.firstIndex(of: viewController) else {
             return true
         }
@@ -156,26 +154,36 @@ extension WSSTabBarController: UITabBarControllerDelegate {
             return false
         }
         
-        if let navigationController = viewController as? UINavigationController,
-           let viewController = navigationController.viewControllers.first {
-            
-            switch viewController {
+        if tabBarController.selectedViewController === viewController {
+            if let navigationController = viewController as? UINavigationController,
+               let rootVC = navigationController.viewControllers.first {
                 
-            case let homeViewController as HomeViewController:
-                homeViewController.scrollToTop()
-                
-            case let feedViewController as FeedViewController:
-                if tabBarController.selectedViewController == navigationController {
-                    feedViewController.scrollToTop()
+                switch rootVC {
+                case let homeVC as HomeViewController:
+                    homeVC.scrollToTop()
+                    
+                case let feedVC as FeedViewController:
+                    feedVC.scrollToTop()
+                    
+                case let myPageVC as MyPageViewController:
+                    myPageVC.scrollToTop()
+                    
+                default:
+                    break
                 }
-                
-            case let myPageViewController as MyPageViewController:
-                myPageViewController.scrollToTop()
-                
-            default:
-                break
             }
+            return false
         }
+        
+        viewController.view.alpha = 0
+        viewController.view.transform = CGAffineTransform(scaleX: 0.99, y: 0.99)
+        
+        UIView.transition(with: tabBarController.view,
+                          duration: 0.2,
+                          options: [.transitionCrossDissolve, .curveEaseOut],
+                          animations: {
+            viewController.view.alpha = 1
+        })
         
         return true
     }

--- a/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedPageContentViewController.swift
+++ b/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedPageContentViewController.swift
@@ -54,7 +54,8 @@ final class FeedPageContentViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        reloadFeed.accept(())
+        super.viewWillAppear(animated)
+        
         showTabBar()
     }
     

--- a/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedViewController.swift
+++ b/WSSiOS/Source/Presentation/Feed/Feed/FeedViewController/FeedViewController.swift
@@ -150,7 +150,7 @@ extension FeedViewController: UICollectionViewDelegateFlowLayout {
               let currentVC = pageViewController.viewControllers?.first else { return }
         
         if let scrollView = currentVC.view.subviews.compactMap({ $0 as? UIScrollView }).first {
-            scrollView.setContentOffset(CGPoint(x: 0, y: -scrollView.contentInset.top), animated: true)
+            scrollView.setContentOffset(CGPoint(x: 0, y: -scrollView.adjustedContentInset.top), animated: true)
         }
     }
 }


### PR DESCRIPTION
### ⭐️Issue
- close #671 
<br/>

### 🌟Motivation
- 소소피드, 내피드에서 스크롤 위치가 업데이트 되는 오류를 수정했습니다. 
- 피드 탭 클릭 시 스크롤이 최상단으로 가지 않는 상황이 발생했고, 해당 상황에 대한 오류 수정했습니다. 
<br/>

### 🌟Key Changes
특이사항 없음
<br/>

### 🌟Simulation

|  ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-08 at 19 30 24](https://github.com/user-attachments/assets/934979e1-1e70-4119-a0a4-f9965a916711) |
 | -- | 

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
