### PR TITLE
[Fea] #705 - 일반검색 개선: 장르탐색 기능 추가

### DIFF
--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
@@ -14,6 +14,7 @@ extension StringLiterals {
 
         static let recentSearchTitle = "최근 검색어"
         static let deleteAll = "전체삭제"
+        static let genreSearchTitle = "장르별 검색"
         
         static let induceTitle = "뭐 읽을지 고민될 땐?"
         static let induceDescription = "장르, 연재상태, 별점, 키워드로 작품 찾기"

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Search.swift
@@ -57,5 +57,6 @@ extension StringLiterals {
         static let empty = "해당하는 작품이 없어요\n검색의 범위를 더 넓혀보세요"
         
         static let applyOption = "장르, 연재상태, 별점, 키워드 적용"
+        static let applyGenre = "장르 적용"
     }
 }

--- a/WSSiOS/Resource/Extensions/UIViewController+.swift
+++ b/WSSiOS/Resource/Extensions/UIViewController+.swift
@@ -324,20 +324,6 @@ extension UIViewController {
                                                       animated: true)
     }
     
-    func pushToDetailSearchResultViewController(option: SearchFilterQuery) {
-        let detailSearchResultViewController = DetailSearchResultViewController(
-            viewModel: DetailSearchResultViewModel(
-                searchRepository: DefaultSearchRepository(
-                    searchService: DefaultSearchService()),
-                option: option
-            )
-        )
-        detailSearchResultViewController.navigationController?.isNavigationBarHidden = true
-        detailSearchResultViewController.hidesBottomBarWhenPushed = true
-        self.navigationController?.pushViewController(detailSearchResultViewController,
-                                                      animated: true)
-    }
-    
     func presentInduceLoginViewController() {
         let viewController = InduceLoginViewController()
         viewController.modalPresentationStyle = .overFullScreen

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -216,5 +216,5 @@ extension NovelGenre {
     static let feedFilterGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl, .etc]
     static let detailSearchGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl]
     static let myPageEditGenres: [NovelGenre] = [.romance, .romanceFantasy, .fantasy, .modernFantasy, .wuxia, .bl, .lightNovel, .mystery, .drama]
-    static let normalSearchGenres: [NovelGenre] = [.modernFantasy, .romanceFantasy, .romance, .fantasy, .wuxia, .bl, .lightNovel, .drama, .mystery]
+    static let normalSearchGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romanceFantasy, .romance, .wuxia, .bl, .lightNovel, .drama, .mystery]
 }

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -216,5 +216,5 @@ extension NovelGenre {
     static let feedFilterGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl, .etc]
     static let detailSearchGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl]
     static let myPageEditGenres: [NovelGenre] = [.romance, .romanceFantasy, .fantasy, .modernFantasy, .wuxia, .bl, .lightNovel, .mystery, .drama]
-    static let normalSearchGenres: [NovelGenre] = [.modernFantasy, .romanceFantasy, .fantasy, .romance, .wuxia, .bl, .drama, .mystery, .lightNovel]
+    static let normalSearchGenres: [NovelGenre] = [.modernFantasy, .romanceFantasy, .romance, .fantasy, .wuxia, .bl, .lightNovel, .drama, .mystery]
 }

--- a/WSSiOS/Source/Data/Base/NovelGenre.swift
+++ b/WSSiOS/Source/Data/Base/NovelGenre.swift
@@ -216,4 +216,5 @@ extension NovelGenre {
     static let feedFilterGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl, .etc]
     static let detailSearchGenres: [NovelGenre] = [.fantasy, .modernFantasy, .romance, .romanceFantasy, .wuxia, .mystery, .drama, .lightNovel, .bl]
     static let myPageEditGenres: [NovelGenre] = [.romance, .romanceFantasy, .fantasy, .modernFantasy, .wuxia, .bl, .lightNovel, .mystery, .drama]
+    static let normalSearchGenres: [NovelGenre] = [.modernFantasy, .romanceFantasy, .fantasy, .romance, .wuxia, .bl, .drama, .mystery, .lightNovel]
 }

--- a/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchAssistantView/DetailSearchResultHeaderView.swift
+++ b/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchView/DetailSearchAssistantView/DetailSearchResultHeaderView.swift
@@ -102,4 +102,8 @@ final class DetailSearchResultHeaderView: UIView {
             }
         }
     }
