### PR TITLE
[Fix] #729 - 홈 화면 로딩 성능 개선

### DIFF
--- a/WSSiOS.xcodeproj/project.pbxproj
+++ b/WSSiOS.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso.debug2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -415,7 +415,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.websoso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WSSiOS/App/SceneDelegate.swift
+++ b/WSSiOS/App/SceneDelegate.swift
@@ -31,7 +31,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let spashViewController = SplashViewController()
         window.rootViewController = spashViewController
         window.makeKeyAndVisible()
-        
+
+        // 스플래시가 떠 있는 동안 홈 상단 콘텐츠(오늘의 인기작/지금 뜨는 수다글)를 미리 요청해
+        // 홈 진입 시 로딩 스피너가 보이는 시간을 줄인다.
+        HomePrefetchService.shared.prefetchTopSections()
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.checkIsRegistered()
             

--- a/WSSiOS/Resource/Extensions/UIImage+.swift
+++ b/WSSiOS/Resource/Extensions/UIImage+.swift
@@ -8,22 +8,34 @@
 import UIKit
 
 extension UIImage {
+    // CIContext는 생성 비용이 크므로(렌더링 파이프라인 구성) 전역에서 재사용
+    private static let blurContext = CIContext()
+
     func asBlurredBannerImage(radius: CGFloat) -> UIImage {
-        let context = CIContext()
         guard let ciImage = CIImage(image: self),
               let clampFilter = CIFilter(name: "CIAffineClamp"),
               let blurFilter = CIFilter(name: "CIGaussianBlur") else {
             return self
-            
+
         }
         clampFilter.setValue(ciImage, forKey: kCIInputImageKey)
         blurFilter.setValue(clampFilter.outputImage, forKey: kCIInputImageKey)
         blurFilter.setValue(radius, forKey: kCIInputRadiusKey)
         guard let output = blurFilter.outputImage,
-              let cgimg = context.createCGImage(output, from: ciImage.extent) else {
+              let cgimg = Self.blurContext.createCGImage(output, from: ciImage.extent) else {
             return self
         }
         return UIImage(cgImage: cgimg)
+    }
+
+    // 블러 연산을 백그라운드 큐에서 수행하고 결과를 메인 스레드로 전달 (메인 스레드 블로킹 방지)
+    func asBlurredBannerImage(radius: CGFloat, completion: @escaping (UIImage) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let blurred = self.asBlurredBannerImage(radius: radius)
+            DispatchQueue.main.async {
+                completion(blurred)
+            }
+        }
     }
     
     // 이미지 해상도 조절 함수

--- a/WSSiOS/Resource/Helper/HomePrefetchService.swift
+++ b/WSSiOS/Resource/Helper/HomePrefetchService.swift
@@ -1,0 +1,51 @@
+//
+//  HomePrefetchService.swift
+//  WSSiOS
+//
+//  Created by Claude on 8/4/26.
+//
+
+import Foundation
+
+import RxSwift
+
+// 스플래시가 떠 있는 동안(로그인 여부 체크 등으로 어차피 대기하는 시간) 홈 상단 콘텐츠를
+// 미리 요청해두어, 홈 화면 진입 시 로딩 스피너 노출 빈도를 줄인다.
+// 앱 콜드 스타트 직후 첫 홈 진입에서만 소비되며, 소비되는 즉시 초기화되어
+// 이후 홈 재진입(탭 전환 등)은 항상 새로 요청한다.
+final class HomePrefetchService {
+    static let shared = HomePrefetchService()
+    private init() {}
+
+    private let disposeBag = DisposeBag()
+    private var todayPopular: Observable<TodayDiscoveryNovels>?
+    private var realtimeFeeds: Observable<RealtimePopularFeeds>?
+
+    func prefetchTopSections() {
+        let repository = DefaultRecommendRepository(recommendService: DefaultRecommendService())
+
+        // scope는 반드시 .forever여야 한다: .whileConnected는 최초 구독(prime)이 완료되어
+        // 구독자 수가 0으로 떨어지는 순간 리플레이 버퍼를 버리고, 이후 소비 시점에 재구독하며
+        // 네트워크 요청을 한 번 더 발생시킨다(프리페치 무력화).
+        let today = repository.getTodayPopularNovels()
+            .share(replay: 1, scope: .forever)
+        let realtime = repository.getRealtimePopularFeeds()
+            .share(replay: 1, scope: .forever)
+
+        todayPopular = today
+        realtimeFeeds = realtime
+
+        today.subscribe().disposed(by: disposeBag)
+        realtime.subscribe().disposed(by: disposeBag)
+    }
+
+    func consumeTodayPopular() -> Observable<TodayDiscoveryNovels>? {
+        defer { todayPopular = nil }
+        return todayPopular
+    }
+
+    func consumeRealtimeFeeds() -> Observable<RealtimePopularFeeds>? {
+        defer { realtimeFeeds = nil }
+        return realtimeFeeds
+    }
+}

--- a/WSSiOS/Source/Presentation/Base/NetworkView/ShimmerView.swift
+++ b/WSSiOS/Source/Presentation/Base/NetworkView/ShimmerView.swift
@@ -1,0 +1,55 @@
+//
+//  ShimmerView.swift
+//  WSSiOS
+//
+//  Created by Claude on 8/4/26.
+//
+
+import UIKit
+
+// 스켈레톤 placeholder에 붙이는 shimmer(반짝임) 애니메이션 뷰.
+final class ShimmerView: UIView {
+
+    private let gradientLayer = CAGradientLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .wssGray20
+        setupGradientLayer()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+
+    private func setupGradientLayer() {
+        gradientLayer.colors = [
+            UIColor.wssGray20.cgColor,
+            UIColor.wssGray50.cgColor,
+            UIColor.wssGray20.cgColor
+        ]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        gradientLayer.locations = [0, 0.5, 1]
+        layer.addSublayer(gradientLayer)
+    }
+
+    func startShimmering() {
+        let animation = CABasicAnimation(keyPath: "locations")
+        animation.fromValue = [-1.0, -0.5, 0.0]
+        animation.toValue = [1.0, 1.5, 2.0]
+        animation.duration = 1.2
+        animation.repeatCount = .infinity
+        gradientLayer.add(animation, forKey: "shimmer")
+    }
+
+    func stopShimmering() {
+        gradientLayer.removeAnimation(forKey: "shimmer")
+    }
+}

--- a/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendSkeletonView.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendSkeletonView.swift
@@ -1,0 +1,138 @@
+//
+//  HomeTasteRecommendSkeletonView.swift
+//  WSSiOS
+//
+//  Created by Claude on 8/4/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+// 취향추천 카드(HomeTasteRecommendCollectionViewCell) 레이아웃을 흉내낸 스켈레톤.
+// 2열 그리드로 카드 4개를 배치해 실제 컬렉션뷰가 채워졌을 때와 레이아웃 낙차가 없게 한다.
+final class HomeTasteRecommendSkeletonView: UIView {
+
+    //MARK: - UI Components
+
+    private let columnStackView = UIStackView()
+    private let leftColumnStackView = UIStackView()
+    private let rightColumnStackView = UIStackView()
+    private let cardViews = (0..<4).map { _ in HomeTasteRecommendSkeletonCardView() }
+
+    //MARK: - Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: - UI
+
+    private func setUI() {
+        columnStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 9
+            $0.distribution = .fillEqually
+        }
+
+        [leftColumnStackView, rightColumnStackView].forEach {
+            $0.axis = .vertical
+            $0.spacing = 18
+        }
+    }
+
+    private func setHierarchy() {
+        self.addSubview(columnStackView)
+        columnStackView.addArrangedSubviews(leftColumnStackView, rightColumnStackView)
+        leftColumnStackView.addArrangedSubviews(cardViews[0], cardViews[1])
+        rightColumnStackView.addArrangedSubviews(cardViews[2], cardViews[3])
+    }
+
+    private func setLayout() {
+        columnStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    //MARK: - Custom Method
+
+    func startShimmering() {
+        cardViews.forEach { $0.startShimmering() }
+    }
+
+    func stopShimmering() {
+        cardViews.forEach { $0.stopShimmering() }
+    }
+}
+
+private final class HomeTasteRecommendSkeletonCardView: UIView {
+
+    private let imagePlaceholder = ShimmerView()
+    private let titlePlaceholder = ShimmerView()
+    private let authorPlaceholder = ShimmerView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setLayout() {
+        self.addSubviews(imagePlaceholder, titlePlaceholder, authorPlaceholder)
+
+        imagePlaceholder.do {
+            $0.layer.cornerRadius = 14
+            $0.layer.masksToBounds = true
+        }
+        imagePlaceholder.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(241)
+        }
+
+        titlePlaceholder.do {
+            $0.layer.cornerRadius = 4
+            $0.layer.masksToBounds = true
+        }
+        titlePlaceholder.snp.makeConstraints {
+            $0.top.equalTo(imagePlaceholder.snp.bottom).offset(10)
+            $0.leading.equalToSuperview()
+            $0.width.equalTo(100)
+            $0.height.equalTo(14)
+        }
+
+        authorPlaceholder.do {
+            $0.layer.cornerRadius = 4
+            $0.layer.masksToBounds = true
+        }
+        authorPlaceholder.snp.makeConstraints {
+            $0.top.equalTo(titlePlaceholder.snp.bottom).offset(6)
+            $0.leading.equalToSuperview()
+            $0.width.equalTo(60)
+            $0.height.equalTo(10)
+            $0.bottom.equalToSuperview()
+        }
+    }
+
+    func startShimmering() {
+        [imagePlaceholder, titlePlaceholder, authorPlaceholder].forEach { $0.startShimmering() }
+    }
+
+    func stopShimmering() {
+        [imagePlaceholder, titlePlaceholder, authorPlaceholder].forEach { $0.stopShimmering() }
+    }
+}

