### PR TITLE
[Design] #717 - 서재 헤더 및 정렬 바텀시트 UI 리디자인

### DIFF
--- a/WSSiOS/Source/Presentation/Base/WSSFilterButton.swift
+++ b/WSSiOS/Source/Presentation/Base/WSSFilterButton.swift
@@ -14,7 +14,7 @@ final class WSSFilterButton: UIButton {
     
     //MARK: - Properties
     
-    private let buttonHeight: CGFloat = 33
+    let buttonHeight: CGFloat
     
     //MARK: - Components
     
@@ -23,8 +23,10 @@ final class WSSFilterButton: UIButton {
     
     // MARK: - Life Cycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(buttonHeight: CGFloat = 30) {
+        
+        self.buttonHeight = buttonHeight
+        super.init(frame: .zero)
         
         setUI()
         setHierarchy()

--- a/WSSiOS/Source/Presentation/Base/WSSSortButton.swift
+++ b/WSSiOS/Source/Presentation/Base/WSSSortButton.swift
@@ -54,26 +54,26 @@ final class WSSSortButton: UIButton {
     
     private func setLayout() {
         self.snp.makeConstraints {
-            $0.height.equalTo(33)
+            $0.height.equalTo(31)
         }
         
         sortButtonImageView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().offset(9.5)
             $0.size.equalTo(16)
         }
         
         sortButtonLabel.snp.makeConstraints {
             $0.leading.equalTo(sortButtonImageView.snp.trailing).offset(4)
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-9.5)
         }
     }
     
     //MARK: - Custom Method
     
     func updateSortButton(sortType: LibrarySortType) {
-        sortButtonLabel.applyWSSFont(.body3, with: sortType.text)
+        sortButtonLabel.applyWSSFont(.body4, with: sortType.text)
     }
 }
 

--- a/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/MyFeedFilterHeaderView.swift
+++ b/WSSiOS/Source/Presentation/Feed/Feed/FeedView/FeedAssistantView/MyFeedFilterHeaderView.swift
@@ -14,7 +14,7 @@ final class MyFeedFilterHeaderView: UIView {
     
     //MARK: - Components
     
-    let filterButton = WSSFilterButton()
+    let filterButton = WSSFilterButton(buttonHeight: 33)
     
     let sortButton = UIButton()
     let sortButtonLabel = UILabel()

--- a/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/LibrarySortBottomSheetView.swift
+++ b/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/LibrarySortBottomSheetView.swift
@@ -11,38 +11,37 @@ import SnapKit
 import Then
 
 final class LibrarySortBottomSheetView: UIView {
-
+    
     //MARK: - Components
-
+    
     let backgroundButton = UIButton()
     private let sheetView = UIView()
-    private let titleLabel = UILabel()
     private let rowsStackView = UIStackView()
     let sortRowButtons: [LibrarySortRowButton]
-
+    
     //MARK: - Life Cycle
-
+    
     init(currentSort: LibrarySortType) {
         self.sortRowButtons = LibrarySortType.allCases.map { LibrarySortRowButton($0) }
-
+        
         super.init(frame: .zero)
-
+        
         setUI()
         setHierarchy()
         setLayout()
         updateSelection(currentSort)
     }
-
+    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     //MARK: - UI
-
+    
     private func setUI() {
         self.backgroundColor = .clear
-
+        
         sheetView.do {
             $0.backgroundColor = .wssWhite
             $0.layer.cornerRadius = 16
@@ -50,51 +49,41 @@ final class LibrarySortBottomSheetView: UIView {
                                       .layerMaxXMinYCorner]
         }
 
-        titleLabel.do {
-            $0.applyWSSFont(.title2, with: StringLiterals.MyLibrary.Sort.title)
-            $0.textColor = .wssBlack
-        }
-
         rowsStackView.do {
             $0.axis = .vertical
+            $0.spacing = 10
             $0.alignment = .fill
             $0.distribution = .fill
         }
     }
-
+    
     private func setHierarchy() {
         self.addSubviews(backgroundButton,
                          sheetView)
-        sheetView.addSubviews(titleLabel,
-                              rowsStackView)
+        sheetView.addSubview(rowsStackView)
         sortRowButtons.forEach {
             rowsStackView.addArrangedSubview($0)
         }
     }
-
+    
     private func setLayout() {
         backgroundButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
+        
         sheetView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
         }
 
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24)
-            $0.leading.equalToSuperview().inset(20)
-        }
-
         rowsStackView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