+
+    func bindPlaceholder(_ text: String) {
+        headerLabel.applyWSSFont(.body4, with: text)
+    }
 }

--- a/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchResultViewController.swift
+++ b/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchResultViewController.swift
@@ -58,7 +58,13 @@ final class DetailSearchResultViewController: UIViewController, UIScrollViewDele
         bindViewModel()
         bindAction()
 
-        rootView.headerView.updateHeaderLabel(with: viewModel.option)
+        switch viewModel.entryType {
+        case .fullOption:
+            rootView.headerView.updateHeaderLabel(with: viewModel.option)
+        case .genreOnly:
+            rootView.headerView.bindPlaceholder(viewModel.entryType.placeholder)
+        }
+
         viewDidLoadEvent.accept(())
     }
 

--- a/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchViewController.swift
+++ b/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewController/DetailSearchViewController.swift
@@ -157,7 +157,14 @@ final class DetailSearchViewController: UIViewController, UIScrollViewDelegate {
         
         output.pushToResultViewController
             .subscribe(with: self, onNext: { owner, filterQuery in
-                owner.pushToDetailSearchResultViewController(option: filterQuery)
+                let viewModel = DetailSearchResultViewModel(
+                    searchRepository: DefaultSearchRepository(searchService: DefaultSearchService()),
+                    option: filterQuery,
+                    entryType: .fullOption
+                )
+                let viewController = DetailSearchResultViewController(viewModel: viewModel)
+                viewController.hidesBottomBarWhenPushed = true
+                owner.navigationController?.pushViewController(viewController, animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewModel/DetailSearchResultViewModel.swift
+++ b/WSSiOS/Source/Presentation/Search/DetailSearch/DetailSearchViewModel/DetailSearchResultViewModel.swift
@@ -11,14 +11,15 @@ import RxSwift
 import RxCocoa
 
 final class DetailSearchResultViewModel: ViewModelType {
-    
+
     //MARK: - Properties
-    
+
     private let searchRepository: SearchRepository
-    
-    // 검색 필터 옵션 
+
+    // 검색 필터 옵션
     var option: SearchFilterQuery
-    
+    let entryType: EntryType
+
     // 무한 스크롤
     private var currentPage: Int = 0
     private var isLoadable: Bool = false
@@ -54,9 +55,11 @@ final class DetailSearchResultViewModel: ViewModelType {
     }
     
     init(searchRepository: SearchRepository,
-         option: SearchFilterQuery) {
+         option: SearchFilterQuery,
+         entryType: EntryType) {
         self.searchRepository = searchRepository
         self.option = option
+        self.entryType = entryType
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -169,5 +172,19 @@ final class DetailSearchResultViewModel: ViewModelType {
                                                upperNovelRating: upperNovelRating,
                                                keywordIds: keywordIds,
                                                page: page)
+    }
+}
+
+extension DetailSearchResultViewModel {
+    enum EntryType {
+        case fullOption
+        case genreOnly
+
+        var placeholder: String {
+            switch self {
+            case .fullOption: return StringLiterals.DetailSearch.applyOption
+            case .genreOnly: return StringLiterals.DetailSearch.applyGenre
+            }
+        }
     }
 }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchGenreView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchGenreView.swift
@@ -1,0 +1,91 @@
+//
+//  NormalSearchGenreView.swift
+//  WSSiOS
+//
+//  Created by onesunny2 on 5/8/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NormalSearchGenreView: UIView {
+
+    //MARK: - Components
+
+    private let titleLabel = UILabel()
+    private let chevronImageView = UIImageView()
+    let headerButton = UIButton()
+    let genreCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+
+    //MARK: - Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: - UI
+
+    private func setUI() {
+        titleLabel.do {
+            $0.applyWSSFont(.title2, with: StringLiterals.Search.genreSearchTitle)
+            $0.textColor = .wssBlack
+        }
+
+        chevronImageView.do {
+            $0.image = .icChevronRightMini
+            $0.contentMode = .scaleAspectFit
+        }
+
+        genreCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            layout.minimumInteritemSpacing = 12
+            layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+
+            $0.collectionViewLayout = layout
+            $0.isScrollEnabled = true
+            $0.showsHorizontalScrollIndicator = false
+            $0.backgroundColor = .clear
+        }
+    }
+
+    private func setHierarchy() {
+        self.addSubviews(titleLabel, chevronImageView, headerButton, genreCollectionView)
+    }
+
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(8)
+            $0.leading.equalToSuperview().inset(20)
+        }
+
+        chevronImageView.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(3)
+            $0.size.equalTo(16)
+        }
+
+        headerButton.snp.makeConstraints {
+            $0.top.leading.bottom.equalTo(titleLabel)
+            $0.trailing.equalTo(chevronImageView)
+        }
+
+        genreCollectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(69)
+            $0.bottom.equalToSuperview().inset(12)
+        }
+    }
+}

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchGenreView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchGenreView.swift
@@ -66,7 +66,7 @@ final class NormalSearchGenreView: UIView {
 
     private func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(8)
+            $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
         }
 
