### PR TITLE
[Feat] #727 - 홈 지금 뜨는 글 타이틀에 유저 닉네임 반영

### DIFF
--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 1.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -415,7 +415,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 1.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/Network/Foundation/APIConstants.swift
+++ b/WSSiOS/Network/Foundation/APIConstants.swift
@@ -42,7 +42,9 @@ extension APIConstants {
     }
     
     static var accessTokenHeader: Dictionary<String, String> {
-        [contentType: applicationJSON,
+        guard !accessToken.isEmpty else { return noTokenHeader }
+
+        return [contentType: applicationJSON,
                 auth: "Bearer " + accessToken]
     }
     

--- a/WSSiOS/Resource/Constants/Lotties/Lottie.swift
+++ b/WSSiOS/Resource/Constants/Lotties/Lottie.swift
@@ -10,8 +10,6 @@ import Foundation
 import Lottie
 
 enum Lottie {
-    static let loading = LottieAnimationView(name: "loading")
-    
     enum Onboarding {
         static let success = LottieAnimationView(name: "scroll")
     }

--- a/WSSiOS/Resource/Constants/Strings/StringLiterals+Home.swift
+++ b/WSSiOS/Resource/Constants/Strings/StringLiterals+Home.swift
@@ -11,7 +11,8 @@ extension StringLiterals {
     enum Home {
         enum Title {
             static let todayPopular = "+ 오늘의 발견 +"
-            static let realtimePopular = "지금 뜨는 글"
+            static let realtimePopular = "님을 위한 추천글"
+            static let notLoggedInRealtimePopular = "지금 뜨는 글"
             static let interest = "님의 관심글"
             static let notLoggedInInterest = "･ :*관심글*: ･"
             static let recommend = "이 웹소설은 어때요? (´ヮ`)ﾉ📚"

--- a/WSSiOS/Source/Presentation/Base/NetworkView/WSSLoadingView.swift
+++ b/WSSiOS/Source/Presentation/Base/NetworkView/WSSLoadingView.swift
@@ -7,15 +7,16 @@
 
 import UIKit
 
+import Lottie
 import SnapKit
 import Then
 
 final class WSSLoadingView: UIView {
-    
+
     // MARK: - UI Components
-    
+
     private let stackView = UIStackView()
-    private let loadingLottieView = Lottie.loading
+    private let loadingLottieView = LottieAnimationView(name: "loading")
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     

--- a/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/RealTimePopular/HomeRealtimePopularView.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/RealTimePopular/HomeRealtimePopularView.swift
@@ -52,7 +52,7 @@ final class HomeRealtimePopularView: UIView {
         }
         
         titleLabel.do {
-            $0.applyWSSFont(.headline1, with: StringLiterals.Home.Title.realtimePopular)
+            $0.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInRealtimePopular)
             $0.textColor = .wssBlack
         }
         
@@ -131,6 +131,14 @@ final class HomeRealtimePopularView: UIView {
         }
     }
     
+    func updateView(_ isLogined: Bool, _ nickname: String?) {
+        if isLogined, let nickname = nickname {
+            titleLabel.applyWSSFont(.headline1, with: "\(nickname)\(StringLiterals.Home.Title.realtimePopular)")
+        } else {
+            titleLabel.applyWSSFont(.headline1, with: StringLiterals.Home.Title.notLoggedInRealtimePopular)
+        }
+    }
+
     func configureDots(numberOfItems: Int) {
         self.dotStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         self.dotImageViews.removeAll()

--- a/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/RealTimePopular/HomeRealtimePopularView.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/RealTimePopular/HomeRealtimePopularView.swift
@@ -72,7 +72,7 @@ final class HomeRealtimePopularView: UIView {
         realtimePopularCollectionViewLayout.do {
             $0.scrollDirection = .horizontal
             $0.minimumLineSpacing = 0
-            $0.itemSize = CGSize(width: UIScreen.main.bounds.width - 40, height: 245)
+            $0.itemSize = CGSize(width: UIScreen.main.bounds.width - 40, height: 244)
             realtimePopularCollectionView.setCollectionViewLayout($0, animated: false)
         }
         
@@ -111,11 +111,11 @@ final class HomeRealtimePopularView: UIView {
         backgroundView.snp.makeConstraints {
             $0.top.equalTo(titleStackView.snp.bottom).offset(14)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(245)
-            
+            $0.height.equalTo(244)
+
             realtimePopularCollectionView.snp.makeConstraints {
                 $0.top.horizontalEdges.equalToSuperview()
-                $0.height.equalTo(245)
+                $0.height.equalTo(244)
             }
             
             dividerView.snp.makeConstraints {

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -142,6 +142,14 @@ final class HomeViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        output.updateRealtimePopularView
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { owner, updateData in
+                let (isLogined, nickname) = updateData
+                owner.rootView.realtimePopularView.updateView(isLogined, nickname)
+            })
+            .disposed(by: disposeBag)
+
         output.pushToNormalSearchViewController
             .bind(with: self, onNext: { owner, _ in
                 owner.pushToNormalSearchViewController()

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -105,10 +105,26 @@ extension HomeViewModel {
             })
             .flatMapLatest {
                 let todayPopularNovelsObservable = self.getTodayPopularNovels()
+                    .catch { error in
+                        print("❌ TodayPopular fetch failed: \(error)")
+                        return Observable.just(TodayDiscoveryNovels(popularNovels: []))
+                    }
                 let realtimeFeedsObservable = self.getRealtimePopularFeeds()
-                let tasteRecommendNovelsObservable = self.isLogined ? self.getTasteRecommendNovels() : Observable.just(TasteRecommendNovels(tasteNovels: []))
-                let isNotificationUnreadObservable = self.isLogined ? self.getNotificationUnreadStatus() : Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false))
-                
+                    .catch { error in
+                        print("❌ RealtimePopularFeeds fetch failed: \(error)")
+                        return Observable.just(RealtimePopularFeeds(popularFeeds: []))
+                    }
+                let tasteRecommendNovelsObservable = (self.isLogined ? self.getTasteRecommendNovels() : Observable.just(TasteRecommendNovels(tasteNovels: [])))
+                    .catch { error in
+                        print("❌ TasteRecommend fetch failed: \(error)")
+                        return Observable.just(TasteRecommendNovels(tasteNovels: []))
+                    }
+                let isNotificationUnreadObservable = (self.isLogined ? self.getNotificationUnreadStatus() : Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false)))
+                    .catch { error in
+                        print("❌ NotificationUnreadStatus fetch failed: \(error)")
+                        return Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false))
+                    }
+
                 return Observable.zip(todayPopularNovelsObservable,
                                       realtimeFeedsObservable,
                                       tasteRecommendNovelsObservable,
@@ -141,7 +157,7 @@ extension HomeViewModel {
                 
                 owner.showLoadingView.accept(false)
             }, onError: { owner, error in
-                owner.realtimePopularList.onError(error)
+                print("❌ Home data fetch failed: \(error)")
                 owner.showLoadingView.accept(false)
             })
             .disposed(by: disposeBag)

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -119,25 +119,18 @@ extension HomeViewModel {
                         print("❌ TasteRecommend fetch failed: \(error)")
                         return Observable.just(TasteRecommendNovels(tasteNovels: []))
                     }
-                let isNotificationUnreadObservable = (self.isLogined ? self.getNotificationUnreadStatus() : Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false)))
-                    .catch { error in
-                        print("❌ NotificationUnreadStatus fetch failed: \(error)")
-                        return Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false))
-                    }
 
                 return Observable.zip(todayPopularNovelsObservable,
                                       realtimeFeedsObservable,
-                                      tasteRecommendNovelsObservable,
-                                      isNotificationUnreadObservable)
+                                      tasteRecommendNovelsObservable)
             }
             .subscribe(with: self, onNext: { owner, data in
                 let todayPopularNovels = data.0
                 let realtimeFeeds = data.1
                 let tasteRecommendNovels = data.2
-                let isNotificationUnread = data.3
-                
+
                 owner.todayPopularList.accept(todayPopularNovels.popularNovels)
-                
+
                 owner.realtimePopularList.onNext(realtimeFeeds.popularFeeds)
                 let limitedFeeds = Array(realtimeFeeds.popularFeeds.prefix(6))
                 let groupedData = stride(from: 0, to: limitedFeeds.count, by: 2)
@@ -152,16 +145,32 @@ extension HomeViewModel {
                 } else {
                     owner.updateTasteRecommendView.accept((false, true))
                 }
-                
-                owner.isNotificationUnread.accept(isNotificationUnread.hasUnreadNotifications)
-                
+
                 owner.showLoadingView.accept(false)
             }, onError: { owner, error in
                 print("❌ Home data fetch failed: \(error)")
                 owner.showLoadingView.accept(false)
             })
             .disposed(by: disposeBag)