-            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalToSuperview().inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(8)
         }
     }
-
+    
     //MARK: - Custom Method
-
+    
     func updateSelection(_ sort: LibrarySortType) {
         sortRowButtons.forEach {
             $0.setSelected($0.sortType == sort)
@@ -105,65 +94,78 @@ final class LibrarySortBottomSheetView: UIView {
 //MARK: - Row Button
 
 final class LibrarySortRowButton: UIButton {
-
+    
     let sortType: LibrarySortType
-
+    
+    private let selectedBackgroundView = UIView()
     private let sortTitleLabel = UILabel()
     private let checkImageView = UIImageView()
-
+    
     init(_ sortType: LibrarySortType) {
         self.sortType = sortType
-
+        
         super.init(frame: .zero)
-
+        
         setUI()
         setHierarchy()
         setLayout()
     }
-
+    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     private func setUI() {
+        selectedBackgroundView.do {
+            $0.backgroundColor = .wssPrimary20
+            $0.layer.cornerRadius = 12
+            $0.clipsToBounds = true
+            $0.isHidden = true
+        }
+        
         sortTitleLabel.do {
             $0.applyWSSFont(.body2, with: sortType.text)
-            $0.textColor = .wssGray300
+            $0.textColor = .wssGray200
             $0.isUserInteractionEnabled = false
         }
-
+        
         checkImageView.do {
             $0.image = .icCheck
             $0.isHidden = true
             $0.isUserInteractionEnabled = false
         }
     }
-
+    
     private func setHierarchy() {
-        self.addSubviews(sortTitleLabel,
+        self.addSubviews(selectedBackgroundView,
+                         sortTitleLabel,
                          checkImageView)
     }
-
+    
     private func setLayout() {
         self.snp.makeConstraints {
-            $0.height.equalTo(52)
+            $0.height.equalTo(37)
         }
-
+        
+        selectedBackgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
         sortTitleLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(20)
+            $0.center.equalToSuperview()
         }
-
+        
         checkImageView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(20)
-            $0.size.equalTo(20)
+            $0.trailing.equalTo(sortTitleLabel.snp.leading).offset(-10)
+            $0.size.equalTo(22)
         }
     }
-
+    
     func setSelected(_ isSelected: Bool) {
-        sortTitleLabel.textColor = isSelected ? .wssBlack : .wssGray300
+        selectedBackgroundView.isHidden = !isSelected
+        sortTitleLabel.textColor = isSelected ? .wssBlack : .wssGray200
         checkImageView.isHidden = !isSelected
     }
 }

--- a/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
+++ b/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryFilterHeaderView.swift
@@ -110,7 +110,7 @@ final class MyLibraryFilterHeaderView: UIView {
 
     private func setLayout() {
         self.snp.makeConstraints {
-            $0.height.equalTo(57)
+            $0.height.equalTo(50)
         }
 
         scrollView.snp.makeConstraints {
@@ -123,13 +123,13 @@ final class MyLibraryFilterHeaderView: UIView {
         }
 
         stackView.do {
-            $0.spacing = 6
+            $0.spacing = 3
             $0.setCustomSpacing(10, after: interestFilterButton)
             $0.setCustomSpacing(10, after: dividerView)
         }
 
         dividerView.snp.makeConstraints {
-            $0.height.equalTo(33)
+            $0.height.equalTo(30)
             $0.width.equalTo(1)
         }
     }

--- a/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryHeaderView.swift
+++ b/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryHeaderView.swift
@@ -18,10 +18,10 @@ final class MyLibraryHeaderView: UIView {
     private let bottomContentView = UIView()
     private let countLabel = UILabel()
     let sortButton = WSSSortButton()
+    private let buttonDividerView = UIView()
     let layoutToggleButton = UIButton()
-    let layoutToggleButtonImageView = UIImageView()
     private let dividerView = UIView()
-    
+   
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -50,17 +50,15 @@ final class MyLibraryHeaderView: UIView {
         }
         
         layoutToggleButton.do {
-            $0.configuration = .plain()
-            $0.configuration?.background.backgroundColor = .white
+            $0.setImage(.layoutGrid.withTintColor(.wssGray100), for: .normal)
         }
-        
-        layoutToggleButtonImageView.do {
-            $0.image = .layoutGrid.withTintColor(.wssGray100)
-            $0.isUserInteractionEnabled = false
-        }
-        
+
         dividerView.do {
             $0.backgroundColor = .wssGray50
+        }
+        
+        buttonDividerView.do {
+            $0.backgroundColor = .wssGray80
         }
     }
     
@@ -69,9 +67,9 @@ final class MyLibraryHeaderView: UIView {
                          bottomContentView)
         bottomContentView.addSubviews(countLabel,
                                       sortButton,
+                                      buttonDividerView,
                                       layoutToggleButton,
                                       dividerView)
-        layoutToggleButton.addSubview(layoutToggleButtonImageView)
     }
     
     private func setLayout() {
@@ -93,21 +91,25 @@ final class MyLibraryHeaderView: UIView {
         
         sortButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
+            $0.trailing.equalTo(buttonDividerView.snp.leading).offset(-5)
+        }
+        
+        buttonDividerView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
             $0.trailing.equalTo(layoutToggleButton.snp.leading).offset(-10)
+            $0.width.equalTo(1)
+            $0.height.equalTo(10)
         }
         
         layoutToggleButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(20)
-            $0.size.equalTo(33)
+
+            layoutToggleButton.imageView?.snp.makeConstraints {
+                $0.size.equalTo(18)
+            }
         }
-        
-        layoutToggleButtonImageView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview()
-            $0.size.equalTo(12)
-        }
-        
+
         dividerView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(1)
@@ -115,7 +117,7 @@ final class MyLibraryHeaderView: UIView {
     }
     
     func updateLayoutToggleButton(selectedType: LayoutType) {
-        layoutToggleButtonImageView.image = selectedType.image.withTintColor(.wssGray100)
+        layoutToggleButton.setImage(selectedType.image.withTintColor(.wssGray100), for: .normal)
     }
     
     func updateCountLabel(count: Int) {

--- a/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryNavigationView.swift
+++ b/WSSiOS/Source/Presentation/Library/MyLibrary/MyLibraryView/MyLibraryAssistantView/MyLibraryNavigationView.swift
@@ -52,7 +52,7 @@ final class MyLibraryNavigationView: UIView {
 
     private func setLayout() {
         self.snp.makeConstraints {
-            $0.height.equalTo(56)
+            $0.height.equalTo(40)
         }
 
         navigationTitle.snp.makeConstraints {


### PR DESCRIPTION
### ⭐️Issue
- close #717
<br/>

### 🌟Motivation
신규 디자인 시안 반영에 따라 서재(MyLibrary) 헤더 영역과 정렬 바텀시트의 시각적 디테일을 업데이트했습니다.
<br/>

### 🌟Key Changes
**1) 서재 헤더 영역 디테일 정리**

**2) 서재 정렬 바텀시트 리디자인**
- 상단 타이틀 라벨 제거, 정렬 옵션 리스트만 노출
- 옵션 행을 가운데 정렬, 선택 시 좌측에 체크 아이콘 노출
- 행 높이 52→37, 행 간 간격 10pt, 기본 텍스트 컬러 gray300→gray200
<br/>

### 🌟Simulation
| 서재 헤더 | 바텀시트 |
| :---: | :---: |
| <img width="590" height="455" alt="스크린샷, 2026-06-24 00 17 50" src="https://github.com/user-attachments/assets/e7d32574-3a5e-4253-9628-ed939580eef9" /> | <img width="590" height="1278" alt="스크린샷, 2026-06-24 00 17 30" src="https://github.com/user-attachments/assets/542955fd-e7a2-4fa0-8c04-65ff66d74929" /> |
<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