--- a/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeAssistantView/HomeTasteRecommendView.swift
@@ -21,6 +21,7 @@ final class HomeTasteRecommendView: UIView {
                                                         collectionViewLayout: UICollectionViewLayout())
     private let tasteRecommendCollectionViewLayout = UICollectionViewFlowLayout()
     let unregisterView = HomeUnregisterView(.tasteRecommend)
+    private let skeletonView = HomeTasteRecommendSkeletonView()
     
     //MARK: - Life Cycle
     
@@ -70,14 +71,19 @@ final class HomeTasteRecommendView: UIView {
         unregisterView.do {
             $0.isHidden = true
         }
+
+        skeletonView.do {
+            $0.isHidden = true
+        }
     }
-    
+
     private func setHierarchy() {
         self.addSubview(stackView)
         stackView.addArrangedSubviews(titleLabel,
                                       subTitleLabel,
                                       tasteRecommendCollectionView,
-                                      unregisterView)
+                                      unregisterView,
+                                      skeletonView)
     }
     
     private func setLayout() {
@@ -94,11 +100,36 @@ final class HomeTasteRecommendView: UIView {
         unregisterView.snp.makeConstraints {
             $0.height.equalTo(133)
         }
+
+        skeletonView.snp.makeConstraints {
+            $0.height.equalTo(580)
+        }
     }
-    
+
     //MARK: - Custom Method
-    
+
+    func setLoading(_ isLoading: Bool) {
+        skeletonView.isHidden = !isLoading
+        isLoading ? skeletonView.startShimmering() : skeletonView.stopShimmering()
+
+        if isLoading {
+            subTitleLabel.isHidden = false
+            tasteRecommendCollectionView.isHidden = true
+            unregisterView.isHidden = true
+            stackView.do {
+                $0.setCustomSpacing(2, after: titleLabel)
+                $0.setCustomSpacing(20, after: subTitleLabel)
+                $0.snp.updateConstraints {
+                    $0.bottom.equalToSuperview().inset(40)
+                }
+            }
+        }
+    }
+
     func updateView(_ isLogined: Bool, _ isEmpty: Bool) {
+        skeletonView.isHidden = true
+        skeletonView.stopShimmering()
+
         if isLogined {
             if isEmpty {
                 unregisterView.isHidden = false

--- a/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeTodayPopularCollectionViewCell.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeView/HomeCell/HomeTodayPopularCollectionViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import UIImageViewAlignedSwift
 import RxSwift
 
@@ -16,6 +17,9 @@ final class HomeTodayPopularCollectionViewCell: UICollectionViewCell {
     
     private let blurRadius: CGFloat = 8
     private var disposeBag = DisposeBag()
+
+    // 플레이스홀더 블러 이미지는 항상 동일한 결과이므로 앱 생애주기 동안 한 번만 계산
+    private static let blurredPlaceholderImage: UIImage = .imgLoadingThumbnail.asBlurredBannerImage(radius: 8)
     
     //MARK: - Components
   
@@ -78,7 +82,7 @@ final class HomeTodayPopularCollectionViewCell: UICollectionViewCell {
         self.clipsToBounds = true
 
         backgroundNovelImageView.do {
-            $0.image = .imgLoadingThumbnail.asBlurredBannerImage(radius: blurRadius)
+            $0.image = Self.blurredPlaceholderImage
             $0.contentMode = .scaleAspectFill
             $0.alignment = .top
             $0.clipsToBounds = true
@@ -299,22 +303,29 @@ final class HomeTodayPopularCollectionViewCell: UICollectionViewCell {
             chip.setText(keyword)
             keywordStackView.addArrangedSubview(chip)
         }
-        self.novelImageView.kfSetImage(url: data.novelImage)
-       
+        // 썸네일과 배경 블러가 동일한 이미지를 쓰므로, 네트워크 요청을 한 번만 보내고
+        // 완료 콜백에서 받은 이미지로 블러 배경까지 함께 채운다 (중복 요청 제거)
+        if let imageURL = URL(string: data.novelImage) {
+            self.novelImageView.kf.indicatorType = .activity
+            self.novelImageView.kf.setImage(
+                with: imageURL,
+                placeholder: nil,
+                options: [.transition(.fade(1.0))]
+            ) { [weak self] result in
+                guard let self, case .success(let imageResult) = result else { return }
+                imageResult.image.asBlurredBannerImage(radius: self.blurRadius) { [weak self] blurred in
+                    self?.backgroundNovelImageView.image = blurred
+                }
+            }
+        }
+
         self.novelGenreImageView.image = NovelGenre.allCases
             .first(where: { $0.rawValue == data.genreName })?.image
-        
+
         self.commentContentLabel.do {
             $0.lineBreakStrategy = .hangulWordPriority
             $0.lineBreakMode = .byTruncatingTail
         }
-        
-        KingFisherRxHelper.kingFisherImage(urlString: data.novelImage)
-            .observe(on: MainScheduler.instance)
-            .bind(with: self) { owner, image in
-                owner.backgroundNovelImageView.image = image.asBlurredBannerImage(radius: owner.blurRadius)
-            }
-            .disposed(by: disposeBag)
         
         // 대응하는 피드가 존재할 경우
         if let feedContent = data.feedContent,

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewController/HomeViewController.swift
@@ -178,6 +178,13 @@ final class HomeViewController: UIViewController {
                 owner.rootView.tasteRecommendView.updateView(isLogined, isEmpty)
             })
             .disposed(by: disposeBag)
+
+        output.showTasteRecommendLoading
+            .observe(on: MainScheduler.instance)
+            .bind(with: self, onNext: { owner, isLoading in
+                owner.rootView.tasteRecommendView.setLoading(isLoading)
+            })
+            .disposed(by: disposeBag)
         
         output.pushToAnnouncementViewController
             .bind(with: self, onNext: { owner, _ in

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -300,14 +300,14 @@ extension HomeViewModel {
         return userRepository.getUserMeData()
     }
 
-    // 오늘의 인기작 조회
+    // 오늘의 인기작 조회 (스플래시 단계에서 프리페치된 결과가 있으면 그것을 우선 사용)
     func getTodayPopularNovels() -> Observable<TodayDiscoveryNovels> {
-        return recommendRepository.getTodayPopularNovels()
+        return HomePrefetchService.shared.consumeTodayPopular() ?? recommendRepository.getTodayPopularNovels()
     }
 
-    // 지금 뜨는 수다글 조회
+    // 지금 뜨는 수다글 조회 (스플래시 단계에서 프리페치된 결과가 있으면 그것을 우선 사용)
     func getRealtimePopularFeeds() -> Observable<RealtimePopularFeeds> {
-        return recommendRepository.getRealtimePopularFeeds()
+        return HomePrefetchService.shared.consumeRealtimeFeeds() ?? recommendRepository.getRealtimePopularFeeds()
     }
 
     // 관심글 조회 - Deprecated

--- a/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
+++ b/WSSiOS/Source/Presentation/Home/Home/HomeViewModel/HomeViewModel.swift
@@ -11,43 +11,44 @@ import RxSwift
 import RxCocoa
 
 final class HomeViewModel: ViewModelType {
-    
+
     //MARK: - Properties
-    
+
     private let recommendRepository: RecommendRepository
     private let userRepository: UserInfoRepository
     private let notificationRepository: NotificationRepository
     private let disposeBag = DisposeBag()
-    
+
     private let isLogined = APIConstants.isLogined
-    
+
     private let pushToNormalSearchViewController = PublishRelay<Void>()
-    
+
     // 오늘의 인기작
     private let todayPopularList = BehaviorRelay<[TodayDiscoveryNovel]>(value: [])
-    
+
     // 지금 뜨는 수다글
     private let realtimePopularList = PublishSubject<[RealtimePopularFeed]>()
     private let realtimePopularDataRelay = BehaviorRelay<[[RealtimePopularFeed]]>(value: [])
     private let updateRealtimePopularView = PublishRelay<(Bool, String?)>()
-    
+
     // 취향추천
     private let tasteRecommendList = BehaviorRelay<[TasteRecommendNovel]>(value: [])
     private let updateTasteRecommendView = PublishRelay<(Bool, Bool)>()
+    private let showTasteRecommendLoading = PublishRelay<Bool>()
     private let pushToMyPageViewController = PublishRelay<Void>()
-    
+
     private let pushToNovelDetailViewController = PublishRelay<Int>()
     private let pushToAnnouncementViewController = PublishRelay<Void>()
     private let pushToDetailSearchViewController = PublishRelay<Void>()
     let showInduceLoginModalView = PublishRelay<Void>()
-    
+
     private let showLoadingView = PublishRelay<Bool>()
     private let showUpdateVersionAlertView = PublishRelay<Void>()
     private let isNotificationUnread = PublishRelay<Bool>()
     private let showServiceTermAgreementAlert = PublishRelay<Void>()
-    
+
     // MARK: - Inputs
-    
+
     struct Input {
         let viewWillAppearEvent: Observable<Void>
         let viewDidLoadEvent: Observable<Void>
@@ -59,14 +60,14 @@ final class HomeViewModel: ViewModelType {
         let searchBarViewDidTap: Observable<UITapGestureRecognizer>
         let induceDetailSearchViewDidTap: Observable<UITapGestureRecognizer>
     }
-    
+
     //MARK: - Outputs
-    
+
     struct Output {
         let pushToNormalSearchViewController: Observable<Void>
-        
+
         var todayPopularList: Observable<[TodayDiscoveryNovel]>
-        
+
         var realtimePopularList: Observable<[RealtimePopularFeed]>
         var realtimePopularData: Observable<[[RealtimePopularFeed]]>
         let updateRealtimePopularView: Observable<(Bool, String?)>
@@ -74,8 +75,9 @@ final class HomeViewModel: ViewModelType {
         var tasteRecommendList: Observable<[TasteRecommendNovel]>
         let tasteRecommendCollectionViewHeight: Driver<CGFloat>
         let updateTasteRecommendView: Observable<(Bool, Bool)>
+        let showTasteRecommendLoading: Observable<Bool>
         let pushToMyPageEditViewController: Observable<Void>
-        
+
         let pushToNovelDetailViewController: Observable<Int>
         let pushToAnnouncementViewController: Observable<Void>
         let pushToDetailSearchViewController: Observable<Void>
@@ -85,9 +87,9 @@ final class HomeViewModel: ViewModelType {
         let isNotificationUnread: Observable<Bool>
         let showServiceTermAgreementAlert: Observable<Void>
     }
-    
+
     //MARK: - init
-    
+
     init(recommendRepository: RecommendRepository,
          userRepository: UserInfoRepository,
          notificationRepository: NotificationRepository) {
@@ -99,6 +101,9 @@ final class HomeViewModel: ViewModelType {
 
 extension HomeViewModel {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        // 오늘의 인기작 / 지금 뜨는 수다글: 비로그인 사용자에게도 항상 노출되는 상단 콘텐츠.
+        // 이 둘만 zip으로 묶어 로딩 스피너를 제어하므로, 취향추천이 느려도(개인화 연산,
+        // 토큰 재발급 등) 상단 화면 표시가 지연되지 않는다.
         input.viewWillAppearEvent
             .do(onNext: {
                 self.showLoadingView.accept(true)
@@ -114,20 +119,12 @@ extension HomeViewModel {
                         print("❌ RealtimePopularFeeds fetch failed: \(error)")
                         return Observable.just(RealtimePopularFeeds(popularFeeds: []))
                     }
-                let tasteRecommendNovelsObservable = (self.isLogined ? self.getTasteRecommendNovels() : Observable.just(TasteRecommendNovels(tasteNovels: [])))
-                    .catch { error in
-                        print("❌ TasteRecommend fetch failed: \(error)")
-                        return Observable.just(TasteRecommendNovels(tasteNovels: []))
-                    }
 
-                return Observable.zip(todayPopularNovelsObservable,
-                                      realtimeFeedsObservable,
-                                      tasteRecommendNovelsObservable)
+                return Observable.zip(todayPopularNovelsObservable, realtimeFeedsObservable)
             }
             .subscribe(with: self, onNext: { owner, data in
                 let todayPopularNovels = data.0
                 let realtimeFeeds = data.1
-                let tasteRecommendNovels = data.2
 
                 owner.todayPopularList.accept(todayPopularNovels.popularNovels)
 
@@ -139,17 +136,36 @@ extension HomeViewModel {
                     }
                 owner.realtimePopularDataRelay.accept(groupedData)
 
+                owner.showLoadingView.accept(false)
+            }, onError: { owner, error in
+                print("❌ Home data fetch failed: \(error)")
+                owner.showLoadingView.accept(false)
+            })
+            .disposed(by: disposeBag)
+
+        // 취향추천: 로그인 사용자 대상 개인화 콘텐츠(화면 하단 섹션)라 독립적으로 구독해,
+        // 도착하는 대로 해당 섹션만 갱신하고 위 두 섹션의 표시를 막지 않는다.
+        // 응답이 오래 걸리므로(개인화 연산) 항상 스켈레톤을 보여주고, 최신 응답이 오면 그때 채운다.
+        input.viewWillAppearEvent
+            .flatMapLatest { () -> Observable<TasteRecommendNovels> in
+                guard self.isLogined else {
+                    return Observable.just(TasteRecommendNovels(tasteNovels: []))
+                }
+                self.showTasteRecommendLoading.accept(true)
+                return self.getTasteRecommendNovels()
+                    .catch { error in
+                        print("❌ TasteRecommend fetch failed: \(error)")
+                        return Observable.just(TasteRecommendNovels(tasteNovels: []))
+                    }
+            }
+            .subscribe(with: self, onNext: { owner, tasteRecommendNovels in
+                owner.showTasteRecommendLoading.accept(false)
                 if owner.isLogined {
                     owner.tasteRecommendList.accept(tasteRecommendNovels.tasteNovels)
                     owner.updateTasteRecommendView.accept((true, tasteRecommendNovels.tasteNovels.isEmpty))
                 } else {
                     owner.updateTasteRecommendView.accept((false, true))
                 }
-
-                owner.showLoadingView.accept(false)
-            }, onError: { owner, error in
-                print("❌ Home data fetch failed: \(error)")
-                owner.showLoadingView.accept(false)
             })
             .disposed(by: disposeBag)
 
@@ -180,7 +196,7 @@ extension HomeViewModel {
                 }
             })
             .disposed(by: disposeBag)
-        
+
         input.viewDidLoadEvent
             .flatMapLatest { () -> Observable<UserMeEntity?> in
                 self.isLogined ? self.getUserMeData().map { $0 } : Observable.just(nil)
@@ -195,13 +211,13 @@ extension HomeViewModel {
                 owner.updateRealtimePopularView.accept((owner.isLogined, data?.nickname))
             })
             .disposed(by: disposeBag)
-        
+
         input.searchBarViewDidTap
             .subscribe(with: self, onNext: { owner, _ in
                 owner.pushToNormalSearchViewController.accept(())
             })
             .disposed(by: disposeBag)
-        
+
         input.induceDetailSearchViewDidTap
             .subscribe(with: self, onNext: { owner, _ in
                 if owner.isLogined {
@@ -211,7 +227,7 @@ extension HomeViewModel {
                 }
             })
             .disposed(by: disposeBag)
-        
+
         input.todayPopularCellSelected
             .subscribe(with: self, onNext: { owner, indexPath in
                 AmplitudeManager.shared.track(AmplitudeEvent.Home.homeTodayRanking)
@@ -231,11 +247,11 @@ extension HomeViewModel {
                 owner.pushToNovelDetailViewController.accept(novelId)
             })
             .disposed(by: disposeBag)
-        
+
         let tasteRecommendCollectionViewHeight = input.tasteRecommendCollectionViewContentSize
             .map { $0?.height ?? 0 }
             .asDriver(onErrorJustReturn: 0)
-        
+
         input.announcementButtonDidTap
             .subscribe(with: self, onNext: { owner, _ in
                 if owner.isLogined {
@@ -245,7 +261,7 @@ extension HomeViewModel {
                 }
             })
             .disposed(by: disposeBag)
-        
+
         input.setPreferredGenresButtonTapped
             .subscribe(with: self, onNext: { owner, _ in
                 AmplitudeManager.shared.track(AmplitudeEvent.Home.homeToPreferButton)
@@ -256,7 +272,7 @@ extension HomeViewModel {
                 }
             })
             .disposed(by: disposeBag)
-        
+
         return Output(pushToNormalSearchViewController: pushToNormalSearchViewController.asObservable(),
                       todayPopularList: todayPopularList.asObservable(),
                       realtimePopularList: realtimePopularList.asObservable(),
@@ -265,6 +281,7 @@ extension HomeViewModel {
                       tasteRecommendList: tasteRecommendList.asObservable(),
                       tasteRecommendCollectionViewHeight: tasteRecommendCollectionViewHeight.asDriver(),
                       updateTasteRecommendView: updateTasteRecommendView.asObservable(),
+                      showTasteRecommendLoading: showTasteRecommendLoading.asObservable(),
                       pushToMyPageEditViewController: pushToMyPageViewController.asObservable(),
                       pushToNovelDetailViewController: pushToNovelDetailViewController.asObservable(),
                       pushToAnnouncementViewController: pushToAnnouncementViewController.asObservable(),
@@ -275,44 +292,44 @@ extension HomeViewModel {
                       isNotificationUnread: isNotificationUnread.asObservable(),
                       showServiceTermAgreementAlert: showServiceTermAgreementAlert.asObservable())
     }
-    
+
     //MARK: - API
-    
+
     // 유저 정보 조회
     func getUserMeData() -> Observable<UserMeEntity> {
         return userRepository.getUserMeData()
     }
-    
+
     // 오늘의 인기작 조회
     func getTodayPopularNovels() -> Observable<TodayDiscoveryNovels> {
         return recommendRepository.getTodayPopularNovels()
     }
-    
+
     // 지금 뜨는 수다글 조회
     func getRealtimePopularFeeds() -> Observable<RealtimePopularFeeds> {
         return recommendRepository.getRealtimePopularFeeds()
     }
-    
+
     // 관심글 조회 - Deprecated
     func getInterestFeeds() -> Observable<InterestFeeds> {
         return recommendRepository.getInterestFeeds()
     }
-    
+
     // 취향추천 작품 조회
     func getTasteRecommendNovels() -> Observable<TasteRecommendNovels> {
         return recommendRepository.getTasteRecommendNovels()
     }
-    
+
     // 앱 최소 버전 조회
     func getAppMinimumVersion() -> Observable<AppMinimumVersion> {
         return userRepository.getAppMinimumVersion()
     }
-    
+
     //유저 비열람 알림 존재 여부 조회
     func getNotificationUnreadStatus() -> Observable<NotificationUnreadStatusResponse> {
         return notificationRepository.getNotificationUnreadStatus()
     }
-    
+
     func getTermSetting(disposeBag: DisposeBag) {
         userRepository.getTermSetting()
             .subscribe(with: self, onSuccess: { owner, result in


### PR DESCRIPTION
## 관련 이슈
- closes #729

## 문제
홈 화면 진입 시 로딩이 느리게 느껴지는 이슈.

## 원인
- `Observable.zip`이 오늘의 인기작/지금뜨는수다글/취향추천 3개를 한번에 묶어, 가장 느린 취향추천(개인화 연산) 응답을 기다린 뒤에야 로딩 스피너가 사라짐
- 이미지 블러 처리가 매번 새 `CIContext`를 생성하며 메인스레드에서 동기 실행됨
- 취향추천 API가 프로덕션에서 5초 이상 소요됨 (백엔드 이슈로 별도 공유 필요)

## 변경사항
1. **이미지 블러 성능 개선**: `CIContext` 재사용 + 백그라운드 큐 처리, 썸네일/배경 블러 중복 이미지 요청 제거
2. **API 구독 분리 + 스켈레톤 뷰**: 오늘의 인기작/지금뜨는수다글만 zip으로 묶어 스피너 제어, 취향추천은 독립 구독으로 분리. 취향추천 섹션에 shimmer 스켈레톤 뷰 추가
3. **스플래시 프리페치**: 스플래시가 떠 있는 동안(로그인 체크 등으로 대기하는 1초) 상단 2섹션을 미리 요청해 홈 진입 시 스피너 노출 시간 단축

## 측정 결과 (Release, 프로덕션)
- 로딩 스피너 해제: 179ms → 11ms (프리페치 적용)
- 취향추천: 여전히 5초+ 소요 (백엔드 확인 필요, 클라이언트에서는 스켈레톤으로 격리)

## Test plan
- [x] 실기기/시뮬레이터에서 홈 진입 시 스피너가 빠르게 사라지는지 확인
- [x] 취향추천 섹션 스켈레톤 → 실제 데이터 전환이 자연스러운지 확인
- [x] 비로그인(둘러보기) 상태에서 오늘의 인기작/지금뜨는수다글 정상 노출 확인
- [x] 로그인 상태에서 취향추천 정상 노출 확인