@@ -85,7 +85,7 @@ final class NormalSearchGenreView: UIView {
             $0.top.equalTo(titleLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(69)
-            $0.bottom.equalToSuperview().inset(12)
+            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalAssistantView/NormalSearchRecentView.swift
@@ -66,7 +66,7 @@ final class NormalSearchRecentView: UIView {
 
     private func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(8)
+            $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
         }
 
@@ -79,7 +79,7 @@ final class NormalSearchRecentView: UIView {
             $0.top.equalTo(titleLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(35)
-            $0.bottom.equalToSuperview().inset(12)
+            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchGenreCell.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchCell/NormalSearchGenreCell.swift
@@ -1,0 +1,76 @@
+//
+//  NormalSearchGenreCell.swift
+//  WSSiOS
+//
+//  Created by onesunny2 on 5/8/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NormalSearchGenreCell: UICollectionViewCell {
+
+    //MARK: - Components
+
+    private let circleImageView = UIImageView()
+    private let genreIconImageView = UIImageView()
+    private let genreLabel = UILabel()
+
+    //MARK: - Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: - UI
+
+    private func setUI() {
+        circleImageView.do {
+            $0.image = .icGenreBackground
+        }
+
+        genreLabel.do {
+            $0.textColor = .wssGray300
+            $0.textAlignment = .center
+        }
+    }
+
+    private func setHierarchy() {
+        contentView.addSubviews(circleImageView, genreIconImageView, genreLabel)
+    }
+
+    private func setLayout() {
+        circleImageView.snp.makeConstraints {
+            $0.top.centerX.equalToSuperview()
+            $0.size.equalTo(44)
+        }
+
+        genreIconImageView.snp.makeConstraints {
+            $0.center.equalTo(circleImageView)
+            $0.size.equalTo(32)
+        }
+
+        genreLabel.snp.makeConstraints {
+            $0.top.equalTo(circleImageView.snp.bottom).offset(4)
+            $0.centerX.equalToSuperview()
+        }
+    }
+
+    //MARK: - Data
+
+    func bindData(genre: NovelGenre) {
+        genreIconImageView.image = genre.image
+        genreLabel.applyWSSFont(.body3, with: genre.withKorean)
+    }
+}

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchView.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchView/NormalSearchView.swift
@@ -17,6 +17,7 @@ final class NormalSearchView: UIView {
     let headerView = NormalSearchHeaderView()
     private let contentStackView = UIStackView()
     let recentSearchView = NormalSearchRecentView()
+    let genreView = NormalSearchGenreView()
     let sosoPickView = SearchSosoPickView()
     let resultView = NormalSearchResultView()
     let emptyView = NormalSearchEmptyView()
@@ -44,6 +45,7 @@ final class NormalSearchView: UIView {
             $0.spacing = 32
         }
         recentSearchView.isHidden = true
+        genreView.isHidden = true
         resultView.isHidden = true
         emptyView.isHidden = true
         loadingView.isHidden = true
@@ -55,7 +57,7 @@ final class NormalSearchView: UIView {
                          resultView,
                          emptyView,
                          loadingView)
-        contentStackView.addArrangedSubviews(recentSearchView, sosoPickView)
+        contentStackView.addArrangedSubviews(recentSearchView, genreView, sosoPickView)
     }
 
     private func setLayout() {

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -96,11 +96,15 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
         rootView.recentSearchView.recentTagCollectionView.register(
             NormalSearchRecentTagCell.self,
             forCellWithReuseIdentifier: NormalSearchRecentTagCell.cellIdentifier)
+        rootView.genreView.genreCollectionView.register(
+            NormalSearchGenreCell.self,
+            forCellWithReuseIdentifier: NormalSearchGenreCell.cellIdentifier)
     }
 
     private func setDelegate() {
         rootView.headerView.searchTextField.delegate = self
         rootView.recentSearchView.recentTagCollectionView.delegate = self
+        rootView.genreView.genreCollectionView.delegate = self
     }
     
     private func bindViewModel() {
@@ -130,7 +134,9 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
             viewWillAppear: viewWillAppearRelay.asObservable(),
             recentSearchTagSelected: rootView.recentSearchView.recentTagCollectionView.rx.itemSelected,
             recentSearchDeleteAllButtonDidTap: rootView.recentSearchView.deleteAllButton.rx.tap,
-            recentSearchDeleteButtonDidTap: deleteRecentSearchRelay.asObservable())
+            recentSearchDeleteButtonDidTap: deleteRecentSearchRelay.asObservable(),
+            genreSelected: rootView.genreView.genreCollectionView.rx.itemSelected,
+            genreHeaderDidTap: rootView.genreView.headerButton.rx.tap)
         let output = viewModel.transform(from: input, disposeBag: disposeBag)
         
         output.resultCount
@@ -281,6 +287,48 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
                 owner.rootView.headerView.searchTextField.sendActions(for: .editingDidEndOnExit)
             })
             .disposed(by: disposeBag)
