### PR TITLE
[Feat] #703 - 일반검색 개선: 최근검색어 추가

### DIFF
--- a/WSSiOS/Network/Search/SearchService.swift
+++ b/WSSiOS/Network/Search/SearchService.swift
@@ -19,11 +19,59 @@ protocol SearchService {
                             keywordIds: [Int],
                             page: Int,
                             size: Int) -> Single<DetailSearchNovels>
+    func getRecentSearches() -> Single<[RecentSearch]>
+    func deleteRecentSearch(id: Int) -> Single<Void>
+    func deleteAllRecentSearches() -> Single<Void>
 }
 
 final class DefaultSearchService: NSObject, Networking { }
 
 extension DefaultSearchService: SearchService {
+    func getRecentSearches() -> Single<[RecentSearch]> {
+        do {
+            let request = try makeHTTPRequest(method: .get,
+                                              path: URLs.Search.recentSearch,
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+            NetworkLogger.log(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
+                .map { try self.decode(data: $0, to: [RecentSearch].self) }
+                .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
+
+    func deleteRecentSearch(id: Int) -> Single<Void> {
+        do {
+            let request = try makeHTTPRequest(method: .delete,
+                                              path: URLs.Search.deleteRecentSearchKeyword(id: id),
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+            NetworkLogger.log(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
+                .map { _ in }
+                .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
+
+    func deleteAllRecentSearches() -> Single<Void> {
+        do {
+            let request = try makeHTTPRequest(method: .delete,
+                                              path: URLs.Search.deleteAllRecentSearchKeywords,
+                                              headers: APIConstants.accessTokenHeader,
+                                              body: nil)
+            NetworkLogger.log(request: request)
+            return tokenCheckURLSession.rx.data(request: request)
+                .map { _ in }
+                .asSingle()
+        } catch {
+            return Single.error(error)
+        }
+    }
+
     func getSosopicks() -> Single<SosoPickNovels> {
         do {
             let request = try makeHTTPRequest(method: .get,

--- a/WSSiOS/Network/Search/SearchService.swift
+++ b/WSSiOS/Network/Search/SearchService.swift
@@ -35,7 +35,7 @@ extension DefaultSearchService: SearchService {
                                               body: nil)
             NetworkLogger.log(request: request)
             return tokenCheckURLSession.rx.data(request: request)
-                .map { try self.decode(data: $0, to: [RecentSearch].self) }
+                .map { try self.decode(data: $0, to: RecentSearches.self).recentSearches }
                 .asSingle()
         } catch {
             return Single.error(error)

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
@@ -11,6 +11,9 @@ extension StringLiterals {
     enum Search {
         static let title = "탐색하기"
         static let searchbar = "작품 제목, 작가를 검색하세요"
+
+        static let recentSearchTitle = "최근 검색어"
+        static let deleteAll = "전체삭제"
         
         static let induceTitle = "뭐 읽을지 고민될 땐?"
         static let induceDescription = "장르, 연재상태, 별점, 키워드로 작품 찾기"

--- a/WSSiOS/Resource/Constants/URLs/URLs.swift
+++ b/WSSiOS/Resource/Constants/URLs/URLs.swift
@@ -191,6 +191,11 @@ enum URLs {
         static let sosoPick = "/soso-picks"
         static let normalSearch = "/novels"
         static let detailSearch = "/novels/filtered"
+        static let recentSearch = "/novels/recent-searches"
+        static func deleteRecentSearchKeyword(id: Int) -> String {
+            return "/novels/recent-searches/\(id)"
+        }
+        static let deleteAllRecentSearchKeywords = "/novels/recent-searches"
     }
     
     enum Keyword {

--- a/WSSiOS/Source/Data/DTO/SearchResult.swift
+++ b/WSSiOS/Source/Data/DTO/SearchResult.swift
@@ -45,10 +45,16 @@ struct SearchNovel: Codable {
     var interestCount: Int
     var novelRating: Float
     var novelRatingCount: Int
-    
+
     enum CodingKeys: String, CodingKey {
         case novelId, novelImage, interestCount, novelRating, novelRatingCount
         case novelTitle = "title"
         case novelAuthor = "author"
     }
+}
+
+/// 최근 검색어 조회 API
+struct RecentSearch: Codable {
+    let id: Int
+    let keyword: String
 }

--- a/WSSiOS/Source/Data/DTO/SearchResult.swift
+++ b/WSSiOS/Source/Data/DTO/SearchResult.swift
@@ -54,6 +54,10 @@ struct SearchNovel: Codable {
 }
 
 /// 최근 검색어 조회 API
+struct RecentSearches: Codable {
+    let recentSearches: [RecentSearch]
+}
+
 struct RecentSearch: Codable {
     let id: Int
     let keyword: String

--- a/WSSiOS/Source/Data/Repository/SearchRepository.swift
+++ b/WSSiOS/Source/Data/Repository/SearchRepository.swift
@@ -18,6 +18,9 @@ protocol SearchRepository {
                                upperNovelRating: Float,
                                keywordIds: [Int],
                                page: Int) -> Observable<DetailSearchNovels>
+    func getRecentSearches() -> Observable<[RecentSearch]>
+    func deleteRecentSearch(id: Int) -> Observable<Void>
+    func deleteAllRecentSearches() -> Observable<Void>
 }
 
 struct DefaultSearchRepository: SearchRepository {
@@ -51,5 +54,17 @@ struct DefaultSearchRepository: SearchRepository {
                                                 keywordIds: keywordIds,
                                                 page: page,
                                                 size: searchSize).asObservable()
+    }
+
+    func getRecentSearches() -> Observable<[RecentSearch]> {
+        return searchService.getRecentSearches().asObservable()
+    }
+
+    func deleteRecentSearch(id: Int) -> Observable<Void> {
+        return searchService.deleteRecentSearch(id: id).asObservable()
+    }
+
+    func deleteAllRecentSearches() -> Observable<Void> {
+        return searchService.deleteAllRecentSearches().asObservable()
     }
 }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
@@ -1,0 +1,84 @@
+//
+//  NormalSearchRecentView.swift
+//  WSSiOS
+//
+//  Created by onesunny2 on 5/6/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NormalSearchRecentView: UIView {
+
+    //MARK: - Components
+
+    private let titleLabel = UILabel()
+    let deleteAllButton = UIButton()
+    let recentTagCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+
+    //MARK: - Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: - UI
+
+    private func setUI() {
+        titleLabel.do {
+            $0.applyWSSFont(.title2, with: StringLiterals.Search.recentSearchTitle)
+            $0.textColor = .wssBlack
+        }
+
+        deleteAllButton.do {
+            $0.setTitle(StringLiterals.Search.deleteAll, for: .normal)
+            $0.setTitleColor(.wssGray200, for: .normal)
+            $0.titleLabel?.font = .Body4
+        }
+
+        recentTagCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            layout.minimumInteritemSpacing = 8
+            layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+
+            $0.collectionViewLayout = layout
+            $0.isScrollEnabled = true
+            $0.showsHorizontalScrollIndicator = false
+            $0.backgroundColor = .clear
+        }
+    }
+
+    private func setHierarchy() {
+        self.addSubviews(titleLabel, deleteAllButton, recentTagCollectionView)
+    }
+
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(8)
+            $0.leading.equalToSuperview().inset(20)
+        }
+
+        deleteAllButton.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+
+        recentTagCollectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(35)
+            $0.bottom.equalToSuperview().inset(12)
+        }
+    }
+}

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
@@ -28,6 +28,7 @@ final class NormalSearchRecentView: UIView {
         setLayout()
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchRecentTagCell.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchRecentTagCell.swift
@@ -34,6 +34,7 @@ final class NormalSearchRecentTagCell: UICollectionViewCell {
         setLayout()
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -66,7 +67,6 @@ final class NormalSearchRecentTagCell: UICollectionViewCell {
 
         deleteButton.do {
             $0.setImage(.icKeywordCancel, for: .normal)
-            $0.isUserInteractionEnabled = true
         }
     }
 

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchRecentTagCell.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchRecentTagCell.swift
@@ -1,0 +1,100 @@
+//
+//  NormalSearchRecentTagCell.swift
+//  WSSiOS
+//
+//  Created by onesunny2 on 5/6/25.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+import Then
+
+final class NormalSearchRecentTagCell: UICollectionViewCell {
+
+    //MARK: - Properties
+
+    var deleteAction: (() -> Void)?
+    private var disposeBag = DisposeBag()
+
+    //MARK: - Components
+
+    private let keywordLabel = UILabel()
+    private let deleteButton = UIButton()
+    private let contentStackView = UIStackView()
+
+    //MARK: - Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        deleteAction = nil
+        disposeBag = DisposeBag()
+    }
+
+    //MARK: - UI
+
+    private func setUI() {
+        self.contentView.do {
+            $0.layer.cornerRadius = 17.5
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.wssPrimary100.cgColor
+            $0.backgroundColor = .wssWhite
+        }
+
+        contentStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 6
+            $0.alignment = .center
+        }
+
+        keywordLabel.do {
+            $0.textColor = .wssPrimary100
+        }
+
+        deleteButton.do {
+            $0.setImage(.icKeywordCancel, for: .normal)
+            $0.isUserInteractionEnabled = true
+        }
+    }
+
+    private func setHierarchy() {
+        contentView.addSubview(contentStackView)
+        contentStackView.addArrangedSubviews(keywordLabel, deleteButton)
+    }
+
+    private func setLayout() {
+        contentStackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(13)
+            $0.centerY.equalToSuperview()
+        }
+
+        deleteButton.snp.makeConstraints {
+            $0.size.equalTo(16)
+        }
+    }
+
+    //MARK: - Data
+
+    func bindData(keyword: String) {
+        keywordLabel.applyWSSFont(.body2, with: keyword)
+
+        deleteButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.deleteAction?()
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchView.swift
@@ -11,33 +11,39 @@ import SnapKit
 import Then
 
 final class NormalSearchView: UIView {
-    
+
     //MARK: - Components
-    
+
     let headerView = NormalSearchHeaderView()
+    private let contentStackView = UIStackView()
+    let recentSearchView = NormalSearchRecentView()
     let sosoPickView = SearchSosoPickView()
     let resultView = NormalSearchResultView()
     let emptyView = NormalSearchEmptyView()
-
     let loadingView = WSSLoadingView()
-    
+
     // MARK: - Life Cycle
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         setUI()
         setHierarchy()
         setLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     //MARK: - UI
-    
+
     private func setUI() {
+        contentStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 32
+        }
+        recentSearchView.isHidden = true
         resultView.isHidden = true
         emptyView.isHidden = true
         loadingView.isHidden = true
@@ -45,20 +51,21 @@ final class NormalSearchView: UIView {
 
     private func setHierarchy() {
         self.addSubviews(headerView,
-                         sosoPickView,
+                         contentStackView,
                          resultView,
                          emptyView,
                          loadingView)
+        contentStackView.addArrangedSubviews(recentSearchView, sosoPickView)
     }
-    
+
     private func setLayout() {
         headerView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).inset(1)
             $0.leading.trailing.equalToSuperview()
         }
 
-        sosoPickView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom).offset(16)
+        contentStackView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
         }
 
@@ -66,20 +73,20 @@ final class NormalSearchView: UIView {
             $0.top.equalTo(headerView.snp.bottom)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
-        
+
         emptyView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
-        
+
         loadingView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
     }
-    
+
     //MARK: - Custom Methods
-    
+
     func showLoadingView(isShow: Bool) {
         loadingView.do {
             $0.isHidden = !isShow

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -14,12 +14,15 @@ import RxGesture
 final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
     
     //MARK: - Properties
-    
+
     private let viewModel: NormalSearchViewModel
     private let disposeBag = DisposeBag()
-    
+    private let viewWillAppearRelay = PublishRelay<Void>()
+    private let deleteRecentSearchRelay = PublishRelay<Int>()
+    private var currentRecentKeywords: [RecentSearch] = []
+
     //MARK: - Components
-    
+
     private let rootView = NormalSearchView()
     private let emptyView = NormalSearchEmptyView()
     
@@ -40,9 +43,10 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         setNavigationBar()
         swipeBackGesture()
+        viewWillAppearRelay.accept(())
     }
     
     override func viewDidLoad() {
@@ -89,10 +93,14 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
         rootView.sosoPickView.sosopickCollectionView.register(
             SosoPickCollectionViewCell.self,
             forCellWithReuseIdentifier: SosoPickCollectionViewCell.cellIdentifier)
+        rootView.recentSearchView.recentTagCollectionView.register(
+            NormalSearchRecentTagCell.self,
+            forCellWithReuseIdentifier: NormalSearchRecentTagCell.cellIdentifier)
     }
-    
+
     private func setDelegate() {
         rootView.headerView.searchTextField.delegate = self
+        rootView.recentSearchView.recentTagCollectionView.delegate = self
     }
     
     private func bindViewModel() {
@@ -118,7 +126,11 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
             normalSearchCellSelected: rootView.resultView.normalSearchCollectionView.rx.itemSelected,
             reachedBottom: reachedBottom,
             normalSearchCollectionViewSwipeGesture: collectionViewSwipeGesture,
-            sosoPickCellSelected: rootView.sosoPickView.sosopickCollectionView.rx.itemSelected)
+            sosoPickCellSelected: rootView.sosoPickView.sosopickCollectionView.rx.itemSelected,
+            viewWillAppear: viewWillAppearRelay.asObservable(),
+            recentSearchTagSelected: rootView.recentSearchView.recentTagCollectionView.rx.itemSelected,
+            recentSearchDeleteAllButtonDidTap: rootView.recentSearchView.deleteAllButton.rx.tap,
+            recentSearchDeleteButtonDidTap: deleteRecentSearchRelay.asObservable())
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         
         output.resultCount
@@ -241,6 +253,34 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
                 owner.presentInduceLoginViewController()
             })
             .disposed(by: disposeBag)
+
+        output.recentSearchList
+            .observe(on: MainScheduler.instance)
+            .do(onNext: { [weak self] list in
+                self?.currentRecentKeywords = list
+            })
+            .bind(to: rootView.recentSearchView.recentTagCollectionView.rx.items(
+                cellIdentifier: NormalSearchRecentTagCell.cellIdentifier,
+                cellType: NormalSearchRecentTagCell.self)) { [weak self] _, recentSearch, cell in
+                    cell.bindData(keyword: recentSearch.keyword)
+                    cell.deleteAction = { self?.deleteRecentSearchRelay.accept(recentSearch.id) }
+                }
+            .disposed(by: disposeBag)
+
+        output.showRecentSearchView
+            .drive(with: self, onNext: { owner, shouldShow in
+                owner.rootView.recentSearchView.isHidden = !shouldShow
+            })
+            .disposed(by: disposeBag)
+
+        output.fillSearchTextField
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, keyword in
+                owner.rootView.headerView.searchTextField.text = keyword
+                owner.rootView.headerView.searchTextField.sendActions(for: .valueChanged)
+                owner.rootView.headerView.searchTextField.sendActions(for: .editingDidEndOnExit)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindAction() {
@@ -266,11 +306,24 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
 }
 
 extension NormalSearchViewController: UITextFieldDelegate {
-    func textField(_ textField: UITextField, 
+    func textField(_ textField: UITextField,
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool {
         let currentText = textField.text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
         return newText.count <= 30
+    }
+}
+
+extension NormalSearchViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard collectionView == rootView.recentSearchView.recentTagCollectionView,
+              indexPath.row < currentRecentKeywords.count else { return .zero }
+        let keyword = currentRecentKeywords[indexPath.row].keyword
+        let textWidth = (keyword as NSString).size(withAttributes: [.font: UIFont.Body2]).width
+        let width = ceil(textWidth) + 13 * 2 + 6 + 16
+        return CGSize(width: min(width, UIScreen.main.bounds.width - 40), height: 35)
     }
 }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -38,9 +38,12 @@ final class NormalSearchViewModel: ViewModelType {
     // 소소픽
     private let sosoPickList = BehaviorRelay<[SosoPickNovel]>(value: [])
     private let presentToInduceLoginView = PublishRelay<Void>()
+
+    // 최근 검색어
+    private let recentSearchList = BehaviorRelay<[RecentSearch]>(value: [])
     
     //MARK: - Inputs
-    
+
     struct Input {
         let searchTextUpdated: ControlProperty<String>
         let searchTextFieldEditingDidBegin: ControlEvent<Void>
@@ -55,10 +58,14 @@ final class NormalSearchViewModel: ViewModelType {
         let reachedBottom: Observable<Bool>
         let normalSearchCollectionViewSwipeGesture: Observable<UISwipeGestureRecognizer>
         let sosoPickCellSelected: ControlEvent<IndexPath>
+        let viewWillAppear: Observable<Void>
+        let recentSearchTagSelected: ControlEvent<IndexPath>
+        let recentSearchDeleteAllButtonDidTap: ControlEvent<Void>
+        let recentSearchDeleteButtonDidTap: Observable<Int>
     }
-    
+
     //MARK: - Outputs
-    
+
     struct Output {
         let resultCount: Observable<Int>
         let normalSearchList: Observable<[SearchNovel]>
@@ -74,6 +81,9 @@ final class NormalSearchViewModel: ViewModelType {
         let showLoadingView: Observable<Bool>
         let sosoPickList: Observable<[SosoPickNovel]>
         let presentToInduceLoginView: Observable<Void>
+        let recentSearchList: Observable<[RecentSearch]>
+        let showRecentSearchView: Driver<Bool>
+        let fillSearchTextField: Observable<String>
     }
     
     //MARK: - init
@@ -221,6 +231,48 @@ final class NormalSearchViewModel: ViewModelType {
         let endEditing = input.normalSearchCollectionViewSwipeGesture
             .map { _ in () }
         
+        // 최근 검색어 로직
+        input.viewWillAppear
+            .filter { self.isLogined }
+            .flatMapLatest { _ in
+                self.searchRepository.getRecentSearches()
+                    .catchAndReturn([])
+            }
+            .subscribe(with: self, onNext: { owner, data in
+                owner.recentSearchList.accept(data)
+            })
+            .disposed(by: disposeBag)
+
+        input.recentSearchDeleteButtonDidTap
+            .do(onNext: { id in
+                var list = self.recentSearchList.value
+                list.removeAll { $0.id == id }
+                self.recentSearchList.accept(list)
+            })
+            .flatMapLatest { id in
+                self.searchRepository.deleteRecentSearch(id: id)
+                    .catchAndReturn(())
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        input.recentSearchDeleteAllButtonDidTap
+            .do(onNext: { self.recentSearchList.accept([]) })
+            .flatMapLatest { self.searchRepository.deleteAllRecentSearches().catchAndReturn(()) }
+            .subscribe()
+            .disposed(by: disposeBag)
+
+        let fillSearchTextField = input.recentSearchTagSelected
+            .withLatestFrom(recentSearchList) { indexPath, list in list[indexPath.row].keyword }
+
+        let showRecentSearchView = Observable.combineLatest(
+            recentSearchList.map { !$0.isEmpty },
+            input.searchTextUpdated.map { $0.isEmpty },
+            normalSearchList.map { $0.isEmpty }
+        )
+        .map { $0 && $1 && $2 }
+        .asDriver(onErrorJustReturn: false)
+
         return Output(resultCount: resultCount.asObservable(),
                       normalSearchList: normalSearchList.asObservable(),
                       scrollToTop: returnKeyEnabled.asObservable(),
@@ -234,6 +286,9 @@ final class NormalSearchViewModel: ViewModelType {
                       endEditing: endEditing,
                       showLoadingView: showLoadingView.asObservable(),
                       sosoPickList: sosoPickList.asObservable(),
-                      presentToInduceLoginView: presentToInduceLoginView.asObservable())
+                      presentToInduceLoginView: presentToInduceLoginView.asObservable(),
+                      recentSearchList: recentSearchList.asObservable(),
+                      showRecentSearchView: showRecentSearchView,
+                      fillSearchTextField: fillSearchTextField.asObservable())
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #703 
<br/>

### 🌟Motivation
최근 검색어 기능을 추가했습니다. 
<br/>

### 🌟Key Changes
  - /novels/recent-searches API 연동 (조회 / 단일 삭제 / 전체 삭제)                                                                                    
  - NormalSearchRecentView, NormalSearchRecentTagCell 신규 구현                                                                                        
  - 검색창이 비어있고 검색 결과가 없을 때만 최근 검색어 영역 노출
  - 최근 검색어 태그 탭 시 해당 키워드로 즉시 검색 실행                                                                                                
  - 단일 삭제 시 Optimistic UI 업데이트 (API 응답 전 목록에서 즉시 제거)
  - 향후 섹션 추가를 고려해 contentStackView(UIStackView, spacing: 32) 기반으로 레이아웃 구조화  
  
```swift
  // 최근 검색어 표시 조건 (3가지 모두 충족 시)
  let showRecentSearchView = Observable.combineLatest(                                                                                                 
      recentSearchList.map { !$0.isEmpty },        // 최근 검색어 존재                                                                                         
      normalSearchList.map { $0.isEmpty }          // 검색 결과 없음                                                                                   
  )               
  .map { $0 && $1 }                                                                                                                              
  .asDriver(onErrorJustReturn: false)    
```
<br/>


### 🌟Simulation
| 검색어 20개까지 노출되는 것 확인 | 최근 검색어 단일/전체 삭제  |
| -- | -- |
| <img width="200" src="https://github.com/user-attachments/assets/26b1fb99-c396-404a-89d6-ba9f1b59122b" /> | <img width="200" src="https://github.com/user-attachments/assets/8bbbedf8-762e-4913-af05-4661271f2124" />) |
<br/>