-        
+
+        // 알림 미확인 여부는 핵심 콘텐츠 로딩과 무관하므로 별도로 조회해
+        // 응답이 느려도 홈 화면 전체 로딩을 지연시키지 않도록 분리
+        input.viewWillAppearEvent
+            .flatMapLatest { () -> Observable<NotificationUnreadStatusResponse> in
+                guard self.isLogined else {
+                    return Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false))
+                }
+                return self.getNotificationUnreadStatus()
+                    .catch { error in
+                        print("❌ NotificationUnreadStatus fetch failed: \(error)")
+                        return Observable.just(NotificationUnreadStatusResponse(hasUnreadNotifications: false))
+                    }
+            }
+            .subscribe(with: self, onNext: { owner, response in
+                owner.isNotificationUnread.accept(response.hasUnreadNotifications)
+            })
+            .disposed(by: disposeBag)
+
         input.viewWillAppearEvent
             .flatMapLatest { self.getAppMinimumVersion() }
             .subscribe(with: self, onNext: { owner, versionInfo in

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -29,6 +29,7 @@ final class HomeViewModel: ViewModelType {
     // 지금 뜨는 수다글
     private let realtimePopularList = PublishSubject<[RealtimePopularFeed]>()
     private let realtimePopularDataRelay = BehaviorRelay<[[RealtimePopularFeed]]>(value: [])
+    private let updateRealtimePopularView = PublishRelay<(Bool, String?)>()
     
     // 취향추천
     private let tasteRecommendList = BehaviorRelay<[TasteRecommendNovel]>(value: [])
@@ -68,7 +69,8 @@ final class HomeViewModel: ViewModelType {
         
         var realtimePopularList: Observable<[RealtimePopularFeed]>
         var realtimePopularData: Observable<[[RealtimePopularFeed]]>
-        
+        let updateRealtimePopularView: Observable<(Bool, String?)>
+
         var tasteRecommendList: Observable<[TasteRecommendNovel]>
         let tasteRecommendCollectionViewHeight: Driver<CGFloat>
         let updateTasteRecommendView: Observable<(Bool, Bool)>
@@ -155,15 +157,17 @@ extension HomeViewModel {
             .disposed(by: disposeBag)
         
         input.viewDidLoadEvent
-            .filter { self.isLogined }
-            .flatMapLatest {
-                return self.getUserMeData()
+            .flatMapLatest { () -> Observable<UserMeEntity?> in
+                self.isLogined ? self.getUserMeData().map { $0 } : Observable.just(nil)
             }
             .subscribe(with: self, onNext: { owner, data in
-                UserDefaults.standard.setValue(data.userId, forKey: StringLiterals.UserDefault.userId)
-                UserDefaults.standard.setValue(data.nickname, forKey: StringLiterals.UserDefault.userNickname)
-                UserDefaults.standard.setValue(data.gender, forKey: StringLiterals.UserDefault.userGender)
-                owner.getTermSetting(disposeBag: disposeBag)
+                if let data = data {
+                    UserDefaults.standard.setValue(data.userId, forKey: StringLiterals.UserDefault.userId)
+                    UserDefaults.standard.setValue(data.nickname, forKey: StringLiterals.UserDefault.userNickname)
+                    UserDefaults.standard.setValue(data.gender, forKey: StringLiterals.UserDefault.userGender)
+                    owner.getTermSetting(disposeBag: disposeBag)
+                }
+                owner.updateRealtimePopularView.accept((owner.isLogined, data?.nickname))
             })
             .disposed(by: disposeBag)
         
@@ -232,6 +236,7 @@ extension HomeViewModel {
                       todayPopularList: todayPopularList.asObservable(),
                       realtimePopularList: realtimePopularList.asObservable(),
                       realtimePopularData: realtimePopularDataRelay.asObservable(),
+                      updateRealtimePopularView: updateRealtimePopularView.asObservable(),
                       tasteRecommendList: tasteRecommendList.asObservable(),
                       tasteRecommendCollectionViewHeight: tasteRecommendCollectionViewHeight.asDriver(),
                       updateTasteRecommendView: updateTasteRecommendView.asObservable(),


### PR DESCRIPTION
## Summary
- 홈 지금 뜨는 글 섹션의 타이틀에 로그인 유저의 닉네임을 반영 ("{닉네임}님을 위한 추천글")
- 비로그인 시에는 "지금 뜨는 글" 타이틀로 노출하고, 글 목록은 기존과 동일하게 노출
- 기존에 로그인 시에만 조회하던 유저 닉네임(getUserMeData)을 재사용하여 별도 API 추가 없이 구현

## 추가 수정사항
- 액세스 토큰이 없을 때 `"Bearer "` 형태의 잘못된 Authorization 헤더가 전송되던 문제 수정
- 홈 데이터 조회(오늘의 인기작/지금 뜨는 수다글/취향추천)를 개별적으로 격리하여, 한 섹션의 API 실패(디코딩 에러 등)가 홈 화면 전체 렌더링을 막지 않도록 수정
- `Lottie.loading`이 앱 전체에서 공유되는 단일 인스턴스라 여러 화면에서 로딩 뷰를 생성할 때 애니메이션이 마지막 화면으로만 옮겨가던 문제 수정 (화면마다 자체 인스턴스 생성)
- 지금 뜨는 수다글 셀의 오토레이아웃 제약조건 불일치(244 vs 245)로 발생하던 "Unable to simultaneously satisfy constraints" 경고 수정
- 알림 미확인 여부 조회를 홈 데이터 로딩과 분리하여, 알림 배지 API가 느려도 핵심 콘텐츠 로딩이 지연되지 않도록 수정
- 버전 1.9.2로 업데이트

## Test plan
- [x] 로그인 상태에서 홈 진입 시 "{닉네임}님을 위한 추천글" 타이틀 노출 확인
- [x] 비로그인 상태에서 홈 진입 시 "지금 뜨는 글" 타이틀 및 기존과 동일한 글 목록 노출 확인
- [x] xcodebuild 빌드 성공 확인
- [x] 홈/검색/서재 등 여러 화면에서 로딩 뷰 Lottie 애니메이션 정상 노출 확인
- [x] 지금 뜨는 수다글 셀 레이아웃 제약조건 경고 미발생 확인

| 로그인 | 비로그인 | 
| -- | -- | 
| <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 14 06 10" src="https://github.com/user-attachments/assets/f10d284b-5bb6-451a-9fbc-abf57d9726fc" /> | <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 14 06 58" src="https://github.com/user-attachments/assets/fd5aa560-8922-4587-9604-061bdd8bbe92" /> | 

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)