+
+        Observable.just(NovelGenre.normalSearchGenres)
+            .observe(on: MainScheduler.instance)
+            .bind(to: rootView.genreView.genreCollectionView.rx.items(
+                cellIdentifier: NormalSearchGenreCell.cellIdentifier,
+                cellType: NormalSearchGenreCell.self)) { _, genre, cell in
+                    cell.bindData(genre: genre)
+                }
+            .disposed(by: disposeBag)
+
+        output.pushToGenreSearchResult
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, genre in
+                let filterQuery = SearchFilterQuery(
+                    keywords: [],
+                    genres: [genre],
+                    isCompleted: nil,
+                    lowerNovelRating: 0.0,
+                    upperNovelRating: 5.0
+                )
+                let viewModel = DetailSearchResultViewModel(
+                    searchRepository: DefaultSearchRepository(searchService: DefaultSearchService()),
+                    option: filterQuery
+                )
+                let viewController = DetailSearchResultViewController(viewModel: viewModel)
+                viewController.hidesBottomBarWhenPushed = true
+                owner.navigationController?.pushViewController(viewController, animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        output.pushToDetailSearch
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.pushToDetailSearchViewController()
+            })
+            .disposed(by: disposeBag)
+
+        output.showGenreView
+            .drive(with: self, onNext: { owner, shouldShow in
+                owner.rootView.genreView.isHidden = !shouldShow
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindAction() {
@@ -319,6 +367,9 @@ extension NormalSearchViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if collectionView == rootView.genreView.genreCollectionView {
+            return CGSize(width: 44, height: 69)
+        }
         guard collectionView == rootView.recentSearchView.recentTagCollectionView,
               indexPath.row < currentRecentKeywords.count else { return .zero }
         let keyword = currentRecentKeywords[indexPath.row].keyword

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewController/NormalSearchViewController.swift
@@ -309,7 +309,8 @@ final class NormalSearchViewController: UIViewController, UIScrollViewDelegate {
                 )
                 let viewModel = DetailSearchResultViewModel(
                     searchRepository: DefaultSearchRepository(searchService: DefaultSearchService()),
-                    option: filterQuery
+                    option: filterQuery,
+                    entryType: .genreOnly
                 )
                 let viewController = DetailSearchResultViewController(viewModel: viewModel)
                 viewController.hidesBottomBarWhenPushed = true

--- a/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
+++ b/WSSiOS/Source/Presentation/Search/NormalSearch/NormalSearchViewModel/NormalSearchViewModel.swift
@@ -62,6 +62,8 @@ final class NormalSearchViewModel: ViewModelType {
         let recentSearchTagSelected: ControlEvent<IndexPath>
         let recentSearchDeleteAllButtonDidTap: ControlEvent<Void>
         let recentSearchDeleteButtonDidTap: Observable<Int>
+        let genreSelected: ControlEvent<IndexPath>
+        let genreHeaderDidTap: ControlEvent<Void>
     }
 
     //MARK: - Outputs
@@ -84,6 +86,9 @@ final class NormalSearchViewModel: ViewModelType {
         let recentSearchList: Observable<[RecentSearch]>
         let showRecentSearchView: Driver<Bool>
         let fillSearchTextField: Observable<String>
+        let pushToGenreSearchResult: Observable<NovelGenre>
+        let pushToDetailSearch: Observable<Void>
+        let showGenreView: Driver<Bool>
     }
     
     //MARK: - init
@@ -267,11 +272,19 @@ final class NormalSearchViewModel: ViewModelType {
 
         let showRecentSearchView = Observable.combineLatest(
             recentSearchList.map { !$0.isEmpty },
-            input.searchTextUpdated.map { $0.isEmpty },
             normalSearchList.map { $0.isEmpty }
         )
-        .map { $0 && $1 && $2 }
+        .map { $0 && $1 }
         .asDriver(onErrorJustReturn: false)
+
+        let pushToGenreSearchResult = input.genreSelected
+            .map { NovelGenre.normalSearchGenres[$0.row] }
+
+        let pushToDetailSearch = input.genreHeaderDidTap.asObservable()
+
+        let showGenreView = normalSearchList
+            .map { $0.isEmpty }
+            .asDriver(onErrorJustReturn: true)
 
         return Output(resultCount: resultCount.asObservable(),
                       normalSearchList: normalSearchList.asObservable(),
@@ -289,6 +302,9 @@ final class NormalSearchViewModel: ViewModelType {
                       presentToInduceLoginView: presentToInduceLoginView.asObservable(),
                       recentSearchList: recentSearchList.asObservable(),
                       showRecentSearchView: showRecentSearchView,
-                      fillSearchTextField: fillSearchTextField.asObservable())
+                      fillSearchTextField: fillSearchTextField.asObservable(),
+                      pushToGenreSearchResult: pushToGenreSearchResult.asObservable(),
+                      pushToDetailSearch: pushToDetailSearch,
+                      showGenreView: showGenreView)
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue
- close #705 
<br/>

  ### 🌟Motivation                            
  NormalSearch 화면의 검색창이 비어있을 때 장르별 검색 섹션을 추가하여 사용자가 원하는 장르의 작품을 빠르게 탐색할 수 있도록 개선합니다.               
  <br/>                                       
                                                                                                                                                       
  ### 🌟Key Changes    
  - `NormalSearchGenreView`: "장르별 검색" 헤더(chevron 탭 시 상세탐색 이동) + 가로 스크롤 장르 뱃지 컬렉션뷰                                          
  - `NormalSearchGenreCell`: 44×44 원형 배경 + 장르 아이콘 + 장르명 라벨로 구성된 셀
  - `NormalSearchViewModel`: 장르 탭/헤더 탭 Input, 결과화면 push/상세탐색 push/섹션 노출 Output 추가                                                  
  - `NormalSearchViewController`: 장르 탭 시 해당 장르만 선택된 `DetailSearchResultViewController`로 이동
  - `NovelGenre`: `normalSearchGenres` 배열 추가 (현판, 로판, 판타지, 로맨스, 무협, BL, 드라마, 미스터리, 라노벨)                                      
  - 검색 결과가 있을 때는 장르 섹션 자동 숨김 (`normalSearchList.isEmpty` 기반)                                                                        
                                                                                                                                                       
  ```swift                                                                                                                                             
  // 장르 탭 → 해당 장르로 필터링된 검색 결과 화면으로 이동 (상세 탐색의 기능과 동일)                                                                                            
  let filterQuery = SearchFilterQuery(                                                                                                                 
      keywords: [],                                                                                                                                    
      genres: [genre],                                                                                                                                 
      isCompleted: nil,                                                                                                                                
      lowerNovelRating: 0.0,
      upperNovelRating: 5.0                                                                                                                            
  )                                       
  ```                                                                                                                                                  
  <br/>                                                                                                                                                
                                          
  ### 🌟Simulation                                                                                                                                     
               
<img width="296" height="640" alt="Simulator Screen Recording - iPhone 16 Plus - 2026-05-08 at 00 35 02" src="https://github.com/user-attachments/assets/bf729cd6-29fc-4fc4-b01a-41ef9c944614" />
                                                                                                                                        
  <br/>
                                                                                                                                                       
  ### 🌟To Reviewer
  - 장르 순서는 피그마에 정해진건지 문의해둔 상태라 변경될 가능성 있음
  <br/>    