### PR TITLE
[Feat/Fix] #725 - Clarity SDK 추가 및 Amplitude Release 빌드 제한

### DIFF
--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -415,7 +415,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		39EDFB392D38D9A7009F071A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB382D38D9A7009F071A /* FirebaseAnalytics */; };
 		39EDFB3B2D38D9A7009F071A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 39EDFB3A2D38D9A7009F071A /* FirebaseMessaging */; };
 		39EF97AC2B53E43800D2148B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 39EF97AB2B53E43800D2148B /* Lottie */; };
+		B9BAA9B5301CD5B400BCCD24 /* Clarity in Frameworks */ = {isa = PBXBuildFile; productRef = B9BAA9B4301CD5B400BCCD24 /* Clarity */; };
 		CD3E5A852B54254F00C0A659 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = CD3E5A842B54254F00C0A659 /* RxKeyboard */; };
 		CDE0C0312D23B04D000BC822 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CDE0C0302D23B04D000BC822 /* AmplitudeSwift */; };
 /* End PBXBuildFile section */
@@ -64,6 +65,7 @@
 				390162CE2CE6575D00B7476C /* RxKakaoSDKUser in Frameworks */,
 				3999BFEE2B4E6CA000984832 /* UIImageViewAlignedSwift in Frameworks */,
 				CD3E5A852B54254F00C0A659 /* RxKeyboard in Frameworks */,
+				B9BAA9B5301CD5B400BCCD24 /* Clarity in Frameworks */,
 				CDE0C0312D23B04D000BC822 /* AmplitudeSwift in Frameworks */,
 				394401AA2CE9B07B007B5E04 /* Then in Frameworks */,
 				390162CC2CE6575D00B7476C /* RxKakaoSDKAuth in Frameworks */,
@@ -137,6 +139,7 @@
 				CDE0C0302D23B04D000BC822 /* AmplitudeSwift */,
 				39EDFB382D38D9A7009F071A /* FirebaseAnalytics */,
 				39EDFB3A2D38D9A7009F071A /* FirebaseMessaging */,
+				B9BAA9B4301CD5B400BCCD24 /* Clarity */,
 			);
 			productName = WSSiOS;
 			productReference = 2CD229182B42E685005400BE /* WSSiOS.app */;
@@ -178,6 +181,7 @@
 				394401A82CE9B07B007B5E04 /* XCRemoteSwiftPackageReference "Then" */,
 				CDE0C02F2D23B04C000BC822 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */,
 				39EDFB372D38D9A7009F071A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				B9BAA9B3301CD5B400BCCD24 /* XCRemoteSwiftPackageReference "clarity-apps" */,
 			);
 			productRefGroup = 2CD229192B42E685005400BE /* Products */;
 			projectDirPath = "";
@@ -523,6 +527,14 @@
 				minimumVersion = 11.7.0;
 			};
 		};
+		B9BAA9B3301CD5B400BCCD24 /* XCRemoteSwiftPackageReference "clarity-apps" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/microsoft/clarity-apps";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.5.4;
+			};
+		};
 		CD3E5A832B54254F00C0A659 /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RxSwiftCommunity/RxKeyboard";
@@ -616,6 +628,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2CD229452B42E7C8005400BE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		B9BAA9B4301CD5B400BCCD24 /* Clarity */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9BAA9B3301CD5B400BCCD24 /* XCRemoteSwiftPackageReference "clarity-apps" */;
+			productName = Clarity;
 		};
 		CD3E5A842B54254F00C0A659 /* RxKeyboard */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WSSiOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WSSiOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9c71ddbfbd1b05c2ae3aa13f7f2393f53dd7eaad031b5647c59f14e920a8e124",
+  "originHash" : "0c499a792764b8da718d47e36852e8211034a3bdd2703d30ff2cac66ef12e694",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "clarity-apps",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/clarity-apps",
+      "state" : {
+        "revision" : "88652502e9427779c8c10a75bab49125143865af",
+        "version" : "3.5.4"
       }
     },
     {

--- a/WSSiOS/App/AppDelegate.swift
+++ b/WSSiOS/App/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Clarity
 import Firebase
 import FirebaseCore
 import RxKakaoSDKCommon
@@ -25,10 +26,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let _: FirebaseOptions? = FirebaseOptions.init(contentsOfFile: filePath)
         
         RxKakaoSDK.initSDK(appKey: APIConstants.kakaoAppKey)
-        
+
         FirebaseApp.configure()
         NotificationHelper.shared.configure()
-        
+
+#if !DEBUG
+        let clarityProjectId = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.clarityProjectId) as? String ?? ""
+        let clarityConfig = ClarityConfig(projectId: clarityProjectId)
+        ClaritySDK.initialize(config: clarityConfig)
+#endif
+
         return true
     }
     

--- a/WSSiOS/Info.plist
+++ b/WSSiOS/Info.plist
@@ -12,6 +12,8 @@
 	<string>$(BASE_URL)</string>
 	<key>BUCKET_URL</key>
 	<string>$(BUCKET_URL)</string>
+	<key>CLARITY_PROJECT_ID</key>
+	<string>$(CLARITY_PROJECT_ID)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/WSSiOS/Resource/Amplitude/AmplitudeManager.swift
+++ b/WSSiOS/Resource/Amplitude/AmplitudeManager.swift
@@ -12,9 +12,12 @@ import AmplitudeSwift
 final class AmplitudeManager {
     static let shared = AmplitudeManager()
     
-    let amplitude: Amplitude
+    private let amplitude: Amplitude?
 
     private init() {
+#if DEBUG
+        amplitude = nil
+#else
         let apiKey = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.amplitudeAPIKey) as? String ?? ""
         amplitude = Amplitude(
             configuration: Configuration(
@@ -22,9 +25,10 @@ final class AmplitudeManager {
                 autocapture: [.sessions, .appLifecycles]
             )
         )
+#endif
     }
-    
+
     func track<T: RawRepresentable>(_ event: T, properties: [String: Any]? = nil) where T.RawValue == String {
-        amplitude.track(eventType: event.rawValue, eventProperties: properties)
+        amplitude?.track(eventType: event.rawValue, eventProperties: properties)
     }
 }

--- a/WSSiOS/Resource/Constants/Config/Config.swift
+++ b/WSSiOS/Resource/Constants/Config/Config.swift
@@ -16,6 +16,7 @@ enum Config {
             static let kakaoAppKey = "KAKAO_APP_KEY"
             static let appStoreID = "APPSTORE_ID"
             static let amplitudeAPIKey = "AMPLITUDE_API_KEY"
+            static let clarityProjectId = "CLARITY_PROJECT_ID"
         }
     }
     


### PR DESCRIPTION
## Summary
- Clarity SDK를 추가하고 Release 빌드에서만 초기화되도록 구성
- Amplitude 이벤트 수집이 Release 빌드에서만 동작하도록 제한 (Debug 빌드에서는 no-op)

## Test plan
- [x] Debug 빌드에서 Amplitude/Clarity 초기화 및 이벤트 전송이 발생하지 않는지 확인
- [x] Release 빌드에서 Amplitude/Clarity가 정상 초기화 및 이벤트 전송되는지 확인
- [x] Info.plist의 CLARITY_PROJECT_ID 치환이 정상적으로 이루어지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